### PR TITLE
Prevent from unhandled promise rejection durning workbook load

### DIFF
--- a/lib/utils/stream-buf.js
+++ b/lib/utils/stream-buf.js
@@ -233,9 +233,10 @@ utils.inherits(StreamBuf, Stream.Duplex, {
       chunk = new StringBufChunk(data);
     } else if (data instanceof Buffer) {
       chunk = new BufferChunk(data);
-    } else {
-      // assume string
+    } else if (typeof data === 'string' || data instanceof String) {
       chunk = new StringChunk(data, encoding);
+    } else {
+      throw new Error('Chunk must be one of type String, Buffer or StringBuf.');
     }
 
     // now, do something with the chunk

--- a/lib/utils/zip-stream.js
+++ b/lib/utils/zip-stream.js
@@ -65,14 +65,20 @@ class ZipReader extends events.EventEmitter {
 
   // ==========================================================================
   // Stream.Writable interface
-  write(data, encoding, callback) {
+  async write(data, encoding, callback) {
     if (this.error) {
       if (callback) {
         callback(this.error);
       }
       throw this.error;
     } else {
-      return this.stream.write(data, encoding, callback);
+      try {
+        const result = await this.stream.write(data, encoding, callback);
+        return result;
+     } catch (err) {
+       this.emit('error', err);
+       return err;
+     }
     }
   }
 

--- a/spec/integration/workbook/workbook.spec.js
+++ b/spec/integration/workbook/workbook.spec.js
@@ -765,6 +765,17 @@ describe('Workbook', () => {
         expect(success).to.equal(2);
       });
   });
+  it('throw an error for wrong data type', async () => {
+    const wb = new ExcelJS.Workbook();
+    try {
+      await wb.xlsx.load({});
+      expect.fail('should fail for given argument');
+    } catch(e) {
+      expect(e.message).to.equal(
+        'Chunk must be one of type String, Buffer or StringBuf.'
+      );
+    }
+  });
 
   describe('Sheet Views', () => {
     it('frozen panes', () => {

--- a/spec/unit/utils/stream-buf.spec.js
+++ b/spec/unit/utils/stream-buf.spec.js
@@ -48,4 +48,15 @@ describe('StreamBuf', () => {
       sb.on('error', reject);
       s.pipe(sb);
     }));
+  it('handle unsupported type of chunk', async () => {
+    const stream = new StreamBuf();
+    try {
+      await stream.write({});
+      expect.fail('should fail for given argument');
+    } catch (e) {
+      expect(e.message).to.equal(
+        'Chunk must be one of type String, Buffer or StringBuf.'
+      );
+    }
+  });
 });


### PR DESCRIPTION
Since https://github.com/exceljs/exceljs/pull/829 `StreamBuf.write` returns Promise, that leads to unhandled promise rejection in `Workbook.load` because `ZipStream.write`do not expect `StreamBuf.write` to return Promise. 