### PR TITLE
Replace the temp lib to tmp

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -5,6 +5,7 @@ var events = require('events');
 var Stream = require('stream');
 var unzip = require('unzipper');
 var Sax = require('sax');
+var tmp = require('tmp');
 
 var utils = require('../../utils/utils');
 var FlowControl = require('../../utils/flow-control');
@@ -15,7 +16,7 @@ var WorkbookPropertiesManager = require('../../xlsx/xform/book/workbook-properti
 var WorksheetReader = require('./worksheet-reader');
 var HyperlinkReader = require('./hyperlink-reader');
 
-var Temp = require('temp');
+tmp.setGracefulCleanup();
 
 var WorkbookReader = module.exports = function(options) {
   this.options = options = options || {};
@@ -37,8 +38,11 @@ var WorkbookReader = module.exports = function(options) {
   // end of stream check
   this.atEnd = false;
 
-  Temp.track();
+  // worksheets, deferred for parsing after shared strings reading
   this.waitingWorkSheets = [];
+
+  // callbacks for temp files cleanup
+  this.tempFileCleanupCallbacks = [];
 };
 
 utils.inherits(WorkbookReader, events.EventEmitter, {
@@ -94,9 +98,17 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
             if (this.sharedStrings) {
               this._parseWorksheet(entry, sheetNo, options);
             } else {
-              var stream = Temp.createWriteStream();
-              this.waitingWorkSheets.push({sheetNo: sheetNo, options: options, path: stream.path});
-              entry.pipe(stream);
+              // create temp file for each worksheet
+              tmp.file((err, path, fd, cleanupCallback) => {
+                if (err) throw err;
+
+                var tempStream = fs.createWriteStream(path);
+
+                this.waitingWorkSheets.push({sheetNo: sheetNo, options: options, path: path});
+                entry.pipe(tempStream);
+
+                this.tempFileCleanupCallbacks.push(cleanupCallback);
+              });
             }
           } else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d+[.]xml.rels/)) {
             match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
@@ -110,29 +122,32 @@ utils.inherits(WorkbookReader, events.EventEmitter, {
     });
 
     zip.on('close', () => {
-      var self = this;
       if (this.waitingWorkSheets.length) {
           var currentBook = 0;
 
-          var processBooks = function () {
-              var worksheetInfo = self.waitingWorkSheets[currentBook];
+          var processBooks = () => {
+              var worksheetInfo = this.waitingWorkSheets[currentBook];
               var entry = fs.createReadStream(worksheetInfo.path);
 
               var sheetNo = worksheetInfo.sheetNo;
               var options = worksheetInfo.options;
-              var worksheet = self._parseWorksheet(entry, sheetNo, options);
+              var worksheet = this._parseWorksheet(entry, sheetNo, options);
 
-              worksheet.on('finished', function (node) {
+              worksheet.on('finished', (node) => {
                   ++currentBook;
-                  if (currentBook == self.waitingWorkSheets.length) {
-                      Temp.cleanupSync();
-                      // setImmediate(this.emit.bind(this), 'finished');
+                  if (currentBook === this.waitingWorkSheets.length) {
+                    // temp files cleaning up
+                    this.tempFileCleanupCallbacks.forEach(function (cb) {
+                      cb();
+                    });
 
-                      self.emit('end');
-                      self.atEnd = true;
-                      if (!self.readers) {
-                          self.emit('finished');
-                      }
+                    this.tempFileCleanupCallbacks = [];
+
+                    this.emit('end');
+                    this.atEnd = true;
+                    if (!this.readers) {
+                      this.emit('finished');
+                    }
                   } else {
                       setImmediate(processBooks);
                   }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "unzipper": "^0.9.7",
     "promish": ">=5.0.2",
     "sax": "^1.2.2",
-    "temp": "0.8.3"
+    "tmp": "^0.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.0",


### PR DESCRIPTION
Right we are using the `temp` package for creating temp files to cache shared strings in the workbook reader. The problem is that the `temp` uses a global cache to keep track of its files, which is not safe for concurrent operation. In particular, the cleanup of one task will delete all files tracked globally, incl. those still needed by another task. This results in a node error that a file was not found.

In this PR we replace the `temp` to `tmp` which is safe for concurrent operations.