### PR TITLE
Add headerFooter to worksheet model when importing from file

### DIFF
--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -313,6 +313,7 @@ class WorkSheetXform extends BaseXform {
           properties,
           views: this.map.sheetViews.model,
           pageSetup,
+          headerFooter: this.map.headerFooter.model,
           background: this.map.picture.model,
           drawing: this.map.drawing.model,
           tables: this.map.tableParts.model,

--- a/spec/unit/xlsx/xform/sheet/data/sheet.1.3.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.1.3.json
@@ -74,5 +74,6 @@
   "mergeCells": null,
   "dataValidations": null,
   "drawing": null,
+  "headerFooter": null,
   "tables": null
 }

--- a/spec/unit/xlsx/xform/sheet/data/sheet.5.3.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.5.3.json
@@ -18,6 +18,7 @@
   "mergeCells": null,
   "dataValidations": null,
   "drawing": null,
+  "headerFooter": null,
   "cols": null,
   "hyperlinks": null,
   "views": null,

--- a/spec/unit/xlsx/xform/sheet/data/sheet.6.3.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.6.3.json
@@ -19,6 +19,7 @@
   "mergeCells": null,
   "dataValidations": null,
   "drawing": null,
+  "headerFooter": null,
   "cols": null,
   "hyperlinks": null,
   "views": null,


### PR DESCRIPTION
Fix #999 

I just added `headerFooter` to the model of `WorkSheetXform` in `#parseClose()`, in order that `Worksheet` object has `headerFooter` property read from existing xlsx file.

Even when `sheetX.xml` doesn't contain `<headerFooter>` node, `Worksheet` object still has `headerFooter` property with value `null`; I wonder whether this behavior is good.

Please let me know if anything is needed for this PR.