### PR TITLE
Add PR, Feature Request and Question github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: 🐛 Bug report
 about: Create a report to help us improve
-title: "[BUG] XYZ"
-labels: bug
+title: '[BUG] XYZ'
+labels: ':bug: Bug'
 ---
 
 ## 🐛 Bug Report

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,18 @@
+---
+name: 🚀 Feature Proposal
+title: '[F] XYZ'
+labels: ':rocket: Feature Request'
+about: Submit a proposal for a new feature
+---
+
+## 🚀 Feature Proposal
+
+A clear and concise description of what the feature is.
+
+## Motivation
+
+Please outline the motivation for the proposal.
+
+## Example
+
+Please provide an example for how this feature would be used.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: 💬 Questions / Help
+title: '[Q] XYZ'
+label: ':speech_balloon: Question'
+about: If you have questions, please check our Discord or StackOverflow
+---
+
+## 💬 Questions and Help
+
+...

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,9 +2,11 @@
 name: 💬 Questions / Help
 title: '[Q] XYZ'
 label: ':speech_balloon: Question'
-about: If you have questions, please check our Discord or StackOverflow
+about: Ask us a question
 ---
 
 ## 💬 Questions and Help
 
-...
+Have a question about exceljs? Need help using it a certain way that our README does not seem to explain? Ask away!
+
+Please keep in mind that we're unpaid open souce volunteers, so it will help us greatly if you add as many details as possible to your question and describe what other approaches you've tried out so far. And of course, we'd love for you to contribute back the answer to our README via a pull request!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
+
+## Summary
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+
+## Test plan
+
+<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


### PR DESCRIPTION
Building on https://github.com/exceljs/exceljs/pull/1112, here are my suggestions for the PR, Feature Request and Question github templates.

Again, they are heavily inspired by https://github.com/facebook/jest/tree/master/.github - but there's one big difference: They don't want the github issue tracker to be used for questions, which are instead handled via discord, stackoverflow, etc. What is our stance here? 

We could encourage users to open issues to ask questions but warn them that they might not get answered (but then where should they go). Or we could ask them to use this only for clear bug reports or feature requests and direct them elsewhere (but where). What do you think?