### PR TITLE
Fix problems caused by case of worksheet names

### DIFF
--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -51,7 +51,7 @@ class Workbook {
       console.warn(`Worksheet name ${name} exceeds 31 chars. This will be truncated`);
     }
     name = (name || `sheet${id}`).substring(0, 31);
-    if (this._worksheets.find(ws => ws && ws.name === name)) {
+    if (this._worksheets.find(ws => ws && ws.name.toLowerCase() === name.toLowerCase())) {
       throw new Error(`Worksheet name already exists: ${name}`);
     }
 

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -406,7 +406,7 @@ describe('Worksheet', () => {
       it('throws an error', () => {
         const wb = new ExcelJS.Workbook();
 
-        const validName = 'thisisaworksheetnameiuppercase';
+        const validName = 'thisisaworksheetnameinuppercase';
         const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
         const expectedError = `Worksheet name already exists: ${invalideName}`;
 

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -406,6 +406,18 @@ describe('Worksheet', () => {
       it('throws an error', () => {
         const wb = new ExcelJS.Workbook();
 
+        const validName = 'thisisaworksheetnameiuppercase';
+        const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
+        const expectedError = `Worksheet name already exists: ${invalideName}`;
+
+        wb.addWorksheet(validName);
+
+        expect(() => wb.addWorksheet(invalideName)).to.throw(expectedError);
+      });
+
+      it('throws an error', () => {
+        const wb = new ExcelJS.Workbook();
+
         const validName = 'ThisIsAWorksheetNameThatIsLonge';
         const invalideName = 'ThisIsAWorksheetNameThatIsLongerThan31';
         const expectedError = `Worksheet name already exists: ${validName}`;


### PR DESCRIPTION
### Changes

1.The sheet name of the excel file created in the windows system is not case sensitive. But the ```workbook.addWorksheet ()``` method does not do the corresponding processing, This PR fixes issues caused by case of sheet names.

2.fix for #1064 