### PR TITLE
Fix README mistakes concerning freezing views

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ var sheet = workbook.addWorksheet('My Sheet', {properties:{tabColor:{argb:'FFC00
 var sheet = workbook.addWorksheet('My Sheet', {properties: {showGridLines: false}});
 
 // create a sheet with the first row and column frozen
-var sheet = workbook.addWorksheet('My Sheet', {views:[{xSplit: 1, ySplit:1}]});
+var sheet = workbook.addWorksheet('My Sheet', {views:[{state: 'frozen', xSplit: 1, ySplit:1}]});
 ```
 
 ## Remove a Worksheet
@@ -482,7 +482,7 @@ worksheet.headerFooter.firstFooter = "Hello World"
 
 Worksheets now support a list of views, that control how Excel presents the sheet:
 
-* frozen - where a number of rows and columns to the top and left are frozen in place. Only the bottom left section will scroll
+* frozen - where a number of rows and columns to the top and left are frozen in place. Only the bottom right section will scroll
 * split - where the view is split into 4 sections, each semi-independently scrollable.
 
 Each view also supports various properties:


### PR DESCRIPTION
This PR fixes a couple of small inaccuracies in `README.md` concerning freezing views.

Just to explain one of the changes: In the "create a sheet with the first row and column frozen" code example, the code doesn't work as currently written. It needs the `state` property too.

Thanks for this excellent package!