### PR TITLE
Drop grunt-lib-phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "grunt-contrib-jasmine": "^2.1.0",
     "grunt-contrib-uglify": "^4.0.1",
     "grunt-contrib-watch": "^1.1.0",
-    "grunt-lib-phantomjs": "^1.1.0",
     "husky": "^2.2.0",
     "lint-staged": "^8.1.5",
     "memorystream": "^0.3.1",


### PR DESCRIPTION
grunt-contrib-jasmine has used Headless Chromium since v2.0.0.

https://github.com/gruntjs/grunt-contrib-jasmine#release-history
> 2018-05-19 v2.0.0 Switch from PhantomJS to Chrome Headless via Puppeteer

Thus we don't need phantomjs.