### PR TITLE
Export shared strings with RichText

### DIFF
--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -65,6 +65,7 @@ class CellXform extends BaseXform {
 
     switch (model.type) {
       case Enums.ValueType.String:
+      case Enums.ValueType.RichText:
         if (options.sharedStrings) {
           model.ssId = options.sharedStrings.add(model.value);
         }
@@ -225,6 +226,7 @@ class CellXform extends BaseXform {
         break;
 
       case Enums.ValueType.String:
+      case Enums.ValueType.RichText:
         if (model.ssId !== undefined) {
           xmlStream.addAttribute('t', 's');
           xmlStream.leafNode('v', null, model.ssId);

--- a/spec/unit/xlsx/xform/sheet/cell-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/cell-xform.spec.js
@@ -174,6 +174,55 @@ const expectations = [
     },
   },
   {
+    title: 'Shared String with RichText',
+    create() {
+      return new CellXform();
+    },
+    initialModel: {
+      address: 'A1',
+      type: Enums.ValueType.RichText,
+      value: {
+        richText: [
+          {font: {color: {argb: 'FF0000'}}, text: 'red'},
+          {font: {color: {argb: '00FF00'}}, text: 'green'},
+        ],
+      },
+    },
+    preparedModel: {
+      address: 'A1',
+      type: Enums.ValueType.RichText,
+      value: {
+        richText: [
+          {font: {color: {argb: 'FF0000'}}, text: 'red'},
+          {font: {color: {argb: '00FF00'}}, text: 'green'},
+        ],
+      },
+      ssId: 0,
+    },
+    xml: '<c r="A1" t="s"><v>0</v></c>',
+    parsedModel: {
+      address: 'A1',
+      type: Enums.ValueType.String,
+      value: 0,
+    },
+    reconciledModel: {
+      address: 'A1',
+      type: Enums.ValueType.RichText,
+      value: {
+        richText: [
+          {font: {color: {argb: 'FF0000'}}, text: 'red'},
+          {font: {color: {argb: '00FF00'}}, text: 'green'},
+        ],
+      },
+    },
+    tests: ['prepare', 'render', 'renderIn', 'parse', 'reconcile'],
+    options: {
+      sharedStrings: new SharedStringsXform(),
+      hyperlinkMap: fakeHyperlinkMap,
+      styles: fakeStyles,
+    },
+  },
+  {
     title: 'Date',
     create() {
       return new CellXform();


### PR DESCRIPTION
This PR is intended to fix https://github.com/exceljs/exceljs/issues/633.

When an Excel file is read, a shared string with rich text (`<r>`) nodes inside is correctly parsed and reconciled into a `CellXform` object like below.
```js
{
  model: {
    value: { richText: [ ... ] },
    type: Enums.ValueType.RichText,
  },
}
```
However, `XLSX#writeFile()` converts this object into an empty cell in the exported Excel file, because `CellXform#prepare()` and `#render()` do nothing when `model.type === Enums.ValueType.RichText`.

To fix this, the both methods now handle `RichText` in the same way as `String`.