### PR TITLE
Include cell address for Shared Formula master must exist.. error

### DIFF
--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -107,7 +107,7 @@ class CellXform extends BaseXform {
         } else if (model.sharedFormula) {
           const master = options.formulae[model.sharedFormula];
           if (!master) {
-            throw new Error('Shared Formula master must exist above and or left of clone');
+            throw new Error(`Shared Formula master must exist above and or left of clone for cell ${model.address}`);
           }
           if (master.si === undefined) {
             master.shareType = 'shared';


### PR DESCRIPTION
## Summary
I kept getting the following error while deleting rows from a sheet: `Shared Formula master must exist above and or left of clone`.
I needed to know what cell it was complaining about, so I have changed it to: `Shared Formula master must exist above and or left of clone for cell <cell address>`

## Test plan
It's just a change in text in the error so not sure if it needs a test?

![image](https://user-images.githubusercontent.com/627654/76521190-3825ed80-645c-11ea-908c-191ec3572377.png)
