### PR TITLE
writeBuffer work again in browser when in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=8.3.0"
   },
   "main": "./lib/exceljs.nodejs.js",
-  "browser": "./dist/exceljs.min.js",
+  "browser": "./dist/exceljs.js",
   "types": "./index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
Fix browser path in package.json so workbook.xlsx.writeBuffer() work again in browser.

Should fix #1014 

**Problem:**
The [current package.json](https://github.com/exceljs/exceljs/blob/master/package.json#L19) points to `"browser": "./dist/exceljs.min.js",` but there is no such file in the distributed dist directory from version 3.4.0. 

<img width="226" alt="Screenshot 2019-11-27 at 10 13 05" src="https://user-images.githubusercontent.com/6098356/69709862-8823b300-10fe-11ea-9ea2-2eaeee17201f.png">

**Solution:**
I think this path should point to: `"browser": "./dist/exceljs.js",`

**other possible Solutions**
Build `exceljs.min.js` again

Why are you not building "./dist/exceljs.min.js" anymore?