### PR TITLE
Drop node version v6, add support to node v11 and v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - 8
-  - 9
   - 10
   - 11
   - 12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-  - 6
   - 8
   - 9
   - 10
+  - 11
+  - 12
 script:
   - npm test
 notifications:


### PR DESCRIPTION

## Release schedule

https://github.com/nodejs/Release

| Release  | Status              | Codename    |Initial Release | Active LTS Start | Maintenance LTS Start | End-of-life               |
| :--:     | :---:               | :---:       | :---:          | :---:            | :---:                 | :---:                     |
| [6.x][]  | **Maintenance LTS** | [Boron][]   | 2016-04-26     | 2016-10-18       | 2018-04-30            | 2019-04-30                |
| [8.x][]  | **Maintenance LTS** | [Carbon][]  | 2017-05-30     | 2017-10-31       | 2019-01-01            | December 2019<sup>1</sup> |
| [10.x][] | **Active LTS**      | [Dubnium][] | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |
| [11.x][] | **Current Release** |             | 2018-10-23     |                  |                       | 2019-06-01                |
| 12.x     | **Pending**         |             | 2019-04-23     | 2019-10-22       | April 2021            | April 2022                |