### PR TITLE
Clarify merging cells by row/column numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,8 +811,9 @@ expect(worksheet.getCell('B5').style).not.toBe(worksheet.getCell('A4').style);
 expect(worksheet.getCell('B5').style.font).not.toBe(myFonts.arial);
 
 // merge by top-left, bottom-right
-worksheet.mergeCells('G10', 'H11');
-worksheet.mergeCells(10,11,12,13); // top,left,bottom,right
+worksheet.mergeCells('K10', 'M12');
+// merge by start row, start column, end row, end column
+worksheet.mergeCells(10,11,12,13);
 ```
 
 ## Defined Names


### PR DESCRIPTION
The previous examples for merging cells by row/column numbers were confusing and didn't actually describe what parameters the function was expecting. The example made it appear that `mergeCells(10, 11, 12, 13)` was the same as `mergeCells("G10", "H11")`, which is not the case. This example has been updated as well as another comment added.