### PR TITLE
Fix existing row styles when using spliceRows

### DIFF
--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -330,6 +330,10 @@ Worksheet.prototype = {
         rSrc = this._rows[i - 1];
         if (rSrc) {
           this.getRow(i + nExpand).values = rSrc.values;
+          // eslint-disable-next-line no-loop-func
+          rSrc.eachCell({ includeEmpty: true }, function(cell, colNumber) {
+            this.getRow(i + nExpand).getCell(colNumber).style = cell.style;
+          }.bind(this));
           this._rows[i - 1] = undefined;
         } else {
           this._rows[(i + nExpand) - 1] = undefined;
@@ -341,6 +345,10 @@ Worksheet.prototype = {
         rSrc = this._rows[i - 1];
         if (rSrc) {
           this.getRow(i + nExpand).values = rSrc.values;
+          // eslint-disable-next-line no-loop-func
+          rSrc.eachCell({ includeEmpty: true }, function(cell, colNumber) {
+            this.getRow(i + nExpand).getCell(colNumber).style = cell.style;
+          }.bind(this));
         } else {
           this._rows[(i + nExpand) - 1] = undefined;
         }

--- a/spec/integration/workbook/workbook.spec.js
+++ b/spec/integration/workbook/workbook.spec.js
@@ -487,6 +487,7 @@ describe('Workbook', function() {
       'splice.rows.insertFewer',
       'splice.rows.insertSame',
       'splice.rows.insertMore',
+      'splice.rows.insertStyle',
       'splice.columns.removeOnly',
       'splice.columns.insertFewer',
       'splice.columns.insertSame',

--- a/spec/unit/doc/worksheet.values.spec.js
+++ b/spec/unit/doc/worksheet.values.spec.js
@@ -346,6 +346,11 @@ describe('Worksheet', function() {
           testUtils.createTestBook(wb, 'xlsx', ['splice.rows.insertMore'], options);
           testUtils.checkTestBook(wb, 'xlsx', ['splice.rows.insertMore'], options);
         });
+        it('Insert style', function() {
+          var wb = new Excel.Workbook();
+          testUtils.createTestBook(wb, 'xlsx', ['splice.rows.insertStyle'], options);
+          testUtils.checkTestBook(wb, 'xlsx', ['splice.rows.insertStyle'], options);
+        });
       });
       describe('Columns', function() {
         it('splices columns', function() {

--- a/spec/utils/test-spliced-sheet.js
+++ b/spec/utils/test-spliced-sheet.js
@@ -128,7 +128,52 @@ module.exports = {
         expect(ws.getRow(5).values).to.deep.equal([, 4.1,, 4.3]);
         expect(ws.getRow(6).values).to.deep.equal([, '5,1', '5,2', '5,3']);
       }
-    }
+    },
+    insertStyle: {
+      addSheet: function(wb) {
+        var ws = wb.addWorksheet('splice-row-insert-style');
+
+        ws.addRow(['1,1', '1,2', '1,3']);
+        ws.addRow(['2,1', '2,2', '2,3']);
+        ws.getCell('A2').fill = {
+          type: 'pattern',
+          pattern:'darkVertical',
+          fgColor: { argb:'FFFF0000' }
+        };
+
+        ws.spliceRows(2, 0, ['one', 'two', 'three']);
+        ws.getCell('A2').border = {
+          top: { style:'thin' },
+          left: { style:'thin' },
+          bottom: { style:'thin' },
+          right: { style:'thin' }
+        };
+      },
+
+      checkSheet: function(wb) {
+        var ws = wb.getWorksheet('splice-row-insert-style');
+        expect(ws).to.not.be.undefined();
+
+        expect(ws.getRow(1).values).to.deep.equal([, '1,1', '1,2', '1,3']);
+        expect(ws.getRow(2).values).to.deep.equal([, 'one', 'two', 'three']);
+        expect(ws.getRow(3).values).to.deep.equal([, '2,1', '2,2', '2,3']);
+        expect(ws.getCell('A2').style).to.deep.equal({
+          border: {
+            top: { style:'thin' },
+            left: { style:'thin' },
+            bottom: { style:'thin' },
+            right: { style:'thin' }
+          }
+        });
+        expect(ws.getCell('A3').style).to.deep.equal({
+          fill: {
+            type: 'pattern',
+            pattern:'darkVertical',
+            fgColor: { argb:'FFFF0000' }
+          }
+        });
+      }
+    },
   },
   columns: {
     removeOnly: {


### PR DESCRIPTION
This PR fixes the style issues reported in https://github.com/exceljs/exceljs/issues/305 and https://github.com/exceljs/exceljs/issues/697 to copy over any existing styles already applied to rows. I have also included additional tests for this fix.