### PR TITLE
Do not use a promise polyfill on modern setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,20 @@ To be clear, all contributions added to this library will be included in the lib
 
 # Interface
 
+## Importing
+
+The default export is a transpiled ES5 version with a Promise polyfill - this offers the highest level of compatibility.
+
 ```javascript
 var Excel = require('exceljs');
+import Excel from 'exceljs';
+```
 
-// or, for node.js version 8+
-const Excel = require('exceljs/nodejs');
+However, if you use this library on a modern node.js version (>=8) or on the frontend using a bundler (or can focus on just evergreen browsers), we recommend to use these imports:
+
+```javascript
+const Excel = require('exceljs/modern.nodejs');
+import Excel from 'exceljs/modern.browser';
 ```
 
 ## Create a Workbook

--- a/lib/config/set-value.js
+++ b/lib/config/set-value.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PromishLib = require('../utils/promish');
+const PromiseLib = require('../utils/promise');
 
 function setValue(key, value, overwrite) {
   if (overwrite === undefined) {
@@ -9,8 +9,8 @@ function setValue(key, value, overwrite) {
   }
   switch (key.toLowerCase()) {
     case 'promise':
-      if (!overwrite && PromishLib.Promish) return;
-      PromishLib.Promish = value;
+      if (!overwrite && PromiseLib.Promise) return;
+      PromiseLib.Promise = value;
       break;
     default:
       break;

--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const csv = require('fast-csv');
 const moment = require('moment');
-const PromishLib = require('../utils/promish');
+const PromiseLib = require('../utils/promise');
 const StreamBuf = require('../utils/stream-buf');
 
 const utils = require('../utils/utils');
@@ -48,7 +48,7 @@ CSV.prototype = {
   },
   read(stream, options) {
     options = options || {};
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       const csvStream = this.createInputStream(options)
         .on('worksheet', resolve)
         .on('error', reject);
@@ -67,8 +67,9 @@ CSV.prototype = {
         if (datum === '') {
           return null;
         }
-        if (!isNaN(datum)) {
-          return parseFloat(datum);
+        const datumNumber = Number(datum);
+        if (!Number.isNaN(datumNumber)) {
+          return datumNumber;
         }
         const dt = moment(datum, dateFormats, true);
         if (dt.isValid()) {
@@ -92,7 +93,7 @@ CSV.prototype = {
   },
 
   write(stream, options) {
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       options = options || {};
       // const encoding = options.encoding || 'utf8';
       // const separator = options.separator || ',';
@@ -107,8 +108,7 @@ CSV.prototype = {
       csvStream.on('error', reject);
       csvStream.pipe(stream);
 
-      const dateFormat = options.dateFormat;
-      const dateUTC = options.dateUTC;
+      const {dateFormat, dateUTC} = options;
       const map =
         options.map ||
         (value => {
@@ -121,7 +121,7 @@ CSV.prototype = {
             }
             if (value instanceof Date) {
               if (dateFormat) {
-                dateUTC ? moment.utc(value).format(dateFormat) : moment(value).format(dateFormat);
+                return dateUTC ? moment.utc(value).format(dateFormat) : moment(value).format(dateFormat);
               }
               return dateUTC ? moment.utc(value).format() : moment(value).format();
             }
@@ -144,7 +144,7 @@ CSV.prototype = {
               csvStream.write([]);
             }
           }
-          const values = row.values;
+          const {values} = row;
           values.shift();
           csvStream.write(values.map(map));
           lastRow = rowNumber;

--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const Archiver = require('archiver');
-const PromishLib = require('../../utils/promish');
+const PromiseLib = require('../../utils/promise');
 
 const StreamBuf = require('../../utils/stream-buf');
 
@@ -57,7 +57,7 @@ const WorkbookWriter = (module.exports = function(options) {
   this.zip.pipe(this.stream);
 
   // these bits can be added right now
-  this.promise = PromishLib.Promish.all([this.addThemes(), this.addOfficeRels()]);
+  this.promise = PromiseLib.Promise.all([this.addThemes(), this.addOfficeRels()]);
 });
 
 WorkbookWriter.prototype = {
@@ -77,21 +77,21 @@ WorkbookWriter.prototype = {
   _commitWorksheets() {
     const commitWorksheet = function(worksheet) {
       if (!worksheet.committed) {
-        return new PromishLib.Promish(resolve => {
+        return new PromiseLib.Promise(resolve => {
           worksheet.stream.on('zipped', () => {
             resolve();
           });
           worksheet.commit();
         });
       }
-      return PromishLib.Promish.resolve();
+      return PromiseLib.Promise.resolve();
     };
     // if there are any uncommitted worksheets, commit them now and wait
     const promises = this._worksheets.map(commitWorksheet);
     if (promises.length) {
-      return PromishLib.Promish.all(promises);
+      return PromiseLib.Promise.all(promises);
     }
-    return PromishLib.Promish.resolve();
+    return PromiseLib.Promise.resolve();
   },
 
   commit() {
@@ -99,7 +99,7 @@ WorkbookWriter.prototype = {
     return this.promise
       .then(() => this._commitWorksheets())
       .then(() =>
-        PromishLib.Promish.all([this.addContentTypes(), this.addApp(), this.addCore(), this.addSharedStrings(), this.addStyles(), this.addWorkbookRels()])
+        PromiseLib.Promise.all([this.addContentTypes(), this.addApp(), this.addCore(), this.addSharedStrings(), this.addStyles(), this.addWorkbookRels()])
       )
       .then(() => this.addWorkbook())
       .then(() => this._finalize());
@@ -164,21 +164,21 @@ WorkbookWriter.prototype = {
   },
   addStyles() {
     const self = this;
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       self.zip.append(self.styles.xml, { name: 'xl/styles.xml' });
       resolve();
     });
   },
   addThemes() {
     const self = this;
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       self.zip.append(theme1Xml, { name: 'xl/theme/theme1.xml' });
       resolve();
     });
   },
   addOfficeRels() {
     const self = this;
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new RelationshipsXform();
       const xml = xform.toXml([
         { Id: 'rId1', Type: RelType.OfficeDocument, Target: 'xl/workbook.xml' },
@@ -191,7 +191,7 @@ WorkbookWriter.prototype = {
   },
 
   addContentTypes() {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const model = {
         worksheets: this._worksheets.filter(Boolean),
         sharedStrings: this.sharedStrings,
@@ -203,7 +203,7 @@ WorkbookWriter.prototype = {
     });
   },
   addApp() {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const model = {
         worksheets: this._worksheets.filter(Boolean),
       };
@@ -215,7 +215,7 @@ WorkbookWriter.prototype = {
   },
   addCore() {
     const self = this;
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const coreXform = new CoreXform();
       const xml = coreXform.toXml(self);
       self.zip.append(xml, { name: 'docProps/core.xml' });
@@ -225,14 +225,14 @@ WorkbookWriter.prototype = {
   addSharedStrings() {
     const self = this;
     if (this.sharedStrings.count) {
-      return new PromishLib.Promish(resolve => {
+      return new PromiseLib.Promise(resolve => {
         const sharedStringsXform = new SharedStringsXform();
         const xml = sharedStringsXform.toXml(self.sharedStrings);
         self.zip.append(xml, { name: '/xl/sharedStrings.xml' });
         resolve();
       });
     }
-    return PromishLib.Promish.resolve();
+    return PromiseLib.Promise.resolve();
   },
   addWorkbookRels() {
     const self = this;
@@ -250,7 +250,7 @@ WorkbookWriter.prototype = {
         relationships.push({ Id: worksheet.rId, Type: RelType.Worksheet, Target: `worksheets/sheet${worksheet.id}.xml` });
       }
     });
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new RelationshipsXform();
       const xml = xform.toXml(relationships);
       self.zip.append(xml, { name: '/xl/_rels/workbook.xml.rels' });
@@ -258,7 +258,7 @@ WorkbookWriter.prototype = {
     });
   },
   addWorkbook() {
-    const zip = this.zip;
+    const {zip} = this;
     const model = {
       worksheets: this._worksheets.filter(Boolean),
       definedNames: this._definedNames.model,
@@ -266,7 +266,7 @@ WorkbookWriter.prototype = {
       properties: {},
     };
 
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new WorkbookXform();
       xform.prepare(model);
       zip.append(xform.toXml(model), { name: '/xl/workbook.xml' });
@@ -274,7 +274,7 @@ WorkbookWriter.prototype = {
     });
   },
   _finalize() {
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       this.stream.on('error', reject);
       this.stream.on('finish', () => {
         resolve(this);

--- a/lib/utils/flow-control.js
+++ b/lib/utils/flow-control.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const events = require('events');
-const PromishLib = require('./promish');
+const PromiseLib = require('./promise');
 
 const utils = require('./utils');
 
@@ -28,7 +28,7 @@ const FlowControl = (module.exports = function(options) {
 
   // determine timeout for flow control delays
   if (options.gc) {
-    const gc = options.gc;
+    const {gc} = options;
     if (gc.getTimeout) {
       this.getTimeout = gc.getTimeout;
     } else {
@@ -64,7 +64,7 @@ utils.inherits(FlowControl, events.EventEmitter, {
   _write(dst, data, encoding) {
     // Write to a single destination and return a promise
 
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       dst.write(data, encoding, error => {
         if (error) {
           reject(error);
@@ -90,9 +90,9 @@ utils.inherits(FlowControl, events.EventEmitter, {
       }
     });
     if (!promises.length) {
-      promises.push(PromishLib.Promish.resolve());
+      promises.push(PromiseLib.Promise.resolve());
     }
-    return PromishLib.Promish.all(promises).then(() => {
+    return PromiseLib.Promise.all(promises).then(() => {
       try {
         chunk.callback();
       } catch (e) {
@@ -112,7 +112,7 @@ utils.inherits(FlowControl, events.EventEmitter, {
     // in certain situations it may be useful to delay processing (e.g. for GC)
     const timeout = this.getTimeout && this.getTimeout();
     if (timeout) {
-      return new PromishLib.Promish(resolve => {
+      return new PromiseLib.Promise(resolve => {
         const anime = this._animate();
         setTimeout(() => {
           clearInterval(anime);
@@ -120,7 +120,7 @@ utils.inherits(FlowControl, events.EventEmitter, {
         }, timeout);
       });
     }
-    return PromishLib.Promish.resolve();
+    return PromiseLib.Promise.resolve();
   },
 
   _flush() {

--- a/lib/utils/promise.js
+++ b/lib/utils/promise.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  Promise: typeof Promise !== 'undefined' ? Promise : null,
+};

--- a/lib/utils/promish.js
+++ b/lib/utils/promish.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  Promish: null,
-};

--- a/lib/utils/stream-buf.js
+++ b/lib/utils/stream-buf.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Stream = require('stream');
-const PromishLib = require('./promish');
+const PromiseLib = require('./promise');
 
 const utils = require('./utils');
 const StringBuf = require('./string-buf');
@@ -183,14 +183,14 @@ utils.inherits(StreamBuf, Stream.Duplex, {
 
   _pipe(chunk) {
     const write = function(pipe) {
-      return new PromishLib.Promish(resolve => {
+      return new PromiseLib.Promise(resolve => {
         pipe.write(chunk.toBuffer(), () => {
           resolve();
         });
       });
     };
     const promises = this.pipes.map(write);
-    return promises.length ? PromishLib.Promish.all(promises).then(utils.nop) : PromishLib.Promish.resolve();
+    return promises.length ? PromiseLib.Promise.all(promises).then(utils.nop) : PromiseLib.Promise.resolve();
   },
   _writeToBuffers(chunk) {
     let inPos = 0;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const PromishLib = require('./promish');
+const PromiseLib = require('./promise');
 
 // useful stuff
 const inherits = function(cls, superCtor, statics, prototype) {
@@ -36,10 +36,10 @@ const inherits = function(cls, superCtor, statics, prototype) {
   cls.prototype = Object.create(superCtor.prototype, properties);
 };
 
-var utils = (module.exports = {
+const utils = {
   nop() {},
   promiseImmediate(value) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       if (global.setImmediate) {
         setImmediate(() => {
           resolve(value);
@@ -110,7 +110,7 @@ var utils = (module.exports = {
   },
   validInt(value) {
     const i = parseInt(value, 10);
-    return !isNaN(i) ? i : 0;
+    return !Number.isNaN(i) ? i : 0;
   },
 
   isDateFmt(fmt) {
@@ -128,7 +128,7 @@ var utils = (module.exports = {
 
   fs: {
     exists(path) {
-      return new PromishLib.Promish(resolve => {
+      return new PromiseLib.Promise(resolve => {
         fs.exists(path, exists => {
           resolve(exists);
         });
@@ -139,4 +139,6 @@ var utils = (module.exports = {
   toIsoDateString(dt) {
     return dt.toIsoString().subsstr(0, 10);
   },
-});
+};
+
+module.exports = utils;

--- a/lib/utils/zip-stream.js
+++ b/lib/utils/zip-stream.js
@@ -6,7 +6,7 @@
 
 const events = require('events');
 const JSZip = require('jszip');
-const PromishLib = require('./promish');
+const PromiseLib = require('./promise');
 
 const utils = require('./utils');
 const StreamBuf = require('./stream-buf');
@@ -27,7 +27,7 @@ const ZipReader = function(options) {
 utils.inherits(ZipReader, events.EventEmitter, {
   _finished() {
     if (!--this.count) {
-      PromishLib.Promish.resolve().then(() => {
+      PromiseLib.Promise.resolve().then(() => {
         this.emit('finished');
       });
     }

--- a/lib/xlsx/xform/base-xform.js
+++ b/lib/xlsx/xform/base-xform.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Sax = require('sax');
-const PromishLib = require('../../utils/promish');
+const PromiseLib = require('../../utils/promise');
 
 const XmlStream = require('../../utils/xml-stream');
 
@@ -50,7 +50,7 @@ BaseXform.prototype = {
 
   parse(parser, stream) {
     const self = this;
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       function abort(error) {
         // Abandon ship! Prevent the parser from consuming any more resources
         parser.removeAllListeners();

--- a/lib/xlsx/xform/simple/date-xform.js
+++ b/lib/xlsx/xform/simple/date-xform.js
@@ -11,7 +11,7 @@ const DateXform = (module.exports = function(options) {
     options.format ||
     function(dt) {
       try {
-        if (isNaN(dt.getTime())) return '';
+        if (Number.isNaN(dt.getTime())) return '';
         return dt.toISOString();
       } catch (e) {
         return '';

--- a/lib/xlsx/xform/style/styles-xform.js
+++ b/lib/xlsx/xform/style/styles-xform.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PromishLib = require('../../../utils/promish');
+const PromiseLib = require('../../../utils/promise');
 
 const utils = require('../../../utils/utils');
 const Enums = require('../../../doc/enums');
@@ -21,7 +21,7 @@ const NUMFMT_BASE = 164;
 // =============================================================================
 // StylesXform is used to generate and parse the styles.xml file
 // it manages the collections of fonts, number formats, alignments, etc
-var StylesXform = (module.exports = function(initialise) {
+const StylesXform = function(initialise) {
   this.map = {
     numFmts: new ListXform({ tag: 'numFmts', count: true, childXform: new NumFmtXform() }),
     fonts: new ListXform({ tag: 'fonts', count: true, childXform: new FontXform(), $: { 'x14ac:knownFonts': 1 } }),
@@ -47,7 +47,7 @@ var StylesXform = (module.exports = function(initialise) {
     // StylesXform also acts as style manager and is used to build up styles-model during worksheet processing
     this.init();
   }
-});
+};
 
 utils.inherits(
   StylesXform,
@@ -211,11 +211,11 @@ utils.inherits(
         return true;
       }
       switch (name) {
-        case 'styleSheet':
-          var model = (this.model = {});
-          var add = function(propName, xform) {
+        case 'styleSheet': {
+          this.model = {};
+          const add = (propName, xform) => {
             if (xform.model && xform.model.length) {
-              model[propName] = xform.model;
+              this.model[propName] = xform.model;
             }
           };
           add('numFmts', this.map.numFmts);
@@ -229,14 +229,15 @@ utils.inherits(
             model: [],
             numFmt: [],
           };
-          if (model.numFmts) {
+          if (this.model.numFmts) {
             const numFmtIndex = this.index.numFmt;
-            model.numFmts.forEach(numFmt => {
+            this.model.numFmts.forEach(numFmt => {
               numFmtIndex[numFmt.id] = numFmt.formatCode;
             });
           }
 
           return false;
+        }
         default:
           // not quite sure how we get here!
           return true;
@@ -430,7 +431,7 @@ utils.inherits(StylesXform.Mock, StylesXform, {
   // override normal behaviour - consume and dispose
   parseStream(stream) {
     stream.autodrain();
-    return PromishLib.Promish.resolve();
+    return PromiseLib.Promise.resolve();
   },
 
   // add a cell's style model to the collection
@@ -462,3 +463,5 @@ utils.inherits(StylesXform.Mock, StylesXform, {
     return {};
   },
 });
+
+module.exports = StylesXform;

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const ZipStream = require('../utils/zip-stream');
 const StreamBuf = require('../utils/stream-buf');
-const PromishLib = require('../utils/promish');
+const PromiseLib = require('../utils/promise');
 
 const utils = require('../utils/utils');
 const XmlStream = require('../utils/xml-stream');
@@ -26,7 +26,7 @@ const XLSX = (module.exports = function(workbook) {
 });
 
 function fsReadFileAsync(filename, options) {
-  return new PromishLib.Promish((resolve, reject) => {
+  return new PromiseLib.Promise((resolve, reject) => {
     fs.readFile(filename, options, (error, data) => {
       if (error) {
         reject(error);
@@ -161,7 +161,7 @@ XLSX.prototype = {
       }
       const extension = filename.substr(lastDot + 1);
       const name = filename.substr(0, lastDot);
-      return new PromishLib.Promish((resolve, reject) => {
+      return new PromiseLib.Promise((resolve, reject) => {
         const streamBuf = new StreamBuf();
         streamBuf.on('finish', () => {
           model.mediaIndex[filename] = model.media.length;
@@ -208,7 +208,7 @@ XLSX.prototype = {
   processThemeEntry(entry, model) {
     const match = entry.path.match(/xl\/theme\/([a-zA-Z0-9]+)[.]xml/);
     if (match) {
-      return new PromishLib.Promish((resolve, reject) => {
+      return new PromiseLib.Promise((resolve, reject) => {
         const name = match[1];
         // TODO: stream entry into buffer and store the xml in the model.themes[]
         const stream = new StreamBuf();
@@ -325,7 +325,7 @@ XLSX.prototype = {
       }
     });
     stream.on('finished', () => {
-      PromishLib.Promish.all(promises)
+      PromiseLib.Promise.all(promises)
         .then(() => {
           self.reconcile(model, options);
 
@@ -346,7 +346,7 @@ XLSX.prototype = {
     options = options || {};
     const self = this;
     const zipStream = this.createInputStream(options);
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       zipStream
         .on('done', () => {
           resolve(self.workbook);
@@ -364,7 +364,7 @@ XLSX.prototype = {
       options = {};
     }
     const zipStream = this.createInputStream();
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       zipStream
         .on('done', () => {
           resolve(self.workbook);
@@ -387,7 +387,7 @@ XLSX.prototype = {
   // Write
 
   addMedia(zip, model) {
-    return PromishLib.Promish.all(
+    return PromiseLib.Promise.all(
       model.media.map(medium => {
         if (medium.type === 'image') {
           const filename = `xl/media/${medium.name}.${medium.extension}`;
@@ -397,13 +397,13 @@ XLSX.prototype = {
             });
           }
           if (medium.buffer) {
-            return new PromishLib.Promish(resolve => {
+            return new PromiseLib.Promise(resolve => {
               zip.append(medium.buffer, { name: filename });
               resolve();
             });
           }
           if (medium.base64) {
-            return new PromishLib.Promish(resolve => {
+            return new PromiseLib.Promise(resolve => {
               const dataimg64 = medium.base64;
               const content = dataimg64.substring(dataimg64.indexOf(',') + 1);
               zip.append(content, { name: filename, base64: true });
@@ -411,7 +411,7 @@ XLSX.prototype = {
             });
           }
         }
-        return PromishLib.Promish.reject(new Error('Unsupported media'));
+        return PromiseLib.Promise.reject(new Error('Unsupported media'));
       })
     );
   },
@@ -422,10 +422,10 @@ XLSX.prototype = {
     const promises = [];
 
     model.worksheets.forEach(worksheet => {
-      const drawing = worksheet.drawing;
+      const {drawing} = worksheet;
       if (drawing) {
         promises.push(
-          new PromishLib.Promish(resolve => {
+          new PromiseLib.Promise(resolve => {
             drawingXform.prepare(drawing, {});
             let xml = drawingXform.toXml(drawing);
             zip.append(xml, { name: `xl/drawings/${drawing.name}.xml` });
@@ -439,11 +439,11 @@ XLSX.prototype = {
       }
     });
 
-    return PromishLib.Promish.all(promises);
+    return PromiseLib.Promise.all(promises);
   },
 
   addContentTypes(zip, model) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new ContentTypesXform();
       const xml = xform.toXml(model);
       zip.append(xml, { name: '[Content_Types].xml' });
@@ -452,7 +452,7 @@ XLSX.prototype = {
   },
 
   addApp(zip, model) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new AppXform();
       const xml = xform.toXml(model);
       zip.append(xml, { name: 'docProps/app.xml' });
@@ -461,7 +461,7 @@ XLSX.prototype = {
   },
 
   addCore(zip, model) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const coreXform = new CoreXform();
       zip.append(coreXform.toXml(model), { name: 'docProps/core.xml' });
       resolve();
@@ -469,7 +469,7 @@ XLSX.prototype = {
   },
 
   addThemes(zip, model) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const themes = model.themes || { theme1: theme1Xml };
       Object.keys(themes).forEach(name => {
         const xml = themes[name];
@@ -481,7 +481,7 @@ XLSX.prototype = {
   },
 
   addOfficeRels(zip) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new RelationshipsXform();
       const xml = xform.toXml([
         { Id: 'rId1', Type: XLSX.RelType.OfficeDocument, Target: 'xl/workbook.xml' },
@@ -506,7 +506,7 @@ XLSX.prototype = {
       worksheet.rId = `rId${count++}`;
       relationships.push({ Id: worksheet.rId, Type: XLSX.RelType.Worksheet, Target: `worksheets/sheet${worksheet.id}.xml` });
     });
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new RelationshipsXform();
       const xml = xform.toXml(relationships);
       zip.append(xml, { name: 'xl/_rels/workbook.xml.rels' });
@@ -515,16 +515,16 @@ XLSX.prototype = {
   },
   addSharedStrings(zip, model) {
     if (!model.sharedStrings || !model.sharedStrings.count) {
-      return PromishLib.Promish.resolve();
+      return PromiseLib.Promise.resolve();
     }
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       zip.append(model.sharedStrings.xml, { name: 'xl/sharedStrings.xml' });
       resolve();
     });
   },
   addStyles(zip, model) {
-    return new PromishLib.Promish(resolve => {
-      const xml = model.styles.xml;
+    return new PromiseLib.Promise(resolve => {
+      const {xml} = model.styles;
       if (xml) {
         zip.append(xml, { name: 'xl/styles.xml' });
       }
@@ -532,14 +532,14 @@ XLSX.prototype = {
     });
   },
   addWorkbook(zip, model) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       const xform = new WorkbookXform();
       zip.append(xform.toXml(model), { name: 'xl/workbook.xml' });
       resolve();
     });
   },
   addWorksheets(zip, model) {
-    return new PromishLib.Promish(resolve => {
+    return new PromiseLib.Promise(resolve => {
       // preparation phase
       const worksheetXform = new WorksheetXform();
       const relationshipsXform = new RelationshipsXform();
@@ -561,7 +561,7 @@ XLSX.prototype = {
     });
   },
   _finalize(zip) {
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       zip.on('finish', () => {
         resolve(this);
       });
@@ -607,14 +607,14 @@ XLSX.prototype = {
   },
   write(stream, options) {
     options = options || {};
-    const model = this.workbook.model;
+    const {model} = this.workbook;
     const zip = new ZipStream.ZipWriter();
     zip.pipe(stream);
 
     this.prepareModel(model, options);
 
     // render
-    return PromishLib.Promish.resolve()
+    return PromiseLib.Promise.resolve()
       .then(() => this.addContentTypes(zip, model))
       .then(() => this.addOfficeRels(zip, model))
       .then(() => this.addWorkbookRels(zip, model))
@@ -623,12 +623,12 @@ XLSX.prototype = {
       .then(() => this.addDrawings(zip, model))
       .then(() => {
         const promises = [this.addThemes(zip, model), this.addStyles(zip, model)];
-        return PromishLib.Promish.all(promises);
+        return PromiseLib.Promise.all(promises);
       })
       .then(() => this.addMedia(zip, model))
       .then(() => {
         const afters = [this.addApp(zip, model), this.addCore(zip, model)];
-        return PromishLib.Promish.all(afters);
+        return PromiseLib.Promise.all(afters);
       })
       .then(() => this.addWorkbook(zip, model))
       .then(() => this._finalize(zip));
@@ -637,7 +637,7 @@ XLSX.prototype = {
     const self = this;
     const stream = fs.createWriteStream(filename);
 
-    return new PromishLib.Promish((resolve, reject) => {
+    return new PromiseLib.Promise((resolve, reject) => {
       stream.on('finish', () => {
         resolve();
       });

--- a/modern.browser.js
+++ b/modern.browser.js
@@ -1,0 +1,4 @@
+const setConfigValue = require('./lib/config/set-value');
+
+setConfigValue('promise', Promise, false);
+module.exports = require('./lib/exceljs.browser');

--- a/modern.nodejs.js
+++ b/modern.nodejs.js
@@ -1,0 +1,4 @@
+const setConfigValue = require('./lib/config/set-value');
+
+setConfigValue('promise', Promise, false);
+module.exports = require('./lib/exceljs.nodejs');

--- a/nodejs.js
+++ b/nodejs.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/exceljs.nodejs');

--- a/spec/config/setup-unit.js
+++ b/spec/config/setup-unit.js
@@ -1,5 +1,4 @@
-// must configure PromishLib for unit tests
-const Promish = require('promish');
-const PromishLib = require('../../lib/utils/promish');
+// must configure PromiseLib for unit tests
+const PromiseLib = require('../../lib/utils/promise');
 
-PromishLib.Promish = Promish;
+PromiseLib.Promise = Promise;

--- a/spec/integration/issues/issue-266-breaking-bluebird.spec.js
+++ b/spec/integration/issues/issue-266-breaking-bluebird.spec.js
@@ -1,28 +1,28 @@
 'use strict';
 
 const chai = require('chai');
+const promish = require('promish');
 
 const verquire = require('../../utils/verquire');
 
-const PromishLib = verquire('utils/promish');
+const PromiseLib = verquire('utils/promise');
 const Excel = verquire('excel');
 
-const expect = chai.expect;
+const {expect} = chai;
 
 // this file to contain integration tests created from github issues
 const TEST_XLSX_FILE_NAME = './spec/out/wb.test.xlsx';
 
 describe('github issues', () => {
   describe('issue 266 - Breaking change removing bluebird', () => {
-    let promish;
     beforeEach(() => {
-      promish = PromishLib.Promish;
+      PromiseLib.Promise = promish;
     });
     afterEach(() => {
-      PromishLib.Promish = promish;
+      PromiseLib.Promise = promish;
     });
 
-    it('common bluebird functions', () => {
+    it('promish supports common bluebird functions', () => {
       const wb = new Excel.Workbook();
       const ws = wb.addWorksheet('Sheet1');
       let calledFinally = false;

--- a/spec/integration/workbook/images.spec.js
+++ b/spec/integration/workbook/images.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const Promish = require('promish');
+const { promisify } = require('util');
 const { expect } = require('chai');
 const verquire = require('../../utils/verquire');
 
@@ -9,7 +9,7 @@ const Excel = verquire('excel');
 
 const IMAGE_FILENAME = `${__dirname}/../data/image.png`;
 const TEST_XLSX_FILE_NAME = './spec/out/wb.test.xlsx';
-const fsReadFileAsync = Promish.promisify(fs.readFile);
+const fsReadFileAsync = promisify(fs.readFile);
 
 // =============================================================================
 // Tests

--- a/spec/unit/utils/stream-buf.spec.js
+++ b/spec/unit/utils/stream-buf.spec.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const expect = require('chai').expect;
-const Promish = require('promish');
+const {expect} = require('chai');
 const fs = require('fs');
 const path = require('path');
+const { Promise } = require('../../../lib/utils/promise');
 
 const StreamBuf = require('../../../lib/utils/stream-buf');
 const StringBuf = require('../../../lib/utils/string-buf');
@@ -41,7 +41,7 @@ describe('StreamBuf', () => {
   });
 
   it('handles buffers', () =>
-    new Promish((resolve, reject) => {
+    new Promise((resolve, reject) => {
       const s = fs.createReadStream(path.join(__dirname, 'data/image1.png'));
       const sb = new StreamBuf();
       sb.on('finish', () => {


### PR DESCRIPTION
To make the most of async/await (performance & stack traces), we need to use the native Promises. This PR does not change that the default export uses `promish`, but it does add two new exports that allow access to the modern codebase and native promises. I've also fixed a couple of eslint failures in the affected files.

```javascript
const Excel = require('exceljs/modern.nodejs');
import Excel from 'exceljs/modern.browser';
```
