### PR TITLE
     remove core-js/ import

### DIFF
--- a/lib/exceljs.browser.js
+++ b/lib/exceljs.browser.js
@@ -1,7 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies,node/no-unpublished-require */
-require('core-js/modules/es.promise');
-require('core-js/modules/es.object.assign');
-require('core-js/modules/es.object.keys');
 require('regenerator-runtime/runtime');
 
 const ExcelJS = {


### PR DESCRIPTION
This affects angular. Because core-js is imported inside the library , the Promise  polyfill is in conflict with  zone.js. Since Excel.js puts browsers compatibility on the hands of the devs. ([link](https://github.com/exceljs/exceljs#es5-imports)) , we can add it manually in a way that does not conflict with Angular.

this PR should fix : https://github.com/exceljs/exceljs/issues/1008

This was fixe din many other package and is referenced here:
 angular/zone.js#783