### PR TITLE
Modify code cause rich text to be lost

### DIFF
--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -335,9 +335,9 @@ class Cell {
   }
 
   set model(value) {
+    var v = value.value !== undefined ? value.value : value;
     this._value.release();
-    this._value = Value.create(value.type, this);
-    this._value.model = value;
+    this._value = Value.create(value.type, this, v);
 
     if (value.comment) {
       switch (value.comment.type) {
@@ -587,7 +587,8 @@ class HyperlinkValue {
         text: value ? value.text : undefined,
         hyperlink: value ? value.hyperlink : undefined,
       },
-      value && value.tooltip ? {tooltip: value.tooltip} : {}
+      value && value.tooltip ? {tooltip: value.tooltip} : {},
+      value && value.formula ? {formula: value.formula} : {}
     );
   }
 
@@ -607,7 +608,8 @@ class HyperlinkValue {
         text: value.text,
         hyperlink: value.hyperlink,
       },
-      value && value.tooltip ? {tooltip: value.tooltip} : {}
+      value && value.tooltip ? {tooltip: value.tooltip} : {},
+      value && value.formula ? {formula: value.formula} : {}
     );
   }
 


### PR DESCRIPTION
When value.type is Cell.Types.RichText, Value.create() creates a RichTextValue object with its model.type set to Cell.Types.String.
And then its model is set to the value passed in, whose type is Cell.Types.RichText.
In exceljs/lib/xlsx/xform/sheet/cell-xform.js, render() uses value.model.type instead of value.type to determine the type of a value.
It ignores the value with value.model.type of Cell.Types.RichText, causing rich text to be lost.