### PR TITLE
Replace uglify with terser

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -3,7 +3,7 @@
 module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-babel');
   grunt.loadNpmTasks('grunt-browserify');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-terser');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-contrib-copy');
 
@@ -46,9 +46,11 @@ module.exports = function(grunt) {
         dest: './build/web/exceljs.spec.js',
       },
     },
-    uglify: {
+    terser: {
       options: {
-        banner: '/*! ExcelJS <%= grunt.template.today("dd-mm-yyyy") %> */\n',
+        output: {
+          preamble: '/*! ExcelJS <%= grunt.template.today("dd-mm-yyyy") %> */\n',
+        },
       },
       dist: {
         files: {
@@ -92,6 +94,6 @@ module.exports = function(grunt) {
     },
   });
 
-  grunt.registerTask('build', ['babel', 'browserify', 'uglify', 'copy']);
-  grunt.registerTask('ug', ['uglify']);
+  grunt.registerTask('build', ['babel', 'browserify', 'terser', 'copy']);
+  grunt.registerTask('ug', ['terser']);
 };

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "grunt-browserify": "^5.3.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jasmine": "^2.1.0",
-    "grunt-contrib-uglify": "^4.0.1",
+    "grunt-terser": "^1.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "husky": "^2.2.0",
     "lint-staged": "^8.1.5",
@@ -137,7 +137,6 @@
     "request": "^2.88.0",
     "semver": "^5.6.0",
     "ts-node": "^8.6.2",
-    "typescript": "^3.7.5",
-    "uglify-js": "^3.4.9"
+    "typescript": "^3.7.5"
   }
 }


### PR DESCRIPTION
Uglify can not handle ES6+, such as `const` and `let`. Some npm dependencies, like `saxes`, can not be used without replacing uglify with the more modern terser because they publish modern JS.