### PR TITLE
Allow user specified iteration count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1860,7 +1860,9 @@ to modify individual cell protection.
 
 **Note:** While the protect() function returns a Promise indicating
 that it is async, the current implementation runs on the main
-thread and will use approx 600ms on an average CPU.
+thread and will use approx 600ms on an average CPU. This can be adjusted
+by setting the spinCount, which can be used to make the process either
+faster or more resilient.
 
 ### Sheet Protection Options
 
@@ -1879,6 +1881,7 @@ thread and will use approx 600ms on an average CPU.
 | sort                | false   | Lets the user sort data |
 | autoFilter          | false   | Lets the user filter data in tables |
 | pivotTables         | false   | Lets the user use pivot tables |
+| spinCount           | 100000  | The number of hash iterations performed when protecting or unprotecting |
 
 
 

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -637,6 +637,9 @@ class Worksheet {
       }
       if (options) {
         this.sheetProtection = Object.assign(this.sheetProtection, options);
+        if (!password && 'spinCount' in options) {
+          delete this.sheetProtection.spinCount;
+        }
       }
       resolve();
     });

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -629,6 +629,10 @@ class Worksheet {
       this.sheetProtection = {
         sheet: true,
       };
+      if (options && 'spinCount' in options) {
+        // force spinCount to be integer >= 0
+        options.spinCount = isFinite(options.spinCount) ? Math.round(Math.max(0, options.spinCount)) : 100000;
+      }
       if (password) {
         this.sheetProtection.algorithmName = 'SHA-512';
         this.sheetProtection.saltValue = Encryptor.randomBytes(16).toString('base64');

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -632,7 +632,7 @@ class Worksheet {
       if (password) {
         this.sheetProtection.algorithmName = 'SHA-512';
         this.sheetProtection.saltValue = Encryptor.randomBytes(16).toString('base64');
-        this.sheetProtection.spinCount = 100000;
+        this.sheetProtection.spinCount = options && 'spinCount' in options ? options.spinCount : 100000; // allow user specified spinCount
         this.sheetProtection.hashValue = Encryptor.convertPasswordToHash(password, 'SHA512', this.sheetProtection.saltValue, this.sheetProtection.spinCount);
       }
       if (options) {

--- a/test/test-protection-spinCount.js
+++ b/test/test-protection-spinCount.js
@@ -16,6 +16,13 @@ async function save() {
 
   await wb.xlsx.writeFile(`${0}-${filename}`);
 
+  // options defined but spinCount not
+  stopwatch.start();
+  await ws.protect(password, {insertRows: true}); // default 100000
+  console.log('Protection Time [spinCount default]:', stopwatch.microseconds);
+
+  await wb.xlsx.writeFile(`${1}-${filename}`);
+
   const values = [
     100000,
     10000,
@@ -30,8 +37,8 @@ async function save() {
     31415.9265,
   ];
 
-  for (let index = 1; index <= values.length; index += 1) {
-    const value = values[index - 1];
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
 
     stopwatch.start();
     await ws.protect(password, {spinCount: value});
@@ -40,7 +47,7 @@ async function save() {
       stopwatch.microseconds
     );
 
-    await wb.xlsx.writeFile(`${index}-${filename}`);
+    await wb.xlsx.writeFile(`${index + 2}-${filename}`);
   }
 }
 

--- a/test/test-protection-spinCount.js
+++ b/test/test-protection-spinCount.js
@@ -1,0 +1,49 @@
+const Excel = require('../lib/exceljs.nodejs.js');
+const HrStopwatch = require('./utils/hr-stopwatch');
+
+const [, , filename, password] = process.argv;
+
+const wb = new Excel.Workbook();
+const ws = wb.addWorksheet('Foo');
+ws.getCell('A1').value = 'Bar';
+
+async function save() {
+  const stopwatch = new HrStopwatch();
+
+  stopwatch.start();
+  await ws.protect(password); // default 100000
+  console.log('Protection Time [spinCount default]:', stopwatch.microseconds);
+
+  await wb.xlsx.writeFile(`${0}-${filename}`);
+
+  const values = [
+    100000,
+    10000,
+    1,
+    0,
+    -1,
+    undefined,
+    null,
+    NaN,
+    Infinity,
+    -Infinity,
+    31415.9265,
+  ];
+
+  for (let index = 1; index <= values.length; index += 1) {
+    const value = values[index - 1];
+
+    stopwatch.start();
+    await ws.protect(password, {spinCount: value});
+    console.log(
+      `Protection Time [spinCount ${value}]:`,
+      stopwatch.microseconds
+    );
+
+    await wb.xlsx.writeFile(`${index}-${filename}`);
+  }
+}
+
+save().catch(error => {
+  console.log(error.message);
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The iteration count controls how many times the hash is applied. It is a mechanism for fine-tuning according to how much computation is desired. This is especially useful to future-proof against increasingly powerful computers (you can simply increase the iteration count). It is therefore natural to expose this as a setting to the developer.

In my use case, I use this library for generating web application downloads, and protecting each worksheet in the workbook caused a download delay of several seconds. I would like to be able to lower the iteration count.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
const time1 = new Date();
await sheet.protect("password");
const time2 = new Date();
await sheet.protect("password", { spinCount: 1000 });
const time3 = new Date();

console.log(`Delta 1: ${time2 - time1}`); // < 1 second
console.log(`Delta 2: ${time3 - time2}`); // ~0 seconds
```

I have created a test script which generates excel documents for various `spinCount` values, and have confirmed that excel opens them all, that the sheet is protected, and that I am able to unprotect with the correct password. And while I can't time how long it took excel to unlock (or fail to unlock), the time seemed to be roughly equal to the protection time.