### PR TITLE
fix issue #731 image extensions not be case sensitive

### DIFF
--- a/lib/xlsx/xform/drawing/base-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/base-cell-anchor-xform.js
@@ -34,7 +34,7 @@ class BaseCellAnchorXform extends BaseXform {
   reconcilePicture(model, options) {
     if (model && model.rId) {
       const rel = options.rels[model.rId];
-      const match = rel.Target.match(/.*\/media\/(.+[.][a-z]{3,4})/);
+      const match = rel.Target.match(/.*\/media\/(.+[.][a-zA-Z]{3,4})/);
       if (match) {
         const name = match[1];
         const mediaId = options.mediaIndex[name];

--- a/spec/integration/workbook/images.spec.js
+++ b/spec/integration/workbook/images.spec.js
@@ -231,5 +231,63 @@ describe('Workbook', () => {
           expect(Buffer.compare(imageData, image.buffer)).to.equal(0);
         });
     });
+
+    it('image extensions should not be case sensitive', () => {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('blort');
+      let wb2;
+      let ws2;
+
+      const imageId1 = wb.addImage({
+        filename: IMAGE_FILENAME,
+        extension: 'PNG',
+      });
+
+      const imageId2 = wb.addImage({
+        filename: IMAGE_FILENAME,
+        extension: 'JPEG',
+      });
+
+      ws.addImage(imageId1, {
+        tl: {col: 0.1125, row: 0.4},
+        ext: {width: 100, height: 100},
+      });
+
+      ws.addImage(imageId2, {
+        tl: {col: 0.1125, row: 0.4},
+        br: {col: 2.101046875, row: 3.4},
+        editAs: 'oneCell',
+      });
+
+      return wb.xlsx
+        .writeFile(TEST_XLSX_FILE_NAME)
+        .then(() => {
+          wb2 = new ExcelJS.Workbook();
+          return wb2.xlsx.readFile(TEST_XLSX_FILE_NAME);
+        })
+        .then(() => {
+          ws2 = wb2.getWorksheet('blort');
+          expect(ws2).to.not.be.undefined();
+
+          return fsReadFileAsync(IMAGE_FILENAME);
+        })
+        .then(imageData => {
+          const images = ws2.getImages();
+          expect(images.length).to.equal(2);
+
+          const imageDesc1 = images[0];
+          expect(imageDesc1.range.ext.width).to.equal(100);
+          expect(imageDesc1.range.ext.height).to.equal(100);
+          const image1 = wb2.getImage(imageDesc1.imageId);
+
+          const imageDesc2 = images[1];
+          expect(imageDesc2.range.editAs).to.equal('oneCell');
+
+          const image2 = wb2.getImage(imageDesc1.imageId);
+
+          expect(Buffer.compare(imageData, image1.buffer)).to.equal(0);
+          expect(Buffer.compare(imageData, image2.buffer)).to.equal(0);
+        });
+    });
   });
 });


### PR DESCRIPTION
## Changes

* fix for issue #731 
* The cause of this issue #731 is that the suffix of the picture is uppercase letters,which causes the regular match to fail. The drawing1.xml file is not generated when the xlsx file is rewritten, so I personally think that the suffix name should not be case sensitive.