### PR TITLE
Add vertical align property

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,11 @@ ws.getCell('A2').font = {
     italic: true
 };
 
+// for the vertical align 
+ws.getCell('A3').font = {
+  vertAlign: 'superscript'
+};
+
 // note: the cell will store a reference to the font object assigned.
 // If the font object is changed afterwards, the cell font will change also...
 var font = { name: 'Arial', size: 12 };
@@ -899,6 +904,7 @@ font.size = 20; // Cell A3 now has font size 20!
 | underline     | Font <u>underline</u> style | true, false, 'none', 'single', 'double', 'singleAccounting', 'doubleAccounting' |
 | strike        | Font <strike>strikethrough</strike> | true, false |
 | outline       | Font outline | true, false |
+| vertAlign     | Vertical align | 'superscript', 'subscript'
 
 ### Alignment
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -226,6 +226,7 @@ export interface Font {
 	bold: boolean;
 	italic: boolean;
 	underline: boolean | 'none' | 'single' | 'double' | 'singleAccounting' | 'doubleAccounting';
+  vertAlign: 'superscript' | 'subscript';
 	strike: boolean;
 	outline: boolean;
 }

--- a/lib/xlsx/xform/style/font-xform.js
+++ b/lib/xlsx/xform/style/font-xform.js
@@ -30,6 +30,7 @@ var FontXform = module.exports = function(options) {
     extend: { prop: 'extend', xform: new BooleanXform({tag: 'extend', attr: 'val'}) },
     family: { prop: 'family', xform: new IntegerXform({tag: 'family', attr: 'val'}) },
     outline: { prop: 'outline', xform: new BooleanXform({tag: 'outline', attr: 'val'}) },
+    vertAlign: { prop: 'vertAlign', xform: new StringXform({ tag: 'vertAlign', attr: 'val' }) },
     scheme: { prop: 'scheme', xform: new StringXform({tag: 'scheme', attr: 'val'}) },
     shadow: { prop: 'shadow', xform: new BooleanXform({tag: 'shadow', attr: 'val'}) },
     strike: { prop: 'strike', xform: new BooleanXform({tag: 'strike', attr: 'val'}) },

--- a/spec/unit/xlsx/xform/style/vertical-aligment-xform.spec.js
+++ b/spec/unit/xlsx/xform/style/vertical-aligment-xform.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var StringXform = require('../../../../../lib/xlsx/xform/simple/string-xform');
+var testXformHelper = require('./../test-xform-helper');
+
+var expectations = [
+  {
+    title: 'superscript',
+    create: function() { return new StringXform({ tag: 'vertAlign', attr: 'val' }); },
+    preparedModel: 'superscript',
+    xml: '<vertAlign val="superscript"/>',
+    parsedModel: 'superscript',
+    tests: ['render', 'renderIn', 'parse']
+  },
+  {
+    title: 'subscript',
+    create: function() { return new StringXform({ tag: 'vertAlign', attr: 'val' }); },
+    preparedModel: 'subscript ',
+    xml: '<vertAlign val="subscript"/>',
+    parsedModel: 'subscript',
+    tests: ['render', 'renderIn', 'parse']
+  }
+];


### PR DESCRIPTION
Add support vertical align property (vertAlign) with possible values are superscript and subscript.
Related to #555 

Use:
for entire cell
`
firstRow.font = { name: 'Arial', family: 2, size: 20, vertAlign: 'superscript'}
`

rich text:
`
worksheet.getCell('A10').value = {
'richText': [
	{'font': {'size': 12,'color': {'theme': 1},'name': 'Calibri','family': 2,'scheme': 'minor'},'text': 'This is '},
	{'font': {'italic': true,'size': 12,'color': {'theme': 1},'name': 'Calibri','vertAlign': 'superscript'},'text': 'superscript'},
	{'font': {'size': 12,'color': {'theme': 1},'name': 'Calibri','family': 2,'scheme': 'minor'},'text': 'and '},
	{'font': {'italic': true,'size': 12,'color': {'theme': 1},'name': 'Calibri','vertAlign': 'subscript'},'text': 'subscript'},
]
};
`