### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare interface Buffer { }
+declare interface Buffer extends ArrayBuffer { }
 declare interface Stream { }
 declare interface Writable { }
 


### PR DESCRIPTION
with typescript 3.1.6,  
extends ArrayBuffer for Buffer to avoid following error:
 Type 'Buffer' is not assignable to type 'Blob'.
    Property 'size' is missing in type 'Buffer'.