### PR TITLE
fix issue #749 Fix internal link example errors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2271,7 +2271,7 @@ worksheet.getCell('A1').value = {
 };
 
 // internal link
-worksheet.getCell('A1').value = { text: 'Sheet2', hyperlink: '#\\"Sheet2\\"!A1' };
+worksheet.getCell('A1').value = { text: 'Sheet2', hyperlink: '#\'Sheet2\'!A1' };
 ```
 
 ## Formula Value

--- a/README_zh.md
+++ b/README_zh.md
@@ -1726,7 +1726,7 @@ worksheet.getCell('A1').value = {
 };
 
 // internal link
-worksheet.getCell('A1').value = { text: 'Sheet2', hyperlink: '#\\"Sheet2\\"!A1' };
+worksheet.getCell('A1').value = { text: 'Sheet2', hyperlink: '#\'Sheet2\'!A1' };
 ```
 
 ## <a id="formula-value">公式值</a>


### PR DESCRIPTION

### Changes
``hyperlink`` should be set like this:
```javascript
// internal link
worksheet.getCell('A1').value = { text: 'Sheet2', hyperlink: '#\'Sheet2\'!A1' };
```