### PR TITLE
Add Typescript support for formulas without results

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -333,13 +333,14 @@ export interface CellHyperlinkValue {
 
 export interface CellFormulaValue {
 	formula: string;
-	result?: number | string | Date;
+	result?: number | string | Date | { error: CellErrorValue };
+	date1904: boolean;
 }
 
 export interface CellSharedFormulaValue {
 	sharedFormula: string;
 	readonly formula?: string;
-	result: number | string | Date | { error: string };
+	result?: number | string | Date| { error: CellErrorValue };
 	date1904: boolean;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -339,7 +339,8 @@ export interface CellFormulaValue {
 export interface CellSharedFormulaValue {
 	sharedFormula: string;
 	readonly formula?: string;
-	result: number | string | Date;
+	result: number | string | Date | { error: string };
+	date1904: boolean;
 }
 
 export const enum ValueType {


### PR DESCRIPTION
It is currently possible, when passing a formula as a value, to omit the result of the formula, and the result will be computed later.
`sheet.getCell("B1").value = { formula: 'SUM(A1:A6)' };`

This PR aims to add this possible syntax to the TypeScript module resolution file.

