### PR TITLE
fix typings for cell.note

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -436,7 +436,7 @@ export interface Cell extends Style, Address {
 	/**
 	 * comment of the cell
 	 */
-	comment: Comment;
+	note: Comment;
 
 	/**
 	 * convenience getter to access the formula

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exceljs",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Excel Workbook Manager - Read and Write xlsx and csv Files.",
   "private": false,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exceljs",
-  "version": "3.5.1",
+  "version": "3.5.0",
   "description": "Excel Workbook Manager - Read and Write xlsx and csv Files.",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
There were issue that cell comments are accessible by Cell.note property, but in index.d.ts were "comments" instead of "note". 