### PR TITLE
Add symlinks for modern export typings

### DIFF
--- a/modern.browser.d.ts
+++ b/modern.browser.d.ts
@@ -1,0 +1,1 @@
+index.d.ts

--- a/modern.nodejs.d.ts
+++ b/modern.nodejs.d.ts
@@ -1,0 +1,1 @@
+index.d.ts


### PR DESCRIPTION
This PR adds symlinks to `index.d.ts` for `modern.nodejs` and `modern.browser` exports. 

The motivation is to be able to use modern bundlers like webpack while still taking advantage of the TypeScript language server for IntelliSense, etc.