### PR TITLE
Introduce async/await 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,7 @@
     "prefer-rest-params": ["off"],
     "quotes": ["error", "single"],
     "semi": ["error", "always"],
-    "space-before-function-paren": ["error", "never"],
+    "space-before-function-paren": ["error", {"anonymous": "never", "named": "never", "asyncArrow": "always"}],
     "strict": ["off"],
     "class-methods-use-this": ["off"],
     "no-return-assign": ["off"],

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ package-lock.json
 
 # optional switch off tests
 .disable-test-*
+
+# jasmine
+_SpecRunner.html

--- a/.prettier
+++ b/.prettier
@@ -1,5 +1,6 @@
 {
   "bracketSpacing": false,
   "printWidth": 160,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "bracketSpacing": false
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -65,9 +65,9 @@ module.exports = function(grunt) {
     copy: {
       dist: {
         files: [
-          { expand: true, src: ['**'], cwd: './build/lib', dest: './dist/es5' },
-          { src: './build/lib/exceljs.nodejs.js', dest: './dist/es5/index.js' },
-          { src: './LICENSE', dest: './dist/LICENSE' },
+          {expand: true, src: ['**'], cwd: './build/lib', dest: './dist/es5'},
+          {src: './build/lib/exceljs.nodejs.js', dest: './dist/es5/index.js'},
+          {src: './LICENSE', dest: './dist/LICENSE'},
         ],
       },
     },

--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -28,23 +28,16 @@ const SpecialValues = {
 /* eslint-ensable quote-props */
 
 CSV.prototype = {
-  readFile(filename, options) {
+  async readFile(filename, options) {
     const self = this;
     options = options || {};
-    let stream;
-    return utils.fs
-      .exists(filename)
-      .then(exists => {
-        if (!exists) {
-          throw new Error(`File not found: ${filename}`);
-        }
-        stream = fs.createReadStream(filename);
-        return self.read(stream, options);
-      })
-      .then(worksheet => {
-        stream.close();
-        return worksheet;
-      });
+    if (!(await utils.fs.exists(filename))) {
+      throw new Error(`File not found: ${filename}`);
+    }
+    const stream = fs.createReadStream(filename);
+    const worksheet = await self.read(stream, options);
+    stream.close();
+    return worksheet;
   },
   read(stream, options) {
     options = options || {};
@@ -163,9 +156,10 @@ CSV.prototype = {
 
     return this.write(stream, options);
   },
-  writeBuffer(options) {
+  async writeBuffer(options) {
     const self = this;
     const stream = new StreamBuf();
-    return self.write(stream, options).then(() => stream.read());
+    await self.write(stream, options);
+    return stream.read();
   },
 };

--- a/lib/exceljs.browser.js
+++ b/lib/exceljs.browser.js
@@ -1,6 +1,4 @@
-// for the benefit of browserify, include browser friendly promise
-const setConfigValue = require('./config/set-value');
-setConfigValue('promise', require('promish/dist/promish-node'), false);
+require('@babel/polyfill');
 
 const ExcelJS = {
   Workbook: require('./doc/workbook'),

--- a/lib/exceljs.browser.js
+++ b/lib/exceljs.browser.js
@@ -1,4 +1,4 @@
-require('@babel/polyfill');
+require('babel-polyfill');
 
 const ExcelJS = {
   Workbook: require('./doc/workbook'),

--- a/lib/exceljs.nodejs.js
+++ b/lib/exceljs.nodejs.js
@@ -1,5 +1,4 @@
-const setConfigValue = require('./config/set-value');
-setConfigValue('promise', require('promish'), false);
+require('@babel/polyfill');
 
 const ExcelJS = {
   Workbook: require('./doc/workbook'),

--- a/lib/exceljs.nodejs.js
+++ b/lib/exceljs.nodejs.js
@@ -1,4 +1,4 @@
-require('@babel/polyfill');
+require('babel-polyfill');
 
 const ExcelJS = {
   Workbook: require('./doc/workbook'),

--- a/lib/stream/xlsx/sheet-rels-writer.js
+++ b/lib/stream/xlsx/sheet-rels-writer.js
@@ -76,7 +76,8 @@ SheetRelsWriter.prototype = {
   // ================================================================================
   _writeOpen() {
     this.stream.write(
-      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+       <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`
     );
   },
   _writeRelationship(relationship) {
@@ -88,14 +89,14 @@ SheetRelsWriter.prototype = {
 
     if (relationship.TargetMode) {
       this.stream.write(
-        `${'<Relationship' + ' Id="'}${rId}"` +
+        `<Relationship Id="${rId}"` +
           ` Type="${relationship.Type}"` +
           ` Target="${utils.xmlEncode(relationship.Target)}"` +
           ` TargetMode="${relationship.TargetMode}"` +
           '/>'
       );
     } else {
-      this.stream.write(`${'<Relationship' + ' Id="'}${rId}"` + ` Type="${relationship.Type}"` + ` Target="${relationship.Target}"` + '/>');
+      this.stream.write(`<Relationship Id="${rId}" Type="${relationship.Type}" Target="${relationship.Target}"/>`);
     }
 
     return rId;

--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -96,15 +96,13 @@ WorkbookWriter.prototype = {
     return PromiseLib.Promise.resolve();
   },
 
-  commit() {
+  async commit() {
     // commit all worksheets, then add suplimentary files
-    return this.promise
-      .then(() => this._commitWorksheets())
-      .then(() =>
-        PromiseLib.Promise.all([this.addContentTypes(), this.addApp(), this.addCore(), this.addSharedStrings(), this.addStyles(), this.addWorkbookRels()])
-      )
-      .then(() => this.addWorkbook())
-      .then(() => this._finalize());
+    await this.promise;
+    await this._commitWorksheets();
+    await PromiseLib.Promise.all([this.addContentTypes(), this.addApp(), this.addCore(), this.addSharedStrings(), this.addStyles(), this.addWorkbookRels()]);
+    await this.addWorkbook();
+    return this._finalize();
   },
   get nextId() {
     // find the next unique spot to add worksheet

--- a/lib/utils/flow-control.js
+++ b/lib/utils/flow-control.js
@@ -29,7 +29,7 @@ class FlowControl extends events.EventEmitter {
 
     // determine timeout for flow control delays
     if (options.gc) {
-      const {gc} = options;
+      const { gc } = options;
       if (gc.getTimeout) {
         this.getTimeout = gc.getTimeout;
       } else {
@@ -77,7 +77,7 @@ class FlowControl extends events.EventEmitter {
     });
   }
 
-  _pipe(chunk) {
+  async _pipe(chunk) {
     // Write chunk to all pipes. A chunk with no data is the end
     const promises = [];
     this.pipes.forEach(pipe => {
@@ -94,13 +94,12 @@ class FlowControl extends events.EventEmitter {
     if (!promises.length) {
       promises.push(PromiseLib.Promise.resolve());
     }
-    return PromiseLib.Promise.all(promises).then(() => {
-      try {
-        chunk.callback();
-      } catch (e) {
-        // quietly ignore
-      }
-    });
+    await PromiseLib.Promise.all(promises);
+    try {
+      chunk.callback();
+    } catch (e) {
+      // quietly ignore
+    }
   }
 
   _animate() {
@@ -127,19 +126,17 @@ class FlowControl extends events.EventEmitter {
     return PromiseLib.Promise.resolve();
   }
 
-  _flush() {
+  async _flush() {
     // If/while not corked and we have buffers to send, send them
     if (this.queue && !this.flushing && !this.corked) {
       if (this.queue.length) {
         this.flushing = true;
-        this._delay()
-          .then(() => this._pipe(this.queue.shift()))
-          .then(() => {
-            setImmediate(() => {
-              this.flushing = false;
-              this._flush();
-            });
-          });
+        await this._delay();
+        await this._pipe(this.queue.shift());
+        setImmediate(() => {
+          this.flushing = false;
+          this._flush();
+        });
       }
 
       if (!this.stem) {

--- a/lib/utils/stream-buf.js
+++ b/lib/utils/stream-buf.js
@@ -201,7 +201,7 @@ utils.inherits(StreamBuf, Stream.Duplex, {
     return buf;
   },
 
-  _pipe(chunk) {
+  async _pipe(chunk) {
     const write = function(pipe) {
       return new PromiseLib.Promise(resolve => {
         pipe.write(chunk.toBuffer(), () => {
@@ -209,8 +209,7 @@ utils.inherits(StreamBuf, Stream.Duplex, {
         });
       });
     };
-    const promises = this.pipes.map(write);
-    return promises.length ? PromiseLib.Promise.all(promises).then(utils.nop) : PromiseLib.Promise.resolve();
+    await Promise.all(this.pipes.map(write));
   },
   _writeToBuffers(chunk) {
     let inPos = 0;
@@ -223,7 +222,7 @@ utils.inherits(StreamBuf, Stream.Duplex, {
       inPos += buffer.write(chunk, inPos, inLen - inPos);
     }
   },
-  write(data, encoding, callback) {
+  async write(data, encoding, callback) {
     if (encoding instanceof Function) {
       callback = encoding;
       encoding = 'utf8';
@@ -249,7 +248,8 @@ utils.inherits(StreamBuf, Stream.Duplex, {
           this._pipe(this.buffers.shift());
         }
       } else if (!this.corked) {
-        this._pipe(chunk).then(callback);
+        await this._pipe(chunk);
+        callback();
       } else {
         this._writeToBuffers(chunk);
         process.nextTick(callback);

--- a/lib/utils/zip-stream.js
+++ b/lib/utils/zip-stream.js
@@ -1,6 +1,5 @@
 const events = require('events');
 const JSZip = require('jszip');
-const PromiseLib = require('./promise');
 
 const StreamBuf = require('./stream-buf');
 
@@ -27,44 +26,40 @@ class ZipReader extends events.EventEmitter {
 
   _finished() {
     if (!--this.count) {
-      PromiseLib.Promise.resolve().then(() => {
+      process.nextTick(() => {
         this.emit('finished');
       });
     }
   }
 
-  _process() {
-    const content = this.stream.read();
-    this.jsZip
-      .loadAsync(content)
-      .then(zip => {
-        zip.forEach((path, entry) => {
-          if (!entry.dir) {
-            this.count++;
-            entry
-              .async(this.getEntryType(path))
-              .then(data => {
-                const entryStream = new StreamBuf();
-                entryStream.path = path;
-                entryStream.write(data);
-                entryStream.autodrain = () => {
-                  this._finished();
-                };
-                entryStream.on('finish', () => {
-                  this._finished();
-                });
+  async _process() {
+    try {
+      const content = this.stream.read();
+      const zip = await this.jsZip.loadAsync(content);
+      zip.forEach(async (path, entry) => {
+        if (!entry.dir) {
+          this.count++;
+          try {
+            const data = await entry.async(this.getEntryType(path));
+            const entryStream = new StreamBuf();
+            entryStream.path = path;
+            entryStream.write(data);
+            entryStream.autodrain = () => {
+              this._finished();
+            };
+            entryStream.on('finish', () => {
+              this._finished();
+            });
 
-                this.emit('entry', entryStream);
-              })
-              .catch(error => {
-                this.emit('error', error);
-              });
+            this.emit('entry', entryStream);
+          } catch (error) {
+            this.emit('error', error);
           }
-        });
-      })
-      .catch(error => {
-        this.emit('error', error);
+        }
       });
+    } catch (error) {
+      this.emit('error', error);
+    }
   }
 
   // ==========================================================================
@@ -121,11 +116,10 @@ class ZipWriter extends events.EventEmitter {
     }
   }
 
-  finalize() {
-    return this.zip.generateAsync(this.options).then(content => {
-      this.stream.end(content);
-      this.emit('finish');
-    });
+  async finalize() {
+    const content = await this.zip.generateAsync(this.options);
+    this.stream.end(content);
+    this.emit('finish');
   }
 
   // ==========================================================================

--- a/lib/xlsx/xform/base-xform.js
+++ b/lib/xlsx/xform/base-xform.js
@@ -52,10 +52,7 @@ class BaseXform {
 
   mergeModel(obj) {
     // set obj's props to this.model
-    this.model = Object.assign(
-      this.model || {},
-      obj
-    );
+    this.model = Object.assign(this.model || {}, obj);
   }
 
   parse(parser, stream) {

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -45,7 +45,7 @@ class XLSX {
   // Read
 
   async readFile(filename, options) {
-    if (!await utils.fs.exists(filename)) {
+    if (!(await utils.fs.exists(filename))) {
       throw new Error(`File not found: ${filename}`);
     }
     const stream = fs.createReadStream(filename);
@@ -137,7 +137,7 @@ class XLSX {
 
   async _processWorksheetEntry(entry, model, sheetNo, options) {
     const xform = new WorksheetXform(options);
-    const worksheet= await xform.parseStream(entry);
+    const worksheet = await xform.parseStream(entry);
     worksheet.sheetNo = sheetNo;
     model.worksheetHash[entry.path] = worksheet;
     model.worksheets.push(worksheet);
@@ -235,105 +235,107 @@ class XLSX {
       getEntryType: path => (path.match(/xl\/media\//) ? 'nodebuffer' : 'string'),
     });
     stream.on('entry', entry => {
-      promises.push(async () => {
-        try {
-          let entryPath = entry.path;
-          if (entryPath[0] === '/') {
-            entryPath = entryPath.substr(1);
+      promises.push(
+        (async () => {
+          try {
+            let entryPath = entry.path;
+            if (entryPath[0] === '/') {
+              entryPath = entryPath.substr(1);
+            }
+            switch (entryPath) {
+              case '_rels/.rels':
+                model.globalRels = await this.parseRels(entry);
+                break;
+
+              case 'xl/workbook.xml': {
+                const workbook = await this.parseWorkbook(entry);
+                model.sheets = workbook.sheets;
+                model.definedNames = workbook.definedNames;
+                model.views = workbook.views;
+                model.properties = workbook.properties;
+                break;
+              }
+
+              case 'xl/_rels/workbook.xml.rels':
+                model.workbookRels = await this.parseRels(entry);
+                break;
+
+              case 'xl/sharedStrings.xml':
+                model.sharedStrings = new SharedStringsXform();
+                await model.sharedStrings.parseStream(entry);
+                break;
+
+              case 'xl/styles.xml':
+                model.styles = new StylesXform();
+                await model.styles.parseStream(entry);
+                break;
+
+              case 'docProps/app.xml': {
+                const appXform = new AppXform();
+                const appProperties = await appXform.parseStream(entry);
+                model.company = appProperties.company;
+                model.manager = appProperties.manager;
+                break;
+              }
+
+              case 'docProps/core.xml': {
+                const coreXform = new CoreXform();
+                const coreProperties = await coreXform.parseStream(entry);
+                Object.assign(model, coreProperties);
+                break;
+              }
+
+              default: {
+                let match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
+                if (match) {
+                  await this._processWorksheetEntry(entry, model, match[1], options);
+                  break;
+                }
+                match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
+                if (match) {
+                  await this._processWorksheetRelsEntry(entry, model, match[1]);
+                  break;
+                }
+                match = entry.path.match(/xl\/theme\/([a-zA-Z0-9]+)[.]xml/);
+                if (match) {
+                  await this._processThemeEntry(entry, model, match[1]);
+                  break;
+                }
+                match = entry.path.match(/xl\/media\/([a-zA-Z0-9]+[.][a-zA-Z0-9]{3,4})$/);
+                if (match) {
+                  await this._processMediaEntry(entry, model, match[1]);
+                  break;
+                }
+                match = entry.path.match(/xl\/drawings\/([a-zA-Z0-9]+)[.]xml/);
+                if (match) {
+                  await this._processDrawingEntry(entry, model, match[1]);
+                  break;
+                }
+                match = entry.path.match(/xl\/(comments\d+)[.]xml/);
+                if (match) {
+                  await this._processCommentEntry(entry, model, match[1]);
+                  break;
+                }
+                match = entry.path.match(/xl\/tables\/(table\d+)[.]xml/);
+                if (match) {
+                  await this._processTableEntry(entry, model, match[1]);
+                  break;
+                }
+                match = entry.path.match(/xl\/drawings\/_rels\/([a-zA-Z0-9]+)[.]xml[.]rels/);
+                if (match) {
+                  await this._processDrawingRelsEntry(entry, model, match[1]);
+                  break;
+                }
+
+                entry.autodrain();
+              }
+            }
+          } catch (error) {
+            stream.destroy(error);
+            throw error;
           }
-          switch (entryPath) {
-            case '_rels/.rels':
-              model.globalRels = await this.parseRels(entry);
-              break;
-
-            case 'xl/workbook.xml': {
-              const workbook = await this.parseWorkbook(entry);
-              model.sheets = workbook.sheets;
-              model.definedNames = workbook.definedNames;
-              model.views = workbook.views;
-              model.properties = workbook.properties;
-              break;
-            }
-
-            case 'xl/_rels/workbook.xml.rels':
-              model.workbookRels = await this.parseRels(entry);
-              break;
-
-            case 'xl/sharedStrings.xml':
-              model.sharedStrings = new SharedStringsXform();
-              await model.sharedStrings.parseStream(entry);
-              break;
-
-            case 'xl/styles.xml':
-              model.styles = new StylesXform();
-              await model.styles.parseStream(entry);
-              break;
-
-            case 'docProps/app.xml': {
-              const appXform = new AppXform();
-              const appProperties = await appXform.parseStream(entry);
-              model.company = appProperties.company;
-              model.manager = appProperties.manager;
-              break;
-            }
-
-            case 'docProps/core.xml': {
-              const coreXform = new CoreXform();
-              const coreProperties = await coreXform.parseStream(entry);
-              Object.assign(model, coreProperties);
-              break;
-            }
-
-            default: {
-              let match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
-              if (match) {
-                await this._processWorksheetEntry(entry, model, match[1], options);
-                break;
-              }
-              match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
-              if (match) {
-                await this._processWorksheetRelsEntry(entry, model, match[1]);
-                break;
-              }
-              match = entry.path.match(/xl\/theme\/([a-zA-Z0-9]+)[.]xml/);
-              if (match) {
-                await this._processThemeEntry(entry, model, match[1]);
-                break;
-              }
-              match = entry.path.match(/xl\/media\/([a-zA-Z0-9]+[.][a-zA-Z0-9]{3,4})$/);
-              if (match) {
-                await this._processMediaEntry(entry, model, match[1]);
-                break;
-              }
-              match = entry.path.match(/xl\/drawings\/([a-zA-Z0-9]+)[.]xml/);
-              if (match) {
-                await this._processDrawingEntry(entry, model, match[1]);
-                break;
-              }
-              match = entry.path.match(/xl\/(comments\d+)[.]xml/);
-              if (match) {
-                await this._processCommentEntry(entry, model, match[1]);
-                break;
-              }
-              match = entry.path.match(/xl\/tables\/(table\d+)[.]xml/);
-              if (match) {
-                await this._processTableEntry(entry, model, match[1]);
-                break;
-              }
-              match = entry.path.match(/xl\/drawings\/_rels\/([a-zA-Z0-9]+)[.]xml[.]rels/);
-              if (match) {
-                await this._processDrawingRelsEntry(entry, model, match[1]);
-                break;
-              }
-
-              entry.autodrain();
-            }
-          }
-        } catch (error) {
-          stream.destroy(error);
-          throw error;
-        }
-      });
+        })()
+      );
     });
     stream.on('finished', async () => {
       try {
@@ -351,9 +353,9 @@ class XLSX {
   }
 
   read(stream, options) {
-    options = options || {};
-    const zipStream = this.createInputStream(options);
     return new PromiseLib.Promise((resolve, reject) => {
+      options = options || {};
+      const zipStream = this.createInputStream(options);
       zipStream
         .on('done', () => {
           resolve(this.workbook);
@@ -629,10 +631,10 @@ class XLSX {
     return this._finalize(zip);
   }
 
-  async writeFile(filename, options) {
+  writeFile(filename, options) {
     const stream = fs.createWriteStream(filename);
 
-    await new PromiseLib.Promise(async (resolve, reject) => {
+    return new PromiseLib.Promise(async (resolve, reject) => {
       stream.on('finish', () => {
         resolve();
       });

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -44,24 +44,19 @@ class XLSX {
   // =========================================================================
   // Read
 
-  readFile(filename, options) {
-    let stream;
-    return utils.fs
-      .exists(filename)
-      .then(exists => {
-        if (!exists) {
-          throw new Error(`File not found: ${filename}`);
-        }
-        stream = fs.createReadStream(filename);
-        return this.read(stream, options).catch(error => {
-          stream.close();
-          throw error;
-        });
-      })
-      .then(workbook => {
-        stream.close();
-        return workbook;
-      });
+  async readFile(filename, options) {
+    if (!await utils.fs.exists(filename)) {
+      throw new Error(`File not found: ${filename}`);
+    }
+    const stream = fs.createReadStream(filename);
+    try {
+      const workbook = await this.read(stream, options);
+      stream.close();
+      return workbook;
+    } catch (error) {
+      stream.close();
+      throw error;
+    }
   }
 
   parseRels(stream) {
@@ -140,72 +135,39 @@ class XLSX {
     delete model.drawingRels;
   }
 
-  processWorksheetEntry(entry, model, options) {
-    const match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
-    if (match) {
-      const sheetNo = match[1];
-      const xform = new WorksheetXform(options);
-      return xform.parseStream(entry)
-        .then(worksheet => {
-          worksheet.sheetNo = sheetNo;
-          model.worksheetHash[entry.path] = worksheet;
-          model.worksheets.push(worksheet);
-        });
-    }
-    return undefined;
+  async _processWorksheetEntry(entry, model, sheetNo, options) {
+    const xform = new WorksheetXform(options);
+    const worksheet= await xform.parseStream(entry);
+    worksheet.sheetNo = sheetNo;
+    model.worksheetHash[entry.path] = worksheet;
+    model.worksheets.push(worksheet);
   }
 
-  processCommentEntry(entry, model) {
-    const match = entry.path.match(/xl\/(comments\d+)[.]xml/);
-    if (match) {
-      const name = match[1];
-      const xform = new CommentsXform();
-      return xform.parseStream(entry)
-        .then(comments => {
-          model.comments[`../${name}.xml`] = comments;
-        });
-    }
-    return undefined;
+  async _processCommentEntry(entry, model, name) {
+    const xform = new CommentsXform();
+    const comments = await xform.parseStream(entry);
+    model.comments[`../${name}.xml`] = comments;
   }
 
-  processTableEntry(entry, model) {
-    const match = entry.path.match(/xl\/tables\/(table\d+)[.]xml/);
-    if (match) {
-      const name = match[1];
-      const xform = new TableXform();
-      return xform.parseStream(entry)
-        .then(table => {
-          model.tables[`../tables/${name}.xml`] = table;
-        });
-    }
-    return undefined;
+  async _processTableEntry(entry, model, name) {
+    const xform = new TableXform();
+    const table = await xform.parseStream(entry);
+    model.tables[`../tables/${name}.xml`] = table;
   }
 
-  processWorksheetRelsEntry(entry, model) {
-    const match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
-    if (match) {
-      const sheetNo = match[1];
-      const xform = new RelationshipsXform();
-      return xform.parseStream(entry)
-        .then(relationships => {
-          model.worksheetRels[sheetNo] = relationships;
-        });
-    }
-    return undefined;
+  async _processWorksheetRelsEntry(entry, model, sheetNo) {
+    const xform = new RelationshipsXform();
+    const relationships = await xform.parseStream(entry);
+    model.worksheetRels[sheetNo] = relationships;
   }
 
-  processMediaEntry(entry, model) {
-    const match = entry.path.match(/xl\/media\/([a-zA-Z0-9]+[.][a-zA-Z0-9]{3,4})$/);
-    if (match) {
-      const filename = match[1];
-      const lastDot = filename.lastIndexOf('.');
-      if (lastDot === -1) {
-        // if we can't determine extension, ignore it
-        return undefined;
-      }
+  async _processMediaEntry(entry, model, filename) {
+    const lastDot = filename.lastIndexOf('.');
+    // if we can't determine extension, ignore it
+    if (lastDot >= 1) {
       const extension = filename.substr(lastDot + 1);
       const name = filename.substr(0, lastDot);
-      return new PromiseLib.Promise((resolve, reject) => {
+      await new PromiseLib.Promise((resolve, reject) => {
         const streamBuf = new StreamBuf();
         streamBuf.on('finish', () => {
           model.mediaIndex[filename] = model.media.length;
@@ -225,56 +187,32 @@ class XLSX {
         entry.pipe(streamBuf);
       });
     }
-    return undefined;
   }
 
-  processDrawingEntry(entry, model) {
-    const match = entry.path.match(/xl\/drawings\/([a-zA-Z0-9]+)[.]xml/);
-    if (match) {
-      const name = match[1];
-      const xform = new DrawingXform();
-      return xform.parseStream(entry)
-        .then(drawing => {
-          model.drawings[name] = drawing;
-        });
-    }
-    return undefined;
+  async _processDrawingEntry(entry, model, name) {
+    const xform = new DrawingXform();
+    const drawing = await xform.parseStream(entry);
+    model.drawings[name] = drawing;
   }
 
-  processDrawingRelsEntry(entry, model) {
-    const match = entry.path.match(/xl\/drawings\/_rels\/([a-zA-Z0-9]+)[.]xml[.]rels/);
-    if (match) {
-      const name = match[1];
-      const xform = new RelationshipsXform();
-      return xform.parseStream(entry)
-        .then(relationships => {
-          model.drawingRels[name] = relationships;
-        });
-    }
-    return undefined;
+  async _processDrawingRelsEntry(entry, model, name) {
+    const xform = new RelationshipsXform();
+    const relationships = await xform.parseStream(entry);
+    model.drawingRels[name] = relationships;
   }
 
-  processThemeEntry(entry, model) {
-    const match = entry.path.match(/xl\/theme\/([a-zA-Z0-9]+)[.]xml/);
-    if (match) {
-      return new PromiseLib.Promise((resolve, reject) => {
-        const name = match[1];
-        // TODO: stream entry into buffer and store the xml in the model.themes[]
-        const stream = new StreamBuf();
-        entry.on('error', reject);
-        stream.on('error', reject);
-        stream.on('finish', () => {
-          model.themes[name] = stream.read().toString();
-          resolve();
-        });
-        entry.pipe(stream);
+  async _processThemeEntry(entry, model, name) {
+    await new PromiseLib.Promise((resolve, reject) => {
+      // TODO: stream entry into buffer and store the xml in the model.themes[]
+      const stream = new StreamBuf();
+      entry.on('error', reject);
+      stream.on('error', reject);
+      stream.on('finish', () => {
+        model.themes[name] = stream.read().toString();
+        resolve();
       });
-    }
-    return undefined;
-  }
-
-  processIgnoreEntry(entry) {
-    entry.autodrain();
+      entry.pipe(stream);
+    });
   }
 
   createInputStream(options) {
@@ -297,106 +235,117 @@ class XLSX {
       getEntryType: path => (path.match(/xl\/media\//) ? 'nodebuffer' : 'string'),
     });
     stream.on('entry', entry => {
-      let promise = null;
+      promises.push(async () => {
+        try {
+          let entryPath = entry.path;
+          if (entryPath[0] === '/') {
+            entryPath = entryPath.substr(1);
+          }
+          switch (entryPath) {
+            case '_rels/.rels':
+              model.globalRels = await this.parseRels(entry);
+              break;
 
-      let entryPath = entry.path;
-      if (entryPath[0] === '/') {
-        entryPath = entryPath.substr(1);
-      }
-      switch (entryPath) {
-        case '_rels/.rels':
-          promise = this.parseRels(entry)
-            .then(relationships => {
-              model.globalRels = relationships;
-            });
-          break;
-
-        case 'xl/workbook.xml':
-          promise = this.parseWorkbook(entry)
-            .then(workbook => {
+            case 'xl/workbook.xml': {
+              const workbook = await this.parseWorkbook(entry);
               model.sheets = workbook.sheets;
               model.definedNames = workbook.definedNames;
               model.views = workbook.views;
               model.properties = workbook.properties;
-            });
-          break;
+              break;
+            }
 
-        case 'xl/_rels/workbook.xml.rels':
-          promise = this.parseRels(entry)
-            .then(relationships => {
-              model.workbookRels = relationships;
-            });
-          break;
+            case 'xl/_rels/workbook.xml.rels':
+              model.workbookRels = await this.parseRels(entry);
+              break;
 
-        case 'xl/sharedStrings.xml':
-          model.sharedStrings = new SharedStringsXform();
-          promise = model.sharedStrings.parseStream(entry);
-          break;
+            case 'xl/sharedStrings.xml':
+              model.sharedStrings = new SharedStringsXform();
+              await model.sharedStrings.parseStream(entry);
+              break;
 
-        case 'xl/styles.xml':
-          model.styles = new StylesXform();
-          promise = model.styles.parseStream(entry);
-          break;
+            case 'xl/styles.xml':
+              model.styles = new StylesXform();
+              await model.styles.parseStream(entry);
+              break;
 
-        case 'docProps/app.xml': {
-          const appXform = new AppXform();
-          promise = appXform.parseStream(entry)
-            .then(appProperties => {
-              Object.assign(model, {
-                company: appProperties.company,
-                manager: appProperties.manager,
-              });
-            });
-          break;
-        }
+            case 'docProps/app.xml': {
+              const appXform = new AppXform();
+              const appProperties = await appXform.parseStream(entry);
+              model.company = appProperties.company;
+              model.manager = appProperties.manager;
+              break;
+            }
 
-        case 'docProps/core.xml': {
-          const coreXform = new CoreXform();
-          promise = coreXform.parseStream(entry)
-            .then(coreProperties => {
+            case 'docProps/core.xml': {
+              const coreXform = new CoreXform();
+              const coreProperties = await coreXform.parseStream(entry);
               Object.assign(model, coreProperties);
-            });
-          break;
-        }
+              break;
+            }
 
-        default:
-          promise =
-            this.processWorksheetEntry(entry, model, options) ||
-            this.processWorksheetRelsEntry(entry, model) ||
-            this.processThemeEntry(entry, model) ||
-            this.processMediaEntry(entry, model) ||
-            this.processDrawingEntry(entry, model) ||
-            this.processCommentEntry(entry, model) ||
-            this.processTableEntry(entry, model) ||
-            this.processDrawingRelsEntry(entry, model) ||
-            this.processIgnoreEntry(entry);
-          break;
-      }
+            default: {
+              let match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
+              if (match) {
+                await this._processWorksheetEntry(entry, model, match[1], options);
+                break;
+              }
+              match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
+              if (match) {
+                await this._processWorksheetRelsEntry(entry, model, match[1]);
+                break;
+              }
+              match = entry.path.match(/xl\/theme\/([a-zA-Z0-9]+)[.]xml/);
+              if (match) {
+                await this._processThemeEntry(entry, model, match[1]);
+                break;
+              }
+              match = entry.path.match(/xl\/media\/([a-zA-Z0-9]+[.][a-zA-Z0-9]{3,4})$/);
+              if (match) {
+                await this._processMediaEntry(entry, model, match[1]);
+                break;
+              }
+              match = entry.path.match(/xl\/drawings\/([a-zA-Z0-9]+)[.]xml/);
+              if (match) {
+                await this._processDrawingEntry(entry, model, match[1]);
+                break;
+              }
+              match = entry.path.match(/xl\/(comments\d+)[.]xml/);
+              if (match) {
+                await this._processCommentEntry(entry, model, match[1]);
+                break;
+              }
+              match = entry.path.match(/xl\/tables\/(table\d+)[.]xml/);
+              if (match) {
+                await this._processTableEntry(entry, model, match[1]);
+                break;
+              }
+              match = entry.path.match(/xl\/drawings\/_rels\/([a-zA-Z0-9]+)[.]xml[.]rels/);
+              if (match) {
+                await this._processDrawingRelsEntry(entry, model, match[1]);
+                break;
+              }
 
-      if (promise) {
-        promise = promise.catch(error => {
+              entry.autodrain();
+            }
+          }
+        } catch (error) {
           stream.destroy(error);
           throw error;
-        });
-
-        promises.push(promise);
-        promise = null;
-      }
+        }
+      });
     });
-    stream.on('finished', () => {
-      PromiseLib.Promise.all(promises)
-        .then(() => {
-          this.reconcile(model, options);
+    stream.on('finished', async () => {
+      try {
+        await PromiseLib.Promise.all(promises);
+        this.reconcile(model, options);
 
-          // apply model
-          this.workbook.model = model;
-        })
-        .then(() => {
-          stream.emit('done');
-        })
-        .catch(error => {
-          stream.emit('error', error);
-        });
+        // apply model
+        this.workbook.model = model;
+        stream.emit('done');
+      } catch (error) {
+        stream.emit('error', error);
+      }
     });
     return stream;
   }
@@ -443,33 +392,25 @@ class XLSX {
   // =========================================================================
   // Write
 
-  addMedia(zip, model) {
-    return PromiseLib.Promise.all(
-      model.media.map(medium => {
+  async addMedia(zip, model) {
+    await PromiseLib.Promise.all(
+      model.media.map(async medium => {
         if (medium.type === 'image') {
           const filename = `xl/media/${medium.name}.${medium.extension}`;
           if (medium.filename) {
-            return fsReadFileAsync(medium.filename)
-              .then(data => {
-                zip.append(data, {name: filename});
-              });
+            const data = await fsReadFileAsync(medium.filename);
+            return zip.append(data, {name: filename});
           }
           if (medium.buffer) {
-            return new PromiseLib.Promise(resolve => {
-              zip.append(medium.buffer, {name: filename});
-              resolve();
-            });
+            return zip.append(medium.buffer, {name: filename});
           }
           if (medium.base64) {
-            return new PromiseLib.Promise(resolve => {
-              const dataimg64 = medium.base64;
-              const content = dataimg64.substring(dataimg64.indexOf(',') + 1);
-              zip.append(content, {name: filename, base64: true});
-              resolve();
-            });
+            const dataimg64 = medium.base64;
+            const content = dataimg64.substring(dataimg64.indexOf(',') + 1);
+            return zip.append(content, {name: filename, base64: true});
           }
         }
-        return PromiseLib.Promise.reject(new Error('Unsupported media'));
+        throw new Error('Unsupported media');
       })
     );
   }
@@ -504,58 +445,43 @@ class XLSX {
     });
   }
 
-  addContentTypes(zip, model) {
-    return new PromiseLib.Promise(resolve => {
-      const xform = new ContentTypesXform();
-      const xml = xform.toXml(model);
-      zip.append(xml, {name: '[Content_Types].xml'});
-      resolve();
+  async addContentTypes(zip, model) {
+    const xform = new ContentTypesXform();
+    const xml = xform.toXml(model);
+    zip.append(xml, {name: '[Content_Types].xml'});
+  }
+
+  async addApp(zip, model) {
+    const xform = new AppXform();
+    const xml = xform.toXml(model);
+    zip.append(xml, {name: 'docProps/app.xml'});
+  }
+
+  async addCore(zip, model) {
+    const coreXform = new CoreXform();
+    zip.append(coreXform.toXml(model), {name: 'docProps/core.xml'});
+  }
+
+  async addThemes(zip, model) {
+    const themes = model.themes || {theme1: theme1Xml};
+    Object.keys(themes).forEach(name => {
+      const xml = themes[name];
+      const path = `xl/theme/${name}.xml`;
+      zip.append(xml, {name: path});
     });
   }
 
-  addApp(zip, model) {
-    return new PromiseLib.Promise(resolve => {
-      const xform = new AppXform();
-      const xml = xform.toXml(model);
-      zip.append(xml, {name: 'docProps/app.xml'});
-      resolve();
-    });
+  async addOfficeRels(zip) {
+    const xform = new RelationshipsXform();
+    const xml = xform.toXml([
+      {Id: 'rId1', Type: XLSX.RelType.OfficeDocument, Target: 'xl/workbook.xml'},
+      {Id: 'rId2', Type: XLSX.RelType.CoreProperties, Target: 'docProps/core.xml'},
+      {Id: 'rId3', Type: XLSX.RelType.ExtenderProperties, Target: 'docProps/app.xml'},
+    ]);
+    zip.append(xml, {name: '_rels/.rels'});
   }
 
-  addCore(zip, model) {
-    return new PromiseLib.Promise(resolve => {
-      const coreXform = new CoreXform();
-      zip.append(coreXform.toXml(model), {name: 'docProps/core.xml'});
-      resolve();
-    });
-  }
-
-  addThemes(zip, model) {
-    return new PromiseLib.Promise(resolve => {
-      const themes = model.themes || {theme1: theme1Xml};
-      Object.keys(themes).forEach(name => {
-        const xml = themes[name];
-        const path = `xl/theme/${name}.xml`;
-        zip.append(xml, {name: path});
-      });
-      resolve();
-    });
-  }
-
-  addOfficeRels(zip) {
-    return new PromiseLib.Promise(resolve => {
-      const xform = new RelationshipsXform();
-      const xml = xform.toXml([
-        {Id: 'rId1', Type: XLSX.RelType.OfficeDocument, Target: 'xl/workbook.xml'},
-        {Id: 'rId2', Type: XLSX.RelType.CoreProperties, Target: 'docProps/core.xml'},
-        {Id: 'rId3', Type: XLSX.RelType.ExtenderProperties, Target: 'docProps/app.xml'},
-      ]);
-      zip.append(xml, {name: '_rels/.rels'});
-      resolve();
-    });
-  }
-
-  addWorkbookRels(zip, model) {
+  async addWorkbookRels(zip, model) {
     let count = 1;
     const relationships = [
       {Id: `rId${count++}`, Type: XLSX.RelType.Styles, Target: 'styles.xml'},
@@ -568,74 +494,57 @@ class XLSX {
       worksheet.rId = `rId${count++}`;
       relationships.push({Id: worksheet.rId, Type: XLSX.RelType.Worksheet, Target: `worksheets/sheet${worksheet.id}.xml`});
     });
-    return new PromiseLib.Promise(resolve => {
-      const xform = new RelationshipsXform();
-      const xml = xform.toXml(relationships);
-      zip.append(xml, {name: 'xl/_rels/workbook.xml.rels'});
-      resolve();
-    });
+    const xform = new RelationshipsXform();
+    const xml = xform.toXml(relationships);
+    zip.append(xml, {name: 'xl/_rels/workbook.xml.rels'});
   }
 
-  addSharedStrings(zip, model) {
-    if (!model.sharedStrings || !model.sharedStrings.count) {
-      return PromiseLib.Promise.resolve();
-    }
-    return new PromiseLib.Promise(resolve => {
+  async addSharedStrings(zip, model) {
+    if (model.sharedStrings && model.sharedStrings.count) {
       zip.append(model.sharedStrings.xml, {name: 'xl/sharedStrings.xml'});
-      resolve();
-    });
+    }
   }
 
-  addStyles(zip, model) {
-    return new PromiseLib.Promise(resolve => {
-      const {xml} = model.styles;
-      if (xml) {
-        zip.append(xml, {name: 'xl/styles.xml'});
+  async addStyles(zip, model) {
+    const {xml} = model.styles;
+    if (xml) {
+      zip.append(xml, {name: 'xl/styles.xml'});
+    }
+  }
+
+  async addWorkbook(zip, model) {
+    const xform = new WorkbookXform();
+    zip.append(xform.toXml(model), {name: 'xl/workbook.xml'});
+  }
+
+  async addWorksheets(zip, model) {
+    // preparation phase
+    const worksheetXform = new WorksheetXform();
+    const relationshipsXform = new RelationshipsXform();
+    const commentsXform = new CommentsXform();
+    const vmlNotesXform = new VmlNotesXform();
+
+    // write sheets
+    model.worksheets.forEach(worksheet => {
+      let xmlStream = new XmlStream();
+      worksheetXform.render(xmlStream, worksheet);
+      zip.append(xmlStream.xml, {name: `xl/worksheets/sheet${worksheet.id}.xml`});
+
+      if (worksheet.rels && worksheet.rels.length) {
+        xmlStream = new XmlStream();
+        relationshipsXform.render(xmlStream, worksheet.rels);
+        zip.append(xmlStream.xml, {name: `xl/worksheets/_rels/sheet${worksheet.id}.xml.rels`});
       }
-      resolve();
-    });
-  }
 
-  addWorkbook(zip, model) {
-    return new PromiseLib.Promise(resolve => {
-      const xform = new WorkbookXform();
-      zip.append(xform.toXml(model), {name: 'xl/workbook.xml'});
-      resolve();
-    });
-  }
+      if (worksheet.comments.length > 0) {
+        xmlStream = new XmlStream();
+        commentsXform.render(xmlStream, worksheet);
+        zip.append(xmlStream.xml, {name: `xl/comments${worksheet.id}.xml`});
 
-  addWorksheets(zip, model) {
-    return new PromiseLib.Promise(resolve => {
-      // preparation phase
-      const worksheetXform = new WorksheetXform();
-      const relationshipsXform = new RelationshipsXform();
-      const commentsXform = new CommentsXform();
-      const vmlNotesXform = new VmlNotesXform();
-
-      // write sheets
-      model.worksheets.forEach(worksheet => {
-        let xmlStream = new XmlStream();
-        worksheetXform.render(xmlStream, worksheet);
-        zip.append(xmlStream.xml, {name: `xl/worksheets/sheet${worksheet.id}.xml`});
-
-        if (worksheet.rels && worksheet.rels.length) {
-          xmlStream = new XmlStream();
-          relationshipsXform.render(xmlStream, worksheet.rels);
-          zip.append(xmlStream.xml, {name: `xl/worksheets/_rels/sheet${worksheet.id}.xml.rels`});
-        }
-
-        if (worksheet.comments.length > 0) {
-          xmlStream = new XmlStream();
-          commentsXform.render(xmlStream, worksheet);
-          zip.append(xmlStream.xml, {name: `xl/comments${worksheet.id}.xml`});
-
-          xmlStream = new XmlStream();
-          vmlNotesXform.render(xmlStream, worksheet);
-          zip.append(xmlStream.xml, {name: `xl/drawings/vmlDrawing${worksheet.id}.vml`});
-        }
-      });
-
-      resolve();
+        xmlStream = new XmlStream();
+        vmlNotesXform.render(xmlStream, worksheet);
+        zip.append(xmlStream.xml, {name: `xl/drawings/vmlDrawing${worksheet.id}.vml`});
+      }
     });
   }
 
@@ -697,7 +606,7 @@ class XLSX {
     // TODO: workbook drawing list
   }
 
-  write(stream, options) {
+  async write(stream, options) {
     options = options || {};
     const {model} = this.workbook;
     const zip = new ZipStream.ZipWriter(options.zip);
@@ -706,31 +615,24 @@ class XLSX {
     this.prepareModel(model, options);
 
     // render
-    return PromiseLib.Promise.resolve()
-      .then(() => this.addContentTypes(zip, model))
-      .then(() => this.addOfficeRels(zip, model))
-      .then(() => this.addWorkbookRels(zip, model))
-      .then(() => this.addWorksheets(zip, model))
-      .then(() => this.addSharedStrings(zip, model)) // always after worksheets
-      .then(() => this.addDrawings(zip, model))
-      .then(() => this.addTables(zip, model))
-      .then(() => {
-        const promises = [this.addThemes(zip, model), this.addStyles(zip, model)];
-        return PromiseLib.Promise.all(promises);
-      })
-      .then(() => this.addMedia(zip, model))
-      .then(() => {
-        const afters = [this.addApp(zip, model), this.addCore(zip, model)];
-        return PromiseLib.Promise.all(afters);
-      })
-      .then(() => this.addWorkbook(zip, model))
-      .then(() => this._finalize(zip));
+    await this.addContentTypes(zip, model);
+    await this.addOfficeRels(zip, model);
+    await this.addWorkbookRels(zip, model);
+    await this.addWorksheets(zip, model);
+    await this.addSharedStrings(zip, model); // always after worksheets
+    await this.addDrawings(zip, model);
+    await this.addTables(zip, model);
+    await PromiseLib.Promise.all([this.addThemes(zip, model), this.addStyles(zip, model)]);
+    await this.addMedia(zip, model);
+    await PromiseLib.Promise.all([this.addApp(zip, model), this.addCore(zip, model)]);
+    await this.addWorkbook(zip, model);
+    return this._finalize(zip);
   }
 
-  writeFile(filename, options) {
+  async writeFile(filename, options) {
     const stream = fs.createWriteStream(filename);
 
-    return new PromiseLib.Promise((resolve, reject) => {
+    await new PromiseLib.Promise(async (resolve, reject) => {
       stream.on('finish', () => {
         resolve();
       });
@@ -738,21 +640,15 @@ class XLSX {
         reject(error);
       });
 
-      this
-        .write(stream, options)
-        .then(() => {
-          stream.end();
-        })
-        .catch(error => {
-          reject(error);
-        });
+      await this.write(stream, options);
+      stream.end();
     });
   }
 
-  writeBuffer(options) {
+  async writeBuffer(options) {
     const stream = new StreamBuf();
-    return this.write(stream, options)
-      .then(() => stream.read());
+    await this.write(stream, options);
+    return stream.read();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
   ],
   "dependencies": {
     "archiver": "^3.0.0",
-    "babel-polyfill": "^6.26.0",
     "fast-csv": "^2.4.1",
     "jszip": "^3.1.5",
     "moment": "^2.22.2",
@@ -99,6 +98,7 @@
     "@babel/preset-env": "^7.1.0",
     "@types/node": "^10.12.0",
     "babel-eslint": "^10.0.1",
+    "babel-polyfill": "^6.26.0",
     "bluebird": "^3.5.2",
     "browserify": "^16.2.3",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "clean-build": "npm run clean && npm run build",
     "lint": "eslint --format node_modules/eslint-friendly-formatter .",
     "lint:fix": "prettier-eslint --write \"**/*.js\"",
+    "lint:staged": "lint-staged",
     "clean": "rm -rf build/ && rm -rf dist",
     "build": "./node_modules/.bin/grunt build",
     "preversion": "npm run clean && npm run build && npm run test:full",
@@ -52,6 +53,7 @@
   },
   "lint-staged": {
     "*.js": [
+      "prettier-eslint --write",
       "eslint --format node_modules/eslint-friendly-formatter",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "pageSetup"
   ],
   "dependencies": {
+    "@babel/polyfill": "^7.4.4",
     "archiver": "^3.0.0",
     "fast-csv": "^2.4.1",
     "jszip": "^3.1.5",
@@ -98,7 +99,6 @@
     "@babel/preset-env": "^7.1.0",
     "@types/node": "^10.12.0",
     "babel-eslint": "^10.0.1",
-    "babel-polyfill": "^6.26.0",
     "bluebird": "^3.5.2",
     "browserify": "^16.2.3",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "pageSetup"
   ],
   "dependencies": {
-    "@babel/polyfill": "^7.4.4",
     "archiver": "^3.0.0",
+    "babel-polyfill": "^6.26.0",
     "fast-csv": "^2.4.1",
     "jszip": "^3.1.5",
     "moment": "^2.22.2",

--- a/spec/browser/exceljs.spec.js
+++ b/spec/browser/exceljs.spec.js
@@ -1,7 +1,7 @@
-'use strict';
+/* global ExcelJS */
+// ExcelJS is a global injected by `./dist/exceljs.js` during jasmine's setup
 
-require('babel-polyfill');
-const ExcelJS = require('../../lib/exceljs.browser');
+'use strict';
 
 function unexpectedError(done) {
   return function(error) {

--- a/spec/browser/exceljs.spec.js
+++ b/spec/browser/exceljs.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('babel-polyfill');
+require('@babel/polyfill');
 const ExcelJS = require('../../lib/exceljs.browser');
 
 function unexpectedError(done) {

--- a/spec/browser/exceljs.spec.js
+++ b/spec/browser/exceljs.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('@babel/polyfill');
+require('babel-polyfill');
 const ExcelJS = require('../../lib/exceljs.browser');
 
 function unexpectedError(done) {


### PR DESCRIPTION
Here it comes! 🎉 

In this PR, I've not modified any tests so that we know that these changes are a pure refactoring.
Unfortunately, `async` uses the internal `Promise` object and we cannot offer our users to use a different Promise library. To be backwards compatible with promish, I've added babel polyfill, but I would expect that most consumers of this library will start to use the modern entrypoints.

Looking forward to your feedback!