### PR TITLE
Add Compression level option to WorkbookWriterOptions for streaming #888

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1454,8 +1454,45 @@ export namespace stream {
 			useStyles: boolean;
 		}
 
+        interface ArchiverZipOptions {
+            comment: string;
+            forceLocalTime: boolean;
+            forceZip64: boolean;
+            store: boolean;
+            zlib: Partial<ZlibOptions>;
+        }
+
+        interface ZlibOptions {
+            /**
+             * @default constants.Z_NO_FLUSH
+             */
+            flush: number;
+            /**
+             * @default constants.Z_FINISH
+             */
+            finishFlush: number;
+            /**
+             * @default 16*1024
+             */
+            chunkSize: number;
+            windowBits: number;
+            level: number; // compression only
+            memLevel: number; // compression only
+            strategy: number; // compression only
+            dictionary: Buffer | NodeJS.TypedArray | DataView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
+        }
+
+		interface WorkbookStreamWriterOptions extends WorkbookWriterOptions {
+
+            /**
+             * Specifies whether to add style information to the workbook.
+             * Styles can add some performance overhead. Default is false
+             */
+            zip: Partial<ArchiverZipOptions>;
+        }
+
 		class WorkbookWriter extends Workbook {
-			constructor(options: Partial<WorkbookWriterOptions>);
+			constructor(options: Partial<WorkbookStreamWriterOptions>);
 			// commit all worksheets, then add suplimentary files
 			commit(): Promise<void>;
 			addStyles(): Promise<void>;

--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -44,9 +44,11 @@ const WorkbookWriter = (module.exports = function(options) {
   this._worksheets = [];
   this.views = [];
 
+  this.zipOptions = options.zip;
+
   this.media = [];
 
-  this.zip = Archiver('zip');
+  this.zip = Archiver('zip', this.zipOptions);
   if (options.stream) {
     this.stream = options.stream;
   } else if (options.filename) {

--- a/spec/integration/workbook-xlsx-writer/workbook-xlsx-writer.spec.js
+++ b/spec/integration/workbook-xlsx-writer/workbook-xlsx-writer.spec.js
@@ -384,5 +384,30 @@ describe('WorkbookWriter', () => {
           testUtils.checkTestBook(wb2, 'xlsx', ['dataValidations']);
         });
     });
+
+    it('with zip compression option', () => {
+      const options = {
+        filename: TEST_XLSX_FILE_NAME,
+        useStyles: true,
+        zip: {
+          zlib: { level: 9 },// Sets the compression level.
+        },
+      };
+      const wb = testUtils.createTestBook(
+        new Excel.stream.xlsx.WorkbookWriter(options),
+        'xlsx',
+        ['dataValidations']
+      );
+
+      return wb
+        .commit()
+        .then(() => {
+          const wb2 = new Excel.Workbook();
+          return wb2.xlsx.readFile(TEST_XLSX_FILE_NAME);
+        })
+        .then(wb2 => {
+          testUtils.checkTestBook(wb2, 'xlsx', ['dataValidations']);
+        });
+    });
   });
 });

--- a/test/testWbStreamCompressionOptions.js
+++ b/test/testWbStreamCompressionOptions.js
@@ -1,0 +1,102 @@
+const Excel = require('../excel');
+const utils = require('../spec/utils/index');
+
+const filename = process.argv[2];
+console.log(filename);
+const optionsBestCompression = {
+  filename,
+  useStyles: true,
+  zip: {
+    zlib: { level: 9 },// Sets the compression level.
+  },
+};
+const wb = new Excel.stream.xlsx.WorkbookWriter(optionsBestCompression);
+const ws = wb.addWorksheet('blort');
+
+const style = {
+  font: utils.styles.fonts.comicSansUdB16,
+  alignment: utils.styles.alignments[1].alignment,
+};
+ws.columns = [
+  { header: 'A1', width: 10 },
+  { header: 'B1', width: 20, style },
+  { header: 'C1', width: 30 },
+];
+
+ws.getRow(2).font = utils.styles.fonts.broadwayRedOutline20;
+
+ws.getCell('A2').value = 'A2';
+ws.getCell('B2').value = 'B2';
+ws.getCell('C2').value = 'C2';
+ws.getCell('A3').value = 'A3';
+ws.getCell('B3').value = 'B3';
+ws.getCell('C3').value = 'C3';
+
+wb.commit().then(() => {
+  console.log('Done');
+  // var wb2 = new Excel.Workbook();
+  // return wb2.xlsx.readFile('./wb.test2.xlsx');
+});
+
+const filename2 = process.argv[3];
+console.log(filename2);
+const optionsBestSpeed = {
+  filename: filename2,
+  useStyles: true,
+  zip: {
+    zlib: { level: 1 },// Sets the compression level.
+  },
+};
+const wb2 = new Excel.stream.xlsx.WorkbookWriter(optionsBestSpeed);
+const ws2 = wb2.addWorksheet('blort');
+
+ws2.columns = [
+  { header: 'A1', width: 10 },
+  { header: 'B1', width: 20, style },
+  { header: 'C1', width: 30 },
+];
+
+ws2.getRow(2).font = utils.styles.fonts.broadwayRedOutline20;
+
+ws2.getCell('A2').value = 'A2';
+ws2.getCell('B2').value = 'B2';
+ws2.getCell('C2').value = 'C2';
+ws2.getCell('A3').value = 'A3';
+ws2.getCell('B3').value = 'B3';
+ws2.getCell('C3').value = 'C3';
+
+wb2.commit().then(() => {
+  console.log('Done');
+  // var wb2 = new Excel.Workbook();
+  // return wb2.xlsx.readFile('./wb.test2.xlsx');
+});
+
+const filename3 = process.argv[4];
+console.log(filename3);
+const options = {
+  filename: filename3,
+  useStyles: true,
+};
+const wb3 = new Excel.stream.xlsx.WorkbookWriter(options);
+const ws3 = wb3.addWorksheet('blort');
+
+ws3.columns = [
+  { header: 'A1', width: 10 },
+  { header: 'B1', width: 20, style },
+  { header: 'C1', width: 30 },
+];
+
+ws3.getRow(2).font = utils.styles.fonts.broadwayRedOutline20;
+
+ws3.getCell('A2').value = 'A2';
+ws3.getCell('B2').value = 'B2';
+ws3.getCell('C2').value = 'C2';
+ws3.getCell('A3').value = 'A3';
+ws3.getCell('B3').value = 'B3';
+ws3.getCell('C3').value = 'C3';
+
+wb3.commit().then(() => {
+  console.log('Done');
+  // var wb2 = new Excel.Workbook();
+  // return wb2.xlsx.readFile('./wb.test2.xlsx');
+});


### PR DESCRIPTION
Changes:
  - Added zip options for `WorkbookWriterOptions` based on `archiver` docs.
  - Added `testWbStreamCompressionOptions.js` test.
  - Added 'with zip compression option' integration test.
  - Updated `index.d.ts` with the new interfaces.

Note:
https://github.com/archiverjs/node-archiver allows setting the compression level of zip files. I added this option to `stream.xlsx.WorkbookWriter`

Resolves #888