### PR TITLE
Add an entrypoint for node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ To be clear, all contributions added to this library will be included in the lib
 
 ```javascript
 var Excel = require('exceljs');
+
+// or, for node.js version 8+
+const Excel = require('exceljs/nodejs');
 ```
 
 ## Create a Workbook

--- a/nodejs.js
+++ b/nodejs.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/exceljs.nodejs');


### PR DESCRIPTION
Since we're about to add async/await, let's give node.js users a way to import our code directly, without getting the transpiled version. Otherwise, it will be much slower and produce worse stack traces.