### PR TITLE
Typo: Replace 'allways' with 'always'

### DIFF
--- a/lib/xlsx/xform/base-xform.js
+++ b/lib/xlsx/xform/base-xform.js
@@ -124,32 +124,32 @@ class BaseXform {
 
   // ============================================================
   // Useful Utilities
-  static toAttribute(value, dflt, allways = false) {
+  static toAttribute(value, dflt, always = false) {
     if (value === undefined) {
-      if (allways) {
+      if (always) {
         return dflt;
       }
-    } else if (allways || (value !== dflt)) {
+    } else if (always || (value !== dflt)) {
       return value.toString();
     }
     return undefined;
   }
 
 
-  static toStringAttribute(value, dflt, allways = false) {
-    return BaseXform.toAttribute(value, dflt, allways);
+  static toStringAttribute(value, dflt, always = false) {
+    return BaseXform.toAttribute(value, dflt, always);
   }
 
   static toStringValue(attr, dflt) {
     return (attr === undefined) ? dflt : attr;
   }
 
-  static toBoolAttribute(value, dflt, allways = false) {
+  static toBoolAttribute(value, dflt, always = false) {
     if (value === undefined) {
-      if (allways) {
+      if (always) {
         return dflt;
       }
-    } else if (allways || (value !== dflt)) {
+    } else if (always || (value !== dflt)) {
       return value ? '1' : '0';
     }
     return undefined;
@@ -159,16 +159,16 @@ class BaseXform {
     return (attr === undefined) ? dflt : (attr === '1');
   }
 
-  static toIntAttribute(value, dflt, allways = false) {
-    return BaseXform.toAttribute(value, dflt, allways);
+  static toIntAttribute(value, dflt, always = false) {
+    return BaseXform.toAttribute(value, dflt, always);
   }
 
   static toIntValue(attr, dflt) {
     return (attr === undefined) ? dflt : parseInt(attr, 10);
   }
 
-  static toFloatAttribute(value, dflt, allways = false) {
-    return BaseXform.toAttribute(value, dflt, allways);
+  static toFloatAttribute(value, dflt, always = false) {
+    return BaseXform.toAttribute(value, dflt, always);
   }
 
   static toFloatValue(attr, dflt) {


### PR DESCRIPTION
Just a typo I came across - we could also use a totally different variable name, if someone has a better suggestion