### PR TITLE
added explicit return types to the type definitions of Worksheet.protect() and Worksheet.unprotect()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1151,8 +1151,8 @@ export interface Worksheet {
 	/**
 	 * Worksheet protection
 	 */
-	protect(password: string, options: Partial<WorksheetProtection>);
-	unprotect();
+	protect(password: string, options: Partial<WorksheetProtection>): Promise<void>;
+	unprotect(): void;
 }
 
 export interface WorksheetProperties {


### PR DESCRIPTION
This pull request attempts to resolve issue #925 (typescript definitions for Worksheet.protect() and Worksheet.unprotect() have no explicit return values).

I understand that the readme file asks for tests for any bug fixes, however, I couldn't find any tests in place dealing with the TypeScript definitions file.