### PR TITLE
Fix typing when Typescript is in strict mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1151,8 +1151,8 @@ export interface Worksheet {
 	/**
 	 * Worksheet protection
 	 */
-	protect(password: string, options: Partial<WorksheetProtection>);
-	unprotect();
+	protect(password: string, options: Partial<WorksheetProtection>): void;
+	unprotect(): void;
 }
 
 export interface WorksheetProperties {


### PR DESCRIPTION
ExcelJS 1.15.0 causes a type error on any project that depend on it and is in strict mode. Downgrading to 1.14.0 solves the issue.

```
node_modules/exceljs/index.d.ts(1154,2): error TS7010: 'protect', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/exceljs/index.d.ts(1155,2): error TS7010: 'unprotect', which lacks return-type annotation, implicitly has an 'any' return type.
```

This PR fixes the issue.