### PR TITLE
Re-translation of simplified Chinese documents (zh-cn)

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -4,9 +4,9 @@
 [![Code Quality: Javascript](https://img.shields.io/lgtm/grade/javascript/g/exceljs/exceljs.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/exceljs/exceljs/context:javascript)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/exceljs/exceljs.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/exceljs/exceljs/alerts)
 
-读取，操作和编写电子表格数据和样式到XLSX和JSON。
+读取，操作并写入电子表格数据和样式到 XLSX 和 JSON 文件。
 
-从Excel电子表格文件逆向工程设计的项目。
+一个 Excel 电子表格文件逆向工程项目。
 
 # 安装
 
@@ -14,152 +14,235 @@
 npm install exceljs
 ```
 
-# 新功能！
+# 新的功能!
 
 <ul>
   <li>
-    合并的 <a href="https://github.com/exceljs/exceljs/pull/834">添加中文文档 #834</a>.
-    非常感谢 <a href="https://github.com/loverto">flydragon</a> 为此贡献。
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1140">优化 SAXStream #1140</a>.
+    非常感谢 <a href="https://github.com/alubbe">Andreas Lubbe</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1143">修复问题 #1057 使用  Streaming XLSX Writer 时 `addConditionalFormatting` 不是方法的错误 #1143</a>.
+    非常感谢 <a href="https://github.com/Alanscut">Alan Wang</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1160">修复问题 #204 设置默认列宽 #1160</a>.
+    非常感谢 <a href="https://github.com/Alanscut">Alan Wang</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1164">共享公式主单元格的包含单元格地址必须存在。 #1164</a>.
+    非常感谢 <a href="https://github.com/noisyscanner">Brad Reed</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1166">数据验证示例中的错字 #1166</a>.
+    非常感谢 <a href="https://github.com/mravey">Matthieu Ravey</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1176">修复 #1175 #1176</a>.
+    非常感谢 <a href="https://github.com/Siemienik">Siemienik Paweł</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1179">修复问题 #1178 和更新 index.d.ts #1179</a>.
+    非常感谢 <a href="https://github.com/Alanscut">Alan Wang</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1182">简单测试 typescript 是否能够编译 #1182</a>.
+    非常感谢 <a href="https://github.com/Siemienik">Siemienik Paweł</a> 对此的贡献。
+  </li>
+  <li>
+    合并 <a href="https://github.com/exceljs/exceljs/pull/1190">更多改进 #1190</a>.
+    非常感谢 <a href="https://github.com/alubbe">Andreas Lubbe</a> 对此的贡献。
   </li>
 </ul>
 
+
+
 # 贡献
 
-非常欢迎贡献！它帮助我了解所需的功能或哪些错误导致最大的痛点。
+欢迎贡献！这可以帮助我了解大家需要一些什么功能，或者哪些 bugs 造成了极大的麻烦。
 
-我只有一个请求;如果您提交了错误修正的拉取请求，请在spec文件夹中添加捕获问题的单元测试或集成测试。
-即使只有失败测试的公关也很好 - 我可以分析测试的内容并从中修复代码。
+我只有一个请求；如果您提交对错误修复的请求（PR），请添加一个能够解决问题的单元测试或集成测试（在 *spec* 文件夹中）。
+即使只是测试失败的请求（PR）也可以 - 我可以分析测试的过程并以此修复代码。
 
-需要明确的是，添加到此库中的所有贡献都将包含在库的MIT许可证中。
+注意：请尽可能避免在请求（PR）中修改软件包版本。
+版本一般在发布时会进行更新，任何版本更改很可能导致合并冲突。
 
-# 待完善列表
-
-<ul>
-  <li>ESLint  - 慢慢开启（合理的）规则，我希望这些规则应该有助于提高贡献。</li>
-  <li>条件格式。</li>
-  <li>还有更多的打印设置要添加;固定行/列等</li>
-  <li>XLSX流式读。</li>
-  <li>用标题解析CSV</li>
-</ul>
+明确地说，添加到该库的所有贡献都将包含在该库的 MIT 许可证中。
 
 # 目录
 
 <ul>
-  <li><a href="#importing">导入</a></li>
+  <li><a href="#导入">导入</a></li>
   <li>
-    <a href="#interface">接口</a>
+    <a href="#接口">接口</a>
     <ul>
-      <li><a href="#create-a-workbook">创建工作簿</a></li>
-      <li><a href="#set-workbook-properties">设置工作簿属性</a></li>
-      <li><a href="#workbook-views">工作簿视图</a></li>
-      <li><a href="#add-a-worksheet">添加工作表</a></li>
-      <li><a href="#remove-a-worksheet">删除工作表</a></li>
-      <li><a href="#access-worksheets">访问工作表</a></li>
-      <li><a href="#worksheet-state">工作表状态</a></li>
-      <li><a href="#worksheet-properties">工作表属性</a></li>
-      <li><a href="#page-setup">页面设置</a></li>
-      <li><a href="#header-footer">页眉和页脚</a></li>
+      <li><a href="#创建工作簿">创建工作簿</a></li>
+      <li><a href="#设置工作簿属性">设置工作簿属性</a></li>
+      <li><a href="#工作簿视图">工作簿视图</a></li>
+      <li><a href="#添加工作表">添加工作表</a></li>
+      <li><a href="#删除工作表">删除工作表</a></li>
+      <li><a href="#访问工作表">访问工作表</a></li>
+      <li><a href="#工作表状态">工作表状态</a></li>
+      <li><a href="#工作表属性">工作表属性</a></li>
+      <li><a href="#页面设置">页面设置</a></li>
+      <li><a href="#页眉和页脚">页眉和页脚</a></li>
       <li>
-        <a href="#worksheet-views">工作表视图</a>
+        <a href="#工作表视图">工作表视图</a>
         <ul>
-          <li><a href="#frozen-views">冻结视图</a></li>
-          <li><a href="#split-views">拆分视图</a></li>
+          <li><a href="#冻结视图">冻结视图</a></li>
+          <li><a href="#拆分视图">拆分视图</a></li>
         </ul>
       </li>
-      <li><a href="#auto-filters">自动过滤器</a></li>
-      <li><a href="#columns">列</a></li>
-      <li><a href="#rows">行</a></li>
-      <li><a href="#handling-individual-cells">处理单个单元格</a></li>
-      <li><a href="#merged-cells">合并单元格</a></li>
-      <li><a href="#defined-names">定义名称</a></li>
-      <li><a href="#data-validations">数据验证</a></li>
-      <li><a href="#styles">样式</a>
+      <li><a href="#自动筛选器">自动筛选器</a></li>
+      <li><a href="#列">列</a></li>
+      <li><a href="#行">行</a></li>
+      <li><a href="#处理单个单元格">处理单个单元格</a></li>
+      <li><a href="#合并单元格">合并单元格</a></li>
+      <li><a href="#重复行">重复行</a></li>
+      <li><a href="#定义名称">定义名称</a></li>
+      <li><a href="#数据验证">数据验证</a></li>
+      <li><a href="#单元格注释">单元格注释</a></li>
+      <li><a href="#表格">表格</a></li>
+      <li><a href="#样式">样式</a>
         <ul>
-          <li><a href="#number-formats">数字格式</a></li>
-          <li><a href="#fonts">字体</a></li>
-          <li><a href="#alignment">对齐方式</a></li>
-          <li><a href="#borders">边框</a></li>
-          <li><a href="#fills">填充</a></li>
-          <li><a href="#rich-text">富文本</a></li>
+          <li><a href="#数字格式">数字格式</a></li>
+          <li><a href="#字体">字体</a></li>
+          <li><a href="#对齐">对齐</a></li>
+          <li><a href="#边框">边框</a></li>
+          <li><a href="#填充">填充</a></li>
+          <li><a href="#富文本">富文本</a></li>
         </ul>
       </li>
-      <li><a href="#outline-levels">大纲级别</a></li>
-      <li><a href="#images">图片</a></li>
-      <li><a href="#file-io">文件 I/O</a>
+      <li><a href="#条件格式化">条件格式化</a></li>
+      <li><a href="#大纲级别">大纲级别</a></li>
+      <li><a href="#图片">图片</a></li>
+      <li><a href="#工作表保护">工作表保护</a></li>
+      <li><a href="#文件-io">文件 I/O</a>
         <ul>
           <li><a href="#xlsx">XLSX</a>
             <ul>
-              <li><a href="#reading-xlsx">读 XLSX</a></li>
-              <li><a href="#writing-xlsx">写 XLSX</a></li>
+              <li><a href="#读-xlsx">读 XLSX</a></li>
+              <li><a href="#写-xlsx">写 XLSX</a></li>
             </ul>
           </li>
           <li><a href="#csv">CSV</a>
             <ul>
-              <li><a href="#reading-csv">读 CSV</a></li>
-              <li><a href="#writing-csv">写 CSV</a></li>
+              <li><a href="#读-csv">读 CSV</a></li>
+              <li><a href="#写-csv">写 CSV</a></li>
             </ul>
           </li>
-          <li><a href="#streaming-io">流 I/O</a>
+          <li><a href="#流式-io">流式 I/O</a>
             <ul>
-              <li><a href="#streaming-xlsx">流 XLSX</a></li>
+              <li><a href="#流式-xlsx">流式 XLSX</a></li>
             </ul>
           </li>
         </ul>
       </li>
     </ul>
   </li>
-  <li><a href="#browser">浏览器</a></li>
+  <li><a href="#浏览器">浏览器</a></li>
   <li>
-    <a href="#value-types">值类型</a>
+    <a href="#值类型">值类型</a>
     <ul>
-      <li><a href="#null-value">空值</a></li>
-      <li><a href="#merge-cell">合并单元格</a></li>
-      <li><a href="#number-value">数值</a></li>
-      <li><a href="#string-value">字符串值</a></li>
-      <li><a href="#date-value">日期值</a></li>
-      <li><a href="#hyperlink-value">超链接值</a></li>
+      <li><a href="#null-值">Null 值</a></li>
+      <li><a href="#合并单元格">合并单元格</a></li>
+      <li><a href="#数字值">数字值</a></li>
+      <li><a href="#字符串值">字符串值</a></li>
+      <li><a href="#日期值">日期值</a></li>
+      <li><a href="#超链接值">超链接值</a></li>
       <li>
-        <a href="#formula-value">公式值</a>
+        <a href="#公式值">公式值</a>
         <ul>
-          <li><a href="#shared-formula">共享公式</a></li>
-          <li><a href="#formula-type">公式类型</a></li>
+          <li><a href="#共享公式">共享公式</a></li>
+          <li><a href="#公式类型">公式类型</a></li>
+          <li><a href="#数组公式">数组公式</a></li>
         </ul>
       </li>
-      <li><a href="#rich-text-value">富文本值</a></li>
-      <li><a href="#boolean-value">布尔值</a></li>
-      <li><a href="#error-value">错误值</a></li>
+      <li><a href="#富文本值">富文本值</a></li>
+      <li><a href="#布尔值">布尔值</a></li>
+      <li><a href="#错误值">错误值</a></li>
     </ul>
   </li>
-  <li><a href="#config">配置</a></li>
-  <li><a href="#known-issues">已知的问题</a></li>
-  <li><a href="#release-history">发布历史</a></li>
+  <li><a href="#配置">配置</a></li>
+  <li><a href="#已知的问题">已知的问题</a></li>
+  <li><a href="#发布历史">发布历史</a></li>
 </ul>
 
-## <a id="importing">导入</a>
 
-默认导出是带有 Promise polyfill 转换的 ES5 版本 - 因为这会提供最高的兼容性。
 
-```javascript
-var Excel = require('exceljs');
-import Excel from 'exceljs';
-```
-
-但是，如果您在现代node.js版本（>=8）上使用此库，或者在使用bundler的前端（或者只关注常绿浏览器）上使用此库，我们建议使用这些导入：
+# 导入
 
 ```javascript
-const Excel = require('exceljs/modern.nodejs');
-import Excel from 'exceljs/modern.browser';
+const ExcelJS = require('exceljs');
 ```
 
-# <a id="interface">接口</a>
+## ES5 导入
 
-## <a id="create-a-workbook">创建工作簿</a>
+要使用 ES5 编译代码，请使用 *dist/es5* 路径。
+
+```javascript
+const ExcelJS = require('exceljs/dist/es5');
+```
+
+**注意：**ES5 版本对许多 polyfill 都具有隐式依赖，而 exceljs 不再明确添加。
+您需要在依赖项中添加 `core-js` 和 `regenerator-runtime`，并在导入 `exceljs` 之前在代码中包含以下引用：
+
+```javascript
+// exceljs 所需的 polyfills
+require('core-js/modules/es.promise');
+require('core-js/modules/es.object.assign');
+require('core-js/modules/es.object.keys');
+require('regenerator-runtime/runtime');
+
+const ExcelJS = require('exceljs/dist/es5');
+```
+
+对于 IE 11，您还需要一个 polyfill 以支持 unicode regex 模式。 例如，
+
+```js
+const rewritePattern = require('regexpu-core');
+const {generateRegexpuOptions} = require('@babel/helper-create-regexp-features-plugin/lib/util');
+
+const {RegExp} = global;
+try {
+  new RegExp('a', 'u');
+} catch (err) {
+  global.RegExp = function(pattern, flags) {
+    if (flags && flags.includes('u')) {
+      return new RegExp(rewritePattern(pattern, flags, generateRegexpuOptions({flags, pattern})));
+    }
+    return new RegExp(pattern, flags);
+  };
+  global.RegExp.prototype = RegExp;
+}
+```
+
+## 浏览器端
+
+ExcelJS 在 *dist/* 文件夹内发布了两个支持浏览器的包：
+
+一个是隐式依赖 `core-js` polyfills 的...
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.js"></script>
+<script src="exceljs.js"></script>
+```
+
+另一个则没有...
+```html
+<script src="--your-project's-pollyfills-here--"></script>
+<script src="exceljs.bare.js"></script>
+```
+
+
+# 接口
+
+## 创建工作簿
 
 ```javascript
 var workbook = new Excel.Workbook();
 ```
 
-## <a id="set-workbook-properties">设置工作簿属性</a>
+## 设置工作簿属性
 
 ```javascript
 workbook.creator = 'Me';
@@ -170,13 +253,20 @@ workbook.lastPrinted = new Date(2016, 9, 27);
 ```
 
 ```javascript
-// 将工作簿日期设置为1904日期系统
+// 将工作簿日期设置为 1904 年日期系统
 workbook.properties.date1904 = true;
 ```
 
-## <a id="workbook-views">工作簿视图</a>
+## 设置计算属性
 
-“工作簿”视图控制Excel在查看工作簿时打开多少个单独的窗口。
+```javascript
+// 在加载时强制工作簿计算属性
+workbook.calcProperties.fullCalcOnLoad = true;
+```
+
+## 工作簿视图
+
+工作簿视图控制在查看工作簿时 Excel 将打开多少个单独的窗口。
 
 ```javascript
 workbook.views = [
@@ -187,124 +277,124 @@ workbook.views = [
 ]
 ```
 
-## <a id="add-a-worksheet">添加工作表</a>
+## 添加工作表
 
 ```javascript
 var sheet = workbook.addWorksheet('My Sheet');
 ```
 
-用addWorksheet函数的第二个参数设置工作表的选项。
+使用 `addWorksheet` 函数的第二个参数来指定工作表的选项。
 
-例如
+示例：
 
 ```javascript
-// 创建一个红色标签颜色的工作表
+// 创建带有红色标签颜色的工作表
 var sheet = workbook.addWorksheet('My Sheet', {properties:{tabColor:{argb:'FFC0000'}}});
 
-// 创建一个隐藏网格线的工作表
+// 创建一个隐藏了网格线的工作表
 var sheet = workbook.addWorksheet('My Sheet', {views: [{showGridLines: false}]});
 
-// 创建一个第一行和列冻结的工作表
-var sheet = workbook.addWorksheet('My Sheet', {views:[{xSplit: 1, ySplit:1}]});
+// 创建一个冻结了第一行和第一列的工作表
+var sheet = workbook.addWorksheet('My Sheet', {views:[{state: 'frozen', xSplit: 1, ySplit:1}]});
 ```
 
-## <a id="remove-a-worksheet">删除工作表</a>
+## 删除工作表
 
-使用工作表`id`从工作簿中删除工作表。
+使用工作表的  `id` 从工作簿中删除工作表。
 
-例如
+示例：
 
 ```javascript
 // 创建工作表
 var sheet = workbook.addWorksheet('My Sheet');
 
-// 使用工作表ID删除工作表
+// 使用工作表 id 删除工作表
 workbook.removeWorksheet(sheet.id)
 ```
 
-## <a id="access-worksheets">访问工作表</a>
+## 访问工作表
 ```javascript
-// 迭代所有sheet
-// 注意：workbook.worksheets.forEach仍然可以工作，但这个方式更好
+// 遍历所有工作表
+// 注意： workbook.worksheets.forEach 仍然是可以正常运行的， 但是以下的方式更好
 workbook.eachSheet(function(worksheet, sheetId) {
   // ...
 });
 
-// 按名称获取表格
+// 按 name 提取工作表
 var worksheet = workbook.getWorksheet('My Sheet');
 
-// 按ID获取表格
+// 按 id 提取工作表
 var worksheet = workbook.getWorksheet(1);
 ```
 
-## <a id="worksheet-state">工作表状态</a>
+## 工作表状态
 
 ```javascript
 // 使工作表可见
 worksheet.state = 'visible';
 
-// 使工作表隐藏
+// 隐藏工作表
 worksheet.state = 'hidden';
 
-// 使工作表隐藏在“隐藏/取消隐藏”对话框中
+// 从“隐藏/取消隐藏”对话框中隐藏工作表
 worksheet.state = 'veryHidden';
 ```
 
-## <a id="worksheet-properties">工作表属性</a>
+## 工作表属性
 
-工作表支持属性桶，以允许控制工作表的某些功能。
+工作表支持属性存储，以允许控制工作表的某些功能。
 
 ```javascript
 // 创建具有属性的新工作表
 var worksheet = workbook.addWorksheet('sheet', {properties:{tabColor:{argb:'FF00FF00'}}});
 
-// 创建一个具有属性的可写的新工作表
+// 创建一个具有属性的新工作表读写器
 var worksheetWriter = workbookWriter.addSheet('sheet', {properties:{outlineLevelCol:1}});
 
-// 之后调整属性（不受工作表 - 编写者支持）
+// 之后调整属性（工作表读写器不支持该操作）
 worksheet.properties.outlineLevelCol = 2;
 worksheet.properties.defaultRowHeight = 15;
 ```
 
 **支持的属性**
 
-| 名称             | 默认值    | 描述 |
+| 属性名            | 默认值 | 描述 |
 | ---------------- | ---------- | ----------- |
-| tabColor         | undefined  | 标签的颜色 |
+| tabColor         | `undefined` | 标签的颜色 |
 | outlineLevelCol  | 0          | 工作表列大纲级别 |
 | outlineLevelRow  | 0          | 工作表行大纲级别 |
 | defaultRowHeight | 15         | 默认行高 |
-| defaultColWidth  | (可选) | 默认列宽 |
+| defaultColWidth  | (optional) | 默认列宽 |
 | dyDescent        | 55         | TBD |
 
-### 工作表指标
+### 工作表尺寸
 
-一些新的指标已添加到工作表...
+一些新的尺寸属性已添加到工作表中...
 
-| 名称              | 描述 |
-| ----------------- | ----------- |
-| rowCount          | 文档的总行大小。等于有值的最后一行的行号。 |
-| actualRowCount    | 具有值的行数的计数。如果中间文档行为空，则它不会包含在计数中。 |
-| columnCount       | 文档的总列大小。等于所有行的最大单元格计数 |
-| actualColumnCount | 具有值的列数的计数。 |
+| 属性名              | 描述                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| rowCount          | 文档的总行数。 等于具有值的最后一行的行号。                  |
+| actualRowCount    | 具有值的行数的计数。 如果中间文档行为空，则该行将不包括在计数中。 |
+| columnCount       | 文档的总列数。 等于所有行的最大单元数。                      |
+| actualColumnCount | 具有值的列数的计数。                                         |
 
 
-## <a id="page-setup">页面设置</a>
+## 页面设置
 
-所有可能影响工作表打印的属性都保存在工作表的pageSetup对象中。
+所有可能影响工作表打印的属性都保存在工作表上的 `pageSetup` 对象中。
 
 ```javascript
-// 使用A4设置的页面设置设置创建新工作表 - 横向
+// 使用 A4 横向的页面设置创建新工作表
 var worksheet =  workbook.addWorksheet('sheet', {
   pageSetup:{paperSize: 9, orientation:'landscape'}
 });
 
-// 使用适合页面的pageSetup设置创建一个新的工作表编写器
+// 使用适用于页面的页面设置配置创建新的表格读写器
 var worksheetWriter = workbookWriter.addSheet('sheet', {
   pageSetup:{fitToPage: true, fitToHeight: 5, fitToWidth: 7}
 });
 
-// 之后调整pageSetup设置
+// 之后调整页面设置配置
 worksheet.pageSetup.margins = {
   left: 0.7, right: 0.7,
   top: 0.75, bottom: 0.75,
@@ -314,148 +404,152 @@ worksheet.pageSetup.margins = {
 // 设置工作表的打印区域
 worksheet.pageSetup.printArea = 'A1:G20';
 
-// 在每个打印页面上重复特定行
+// 通过使用 `&&` 分隔打印区域来设置多个打印区域
+worksheet.pageSetup.printArea = 'A1:G10&&A11:G20';
+
+// 在每个打印页面上重复特定的行
 worksheet.pageSetup.printTitlesRow = '1:3';
 
 // 在每个打印页面上重复特定列
 worksheet.pageSetup.printTitlesColumn = 'A:C';
 ```
 
-**支持的页面设置设置**
+**支持的页面设置配置项**
 
 | 属性名                  | 默认值       | 描述 |
 | --------------------- | ------------- | ----------- |
-| margins               |               | 页面边框上的空格。单位是英寸。 |
-| orientation           | 'portrait'    | 页面的方向 - 即更高（纵向）或更宽（横向） |
-| horizontalDpi         | 4294967295    | 每英寸水平点。默认值为-1 |
-| verticalDpi           | 4294967295    | 每英寸垂直点。默认值为-1 |
-| fitToPage             |               | 是否使用fitToWidth和fitToHeight或缩放设置。默认值基于pageSetup对象中是否存在这些设置 - 如果两者都存在，则缩放获胜（即默认值为false） |
-| pageOrder             | 'downThenOver'| 打印页面的顺序 - 其中之一 ['downThenOver', 'overThenDown'] |
-| blackAndWhite         | false         | 打印没有颜色 |
-| draft                 | false         | 打印质量较差（和墨水） |
-| cellComments          | 'None'        | 在哪里发表评论 - 其中之一 ['atEnd', 'asDisplayed', 'None'] |
-| errors                | 'displayed'   | 在哪里显示错误 - 其中之一 ['dash', 'blank', 'NA', 'displayed'] |
-| scale                 | 100           | 增加或减小打印尺寸的百分比值。当fitToPage为false时激活 |
-| fitToWidth            | 1             | 页面应打印多少页宽。当fitToPage为true时激活  |
-| fitToHeight           | 1             | 页面应打印多少页。当fitToPage为true时激活  |
-| paperSize             |               | 使用什么纸张尺寸（见下文） |
+| margins               |               | 页面上的空白边距。 单位为英寸。 |
+| orientation           | `'portrait'` | 页面方向 - 即较高 (`'portrait'`) 或者较宽 (`'landscape'`) |
+| horizontalDpi         | 4294967295    | 水平方向上的 DPI。默认值为 `-1` |
+| verticalDpi           | 4294967295    | 垂直方向上的 DPI。默认值为 `-1` |
+| fitToPage             |               | 是否使用 `fitToWidth` 和 `fitToHeight` 或 `scale` 设置。默认基于存在于 `pageSetup` 对象中的设置-如果两者都存在，则 `scale` 优先级高（默认值为 `false`）。 |
+| pageOrder             | `'downThenOver'` | 打印页面的顺序-`['downThenOver', 'overThenDown']` 之一 |
+| blackAndWhite         | `false`  | 无色打印 |
+| draft                 | `false`  | 打印质量较低（墨水） |
+| cellComments          | `'None'` | 在何处放置批注-`['atEnd'，'asDisplayed'，'None']`中的一个 |
+| errors                | `'displayed'` | 哪里显示错误 -`['dash', 'blank', 'NA', 'displayed']` 之一 |
+| scale                 | 100           | 增加或减小打印尺寸的百分比值。 当 `fitToPage` 为 `false` 时激活 |
+| fitToWidth            | 1             | 纸张应打印多少页宽。 当 `fitToPage` 为 `true` 时激活 |
+| fitToHeight           | 1             | 纸张应打印多少页高。 当 `fitToPage` 为 `true` 时激活 |
+| paperSize             |               | 使用哪种纸张尺寸（见下文） |
 | showRowColHeaders     | false         | 是否显示行号和列字母 |
 | showGridLines         | false         | 是否显示网格线 |
-| firstPageNumber       |               | 第一页使用哪个号码 |
-| horizontalCentered    | false         | 是否水平居中工作表数据 |
-| verticalCentered      | false         | 是否垂直居中表格数据 |
+| firstPageNumber       |               | 第一页使用哪个页码 |
+| horizontalCentered    | false         | 是否将工作表数据水平居中 |
+| verticalCentered      | false         | 是否将工作表数据垂直居中 |
 
 **示例纸张尺寸**
 
-| 名称                          | 值     |
-| ----------------------------- | --------- |
-| 信                        | undefined |
-| Legal                         |  5        |
-| Executive                     |  7        |
-| A4                            |  9        |
-| A5                            |  11       |
-| B5 (JIS)                      |  13       |
-| 信封 #10                       |  20       |
-| 信封 DL                        |  27       |
-| 信封 C5                        |  28       |
-| 信封 B5                        |  34       |
-| 信封君主                       |  37       |
-| 日本双明信片旋转 |  82       |
-| 16K 197x273 mm                |  119      |
+| 属性名                          | 值       |
+| ----------------------------- | ----------- |
+| Letter                        | `undefined` |
+| Legal                         | 5           |
+| Executive                     | 7           |
+| A4                            | 9           |
+| A5                            | 11          |
+| B5 (JIS)                      | 13          |
+| Envelope #10                  | 20          |
+| Envelope DL                   | 27          |
+| Envelope C5                   | 28          |
+| Envelope B5                   | 34          |
+| Envelope Monarch              | 37          |
+| Double Japan Postcard Rotated | 82          |
+| 16K 197x273 mm                | 119         |
 
-## <a id="header-footer">页眉和页脚</a>
+## 页眉和页脚
 
-这里将介绍如何添加页眉和页脚，添加的内容主要是文本，比如时间，简介，文件信息等，并且可以设置文本的风格。此外，也可以针对首页，奇偶页设置不同的文本。
+这是添加页眉和页脚的方法。
+添加的内容主要是文本，例如时间，简介，文件信息等，您可以设置文本的样式。
+此外，您可以为首页和偶数页设置不同的文本。
 
-警告：不支持添加图片
+注意：目前不支持图片。
 
 ```javascript
-// 代码中出现的&开头字符对应变量，相关信息可查阅下文的变量表
-// 设置页脚(默认居中),结果：“第 2 页，共 16 页”
-worksheet.headerFooter.oddFooter = "第 &P 页，共 &N 页";
+// 设置页脚（默认居中），结果：“第2页，共16页”
+worksheet.headerFooter.oddFooter = "Page &P of &N";
 
-// 设置页脚(默认居中)加粗,结果：“第 2 页，共 16 页”
-worksheet.headerFooter.oddFooter = "&B第 &P 页，共 &N 页";
+// 将页脚（默认居中）设置为粗体，结果是：“第2页，共16页”
+worksheet.headerFooter.oddFooter = "Page &P of &N";
 
-// 设置左边页脚为18px大小并倾斜,结果：“第 2 页，共 16 页”
-worksheet.headerFooter.oddFooter = "&L&18&I第 &P 页，共 &N 页";
+// 将左页脚设置为 18px 并以斜体显示。 结果：“第2页，共16页”
+worksheet.headerFooter.oddFooter = "&LPage &P of &N";
 
-// 设置中间页眉为灰色微软雅黑,结果：“52 exceljs”
-worksheet.headerFooter.oddHeader = "&C&KCCCCCC&\"微软雅黑\"52 exceljs";
+// 将中间标题设置为灰色Aril，结果为：“ 52 exceljs”
+worksheet.headerFooter.oddHeader = "&C&KCCCCCC&\"Aril\"52 exceljs";
 
-// 设置页脚的左中右文本，结果：页脚左“exceljs” 页脚中“demo.xlsx” 页脚右“第 2 页”
-worksheet.headerFooter.oddFooter = "&Lexceljs&C&F&R第 &P 页";
+// 设置页脚的左，中和右文本。 结果：页脚左侧为“ Exceljs”。 页脚中心的“ demo.xlsx”。 页脚右侧的“第2页”
+worksheet.headerFooter.oddFooter = "&Lexceljs&C&F&RPage &P";
 
-// 为首页设置独特的内容
+// 在首页添加不同的页眉和页脚
 worksheet.headerFooter.differentFirst = true;
 worksheet.headerFooter.firstHeader = "Hello Exceljs";
 worksheet.headerFooter.firstFooter = "Hello World"
 ```
 
-**属性表**
+**支持的 headerFooter 设置**
 
-| 名称              | 默认值   | 描述 |
-| ----------------- | --------- | ----------- |
-|differentFirst|false|开启或关闭首页使用独特的文本内容|
-|differentOddEven|false|开启或关闭奇数页和偶数页使用不同的文本内容|
-|oddHeader|null|奇数页的页眉内容，如果 differentOddEven = false ，那么该项作为页面默认的页眉内容|
-|oddFooter|null|奇数页的页脚内容，如果 differentOddEven = false ，那么该项作为页面默认的页脚内容|
-|evenHeader|null|偶数页的页眉内容，differentOddEven = true 后有效|
-|evenFooter|null|偶数页的页脚内容，differentOddEven = true 后有效|
-|firstHeader|null|首页的页眉内容，differentFirst = true 后有效|
-|firstFooter|null|首页的页脚内容，differentFirst = true 后有效|
+| 属性名             | 默认值 | 描述                                                  |
+| ---------------- | ------- | ------------------------------------------------------------ |
+| differentFirst   | `false` | 将 `differentFirst` 的值设置为 `true`，这表示第一页的页眉/页脚与其他页不同 |
+| differentOddEven | `false` | 将 `differentOddEven` 的值设置为 `true`，表示奇数页和偶数页的页眉/页脚不同 |
+| oddHeader        | `null`  | 设置奇数（默认）页面的标题字符串，可以设置格式化字符串       |
+| oddFooter        | `null`  | 设置奇数（默认）页面的页脚字符串，可以设置格式化字符串       |
+| evenHeader       | `null`  | 设置偶数页的标题字符串，可以设置格式化字符串                 |
+| evenFooter       | `null`  | 为偶数页设置页脚字符串，可以设置格式化字符串                 |
+| firstHeader      | `null`  | 设置首页的标题字符串，可以设置格式化字符串                   |
+| firstFooter      | `null`  | 设置首页的页脚字符串，可以设置格式化字符串                   |
 
-**变量表**
+**脚本命令**
 
-| 名称                | 描述 |
-| -----------------  | ----------- |
-|&L|设置位置为左边|
-|&C|设置位置为中间|
-|&R|设置位置为右边|
-|&P|当前页数|
-|&N|总页数|
-|&D|当前日期|
-|&T|当前时间|
-|&G|图片|
-|&A|工作表名|
-|&F|文件名|
-|&B|文本加粗|
-|&I|文本倾斜|
-|&U|文本下划线|
-|&"字体名称"|字体名称，比如：&“微软雅黑”|
-|&数字|字体大小，比如12px大的文本：&12 |
-|&KHEXCode|字体颜色，比如灰色：&KCCCCCC|
+| 命令     | 描述 |
+| ------------ | ----------- |
+| &L           | 将位置设定在左侧 |
+| &C           | 将位置设置在中心 |
+| &R           | 将位置设定在右边 |
+| &P           | 当前页码 |
+| &N           | 总页数 |
+| &D           | 当前日期 |
+| &T           | 当前时间 |
+| &G           | 照片 |
+| &A           | 工作表名称 |
+| &F           | 文件名称 |
+| &B           | 加粗文本 |
+| &I           | 斜体文本                |
+| &U           | 文本下划线 |
+| &"font name" | 字体名称，例如＆“ Aril” |
+| &font size   | 字体大小，例如12 |
+| &KHEXCode    | 字体颜色，例如 &KCCCCCC |
 
-## <a id="worksheet-views">工作表视图</a>
+## 工作表视图
 
-工作表现在支持一个视图列表，用于控制Excel如何显示工作表：
+现在，工作表支持视图列表，这些视图控制Excel如何显示工作表：
 
-* 冻结 - 顶部和左侧的多个行和列被冻结到位。只有左下部分会滚动
-* split - 视图分为4个部分，每个部分半独立可滚动。
+* `frozen` - 顶部和左侧的许多行和列被冻结在适当的位置。 仅右下部分会滚动
+* `split` - 该视图分为4个部分，每个部分可半独立滚动。
 
 每个视图还支持各种属性：
 
-| 名称              | 默认值   | 描述 |
+| 属性名              | 默认值   | 描述 |
 | ----------------- | --------- | ----------- |
-| state             | 'normal'  | 控制视图状态，其中任意一个 normal, frozen or split |
-| rightToLeft       | false     | 将工作表视图的方向设置为 right-to-left |
-| activeCell        | undefined | 当前选择的单元格 |
-| showRuler         | true      | 在页面布局中显示或隐藏标尺 |
-| showRowColHeaders | true      | 显示或隐藏行和列标题（例如顶部的A1，B1和左侧的1,2,3 |
-| showGridLines     | true      | 显示或隐藏网格线（显示未定义边框的单元格） |
-| zoomScale         | 100       | 用于视图的缩放百分比 |
+| state             | `'normal'` | 控制视图状态 -  `'normal'`, `'frozen'` 或者 `'split'` 之一 |
+| rightToLeft       | `false` | 将工作表视图的方向设置为从右到左 |
+| activeCell        | `undefined` | 当前选择的单元格 |
+| showRuler         | `true` | 在页面布局中显示或隐藏标尺 |
+| showRowColHeaders | `true` | 显示或隐藏行标题和列标题（例如，顶部的 A1，B1 和左侧的1,2,3） |
+| showGridLines     | `true` | 显示或隐藏网格线（针对未定义边框的单元格显示） |
+| zoomScale         | 100       | 用于视图的缩放比例 |
 | zoomScaleNormal   | 100       | 正常缩放视图 |
-| style             | undefined | 演示文稿样式 -  pageBreakPreview或pageLayout之一。注意pageLayout与冻结视图不兼容 |
+| style             | `undefined` | 演示样式- `pageBreakPreview` 或 `pageLayout` 之一。 注意：页面布局与 `frozen` 视图不兼容 |
 
-### <a id="frozen-views">冰冻视图</a>
+### 冻结视图
 
-冻结视图支持以下扩展属性：
+冻结视图支持以下额外属性：
 
-| 名称              | 默认值   | 描述 |
+| 属性名              | 默认值   | 描述 |
 | ----------------- | --------- | ----------- |
-| xSplit            | 0         | 要冻结的列数。要仅冻结行，请将其设置为0或未定义 |
-| ySplit            | 0         | 要冻结的行数。要仅冻结列，请将其设置为0或未定义 |
-| topLeftCell       | special   | 哪个单元格将位于右下方窗格的左上角。注意：不能是冻结单元格。默认为首先解冻单元格 |
+| xSplit            | 0         | 冻结多少列。要仅冻结行，请将其设置为 `0` 或 `undefined` |
+| ySplit            | 0         | 冻结多少行。要仅冻结列，请将其设置为 `0` 或 `undefined` |
+| topLeftCell       | special   | 哪个单元格将在右下窗格中的左上角。注意：不能是冻结单元格。默认为第一个未冻结的单元格 |
 
 ```javascript
 worksheet.views = [
@@ -463,16 +557,16 @@ worksheet.views = [
 ];
 ```
 
-### <a id="split-views">拆分视图</a>
+### 拆分视图
 
-拆分视图支持以下扩展属性：
+拆分视图支持以下额外属性：
 
-| 名称              | 默认值   | 描述 |
+| 属性名              | 默认值   | 描述 |
 | ----------------- | --------- | ----------- |
-| xSplit            | 0         | 从左边多少个点设置拆分点。要垂直拆分，请将其设置为0或未定义 |
-| ySplit            | 0         | 从顶部多少个点设置拆分点。要水平拆分，请将其设置为0或未定义  |
-| topLeftCell       | undefined | 哪个单元格将位于右下方窗格的左上角。 |
-| activePane        | undefined | 哪个窗格将处于活动状态 -  topLeft，topRight，bottomLeft和bottomRight之一 |
+| xSplit            | 0         | 从左侧多少个点起，以放置拆分器。要垂直拆分，请将其设置为 `0` 或 `undefined` |
+| ySplit            | 0         | 从顶部多少个点起，放置拆分器。要水平拆分，请将其设置为 `0` 或 `undefined`  |
+| topLeftCell       | `undefined` | 哪个单元格将在右下窗格中的左上角。 |
+| activePane        | `undefined` | 哪个窗格将处于活动状态-`topLeft`，`topRight`，`bottomLeft` 和 `bottomRight` 中的一个 |
 
 ```javascript
 worksheet.views = [
@@ -480,25 +574,24 @@ worksheet.views = [
 ];
 ```
 
-## <a id="auto-filters">自动过滤器</a>
+## 自动筛选器
 
-可以将自动过滤器应用于工作表。
+可以对工作表应用自动筛选器。
 
 ```javascript
 worksheet.autoFilter = 'A1:C1';
 ```
 
-虽然范围字符串是autoFilter的标准形式，但工作表也将支持
-以下值：
+尽管范围字符串是 `autoFilter` 的标准形式，但工作表还将支持以下值：
 
 ```javascript
-// 设置从A1到C1的自动过滤器
+// 将自动筛选器设置为从 A1 到 C1
 worksheet.autoFilter = {
   from: 'A1',
   to: 'C1',
 }
 
-// 设置从第3行的第1列中的单元格到第5行的第12列中的单元格的自动过滤器
+// 将自动筛选器设置为从第3行第1列的单元格到第5行第12列的单元格
 worksheet.autoFilter = {
   from: {
     row: 3,
@@ -510,7 +603,7 @@ worksheet.autoFilter = {
   }
 }
 
-// 将自动过滤器从D3设置为第7行和第5列中的单元格
+// 将自动筛选器设置为从D3到第7行第5列中的单元格
 worksheet.autoFilter = {
   from: 'D3',
   to: {
@@ -520,53 +613,52 @@ worksheet.autoFilter = {
 }
 ```
 
-## <a id="columns">列</a>
+## 列
 
 ```javascript
 // 添加列标题并定义列键和宽度
-// 注意：这些列结构只是工作簿构建方便，
-// 除了列宽之外，它们不会完全持久化。
+// 注意：这些列结构仅是构建工作簿的方便之处，除了列宽之外，它们不会完全保留。
 worksheet.columns = [
   { header: 'Id', key: 'id', width: 10 },
   { header: 'Name', key: 'name', width: 32 },
   { header: 'D.O.B.', key: 'DOB', width: 10, outlineLevel: 1 }
 ];
 
-// 按键，字母和从1开始的列号访问各列
+// 通过键，字母和基于1的列号访问单个列
 var idCol = worksheet.getColumn('id');
 var nameCol = worksheet.getColumn('B');
 var dobCol = worksheet.getColumn(3);
 
 // 设置列属性
 
-// 注意：将覆盖单元格值C1
+// 注意：将覆盖 C1 单元格值
 dobCol.header = 'Date of Birth';
 
-// 注意：这将覆盖单元格值C1:C2
+// 注意：这将覆盖 C1:C2 单元格值
 dobCol.header = ['Date of Birth', 'A.K.A. D.O.B.'];
 
-// 从这一点开始，此列将被'dob'索引而不是'DOB'
+// 从现在开始，此列将以 “dob” 而不是 “DOB” 建立索引
 dobCol.key = 'dob';
 
 dobCol.width = 15;
 
-// 如果您愿意，请隐藏该列
+// 如果需要，隐藏列
 dobCol.hidden = true;
 
-// 设置列的大纲级别
+// 为列设置大纲级别
 worksheet.getColumn(4).outlineLevel = 0;
 worksheet.getColumn(5).outlineLevel = 1;
 
-// columns支持只读字段，以指示基于outlineLevel的折叠状态
+// 列支持一个只读字段，以指示基于 `OutlineLevel` 的折叠状态
 expect(worksheet.getColumn(4).collapsed).to.equal(false);
 expect(worksheet.getColumn(5).collapsed).to.equal(true);
 
-// 迭代此列中的所有当前单元格
+// 遍历此列中的所有当前单元格
 dobCol.eachCell(function(cell, rowNumber) {
   // ...
 });
 
-// 迭代此列中的所有当前单元格，包括空单元格
+// 遍历此列中的所有当前单元格，包括空单元格
 dobCol.eachCell({ includeEmpty: true }, function(cell, rowNumber) {
   // ...
 });
@@ -574,34 +666,34 @@ dobCol.eachCell({ includeEmpty: true }, function(cell, rowNumber) {
 // 添加一列新值
 worksheet.getColumn(6).values = [1,2,3,4,5];
 
-// 添加稀疏的值列
+// 添加稀疏列值
 worksheet.getColumn(7).values = [,,2,3,,5,,7,,,,11];
 
-// 剪切一列或多列（右侧列向左移动）
-// 如果已定义列属性，则会相应地剪切或移动它们
-//已知问题：如果拼接导致任何合并的单元格移动，则结果可能无法预测
+// 剪切一列或多列（右边的列向左移动）
+// 如果定义了列属性，则会相应地对其进行切割或移动
+// 已知问题：如果拼接导致任何合并的单元格移动，结果可能是不可预测的
 worksheet.spliceColumns(3,2);
 
-// 删除一列并再插入两列。
-// 注意：第4列及以上将向右移动1列。
-// 另外：如果工作表的行数多于column插入中的值，则行仍将被移位，就像存在的值一样
+// 删除一列，再插入两列。
+// 注意：第4列及以上的列将右移1列。
+// 另外：如果工作表中的行数多于列插入项中的值，则行将仍然被插入，就好像值存在一样。
 var newCol3Values = [1,2,3,4,5];
 var newCol4Values = ['one', 'two', 'three', 'four', 'five'];
 worksheet.spliceColumns(3, 1, newCol3Values, newCol4Values);
 
 ```
 
-## <a id="rows">行</a>
+## 行
 
 ```javascript
-// 使用列键在最后一行之后按键值添加几行
+// 在最后一个当前行之后，使用列键值添加两行
 worksheet.addRow({id: 1, name: 'John Doe', dob: new Date(1970,1,1)});
 worksheet.addRow({id: 2, name: 'Jane Doe', dob: new Date(1965,1,7)});
 
-// 按连续数组添加一行（分配给A，B和C列）
+// 通过连续数组添加一行（分配给 A，B 和 C 列）
 worksheet.addRow([3, 'Sam', new Date()]);
 
-// 通过稀疏数组添加一行（分配给A，E和I列）
+// 通过稀疏数组添加一行（分配给 A，E 和 I 列）
 var rowValues = [];
 rowValues[1] = 4;
 rowValues[5] = 'Kyle';
@@ -615,43 +707,43 @@ var rows = [
 ];
 worksheet.addRows(rows);
 
-// 获取行对象。如果它尚不存在，将返回一个新的空的
+// 获取一个行对象。如果尚不存在，则将返回一个新的空对象
 var row = worksheet.getRow(5);
 
-// 获取工作表中的最后一个可编辑行（如果没有，则为undefined）
+// 获取工作表中的最后一个可编辑行（如果没有，则为 `undefined`）
 var row = worksheet.lastRow;
 
 // 设置特定的行高
 row.height = 42.5;
 
-// 使行隐藏
+// 隐藏行
 row.hidden = true;
 
-// 设置行的大纲级别
+// 为行设置大纲级别
 worksheet.getRow(4).outlineLevel = 0;
 worksheet.getRow(5).outlineLevel = 1;
 
-// rows支持readonly字段以指示基于outlineLevel的折叠状态
+// 行支持一个只读字段，以指示基于 `OutlineLevel` 的折叠状态
 expect(worksheet.getRow(4).collapsed).to.equal(false);
 expect(worksheet.getRow(5).collapsed).to.equal(true);
 
 
-row.getCell(1).value = 5; // A5的值设为5
-row.getCell('name').value = 'Zeb'; // B5的值设置为'Zeb' - 假设第2列仍然按名称键入
-row.getCell('C').value = new Date(); // C5的值设定为当前日期
+row.getCell(1).value = 5; // A5 的值设置为5
+row.getCell('name').value = 'Zeb'; // B5 的值设置为 “Zeb” - 假设第2列仍按名称键入
+row.getCell('C').value = new Date(); // C5 的值设置为当前时间
 
-// 获取一行作为稀疏数组
-// 注意：接口变更：worksheet.getRow(4)==> worksheet.getRow(4).values
+// 获取行并作为稀疏数组返回
+// 注意：接口更改：worksheet.getRow(4) ==> worksheet.getRow(4).values
 row = worksheet.getRow(4).values;
 expect(row[5]).toEqual('Kyle');
 
-// 通过连续数组分配行值（其中数组元素0具有值）
+// 通过连续数组分配行值（其中数组元素 0 具有值）
 row.values = [1,2,3];
 expect(row.getCell(1).value).toEqual(1);
 expect(row.getCell(2).value).toEqual(2);
 expect(row.getCell(3).value).toEqual(3);
 
-// 通过稀疏数组分配行值（其中数组元素0未定义）
+// 通过稀疏数组分配行值（其中数组元素 0 为 `undefined`）
 var values = []
 values[5] = 7;
 values[10] = 'Hello, World!';
@@ -667,55 +759,55 @@ row.values = {
   dob: new Date()
 };
 
-// 在行下方插入分页符
+// 在该行下方插入一个分页符
 row.addPageBreak();
 
-// 迭代工作表中具有值的所有行
+// 遍历工作表中具有值的所有行
 worksheet.eachRow(function(row, rowNumber) {
   console.log('Row ' + rowNumber + ' = ' + JSON.stringify(row.values));
 });
 
-// 迭代工作表中的所有行（包括空行）
+// 遍历工作表中的所有行（包括空行）
 worksheet.eachRow({ includeEmpty: true }, function(row, rowNumber) {
   console.log('Row ' + rowNumber + ' = ' + JSON.stringify(row.values));
 });
 
-// 迭代连续的所有非空单元格
+// 连续遍历所有非空单元格
 row.eachCell(function(cell, colNumber) {
   console.log('Cell ' + colNumber + ' = ' + cell.value);
 });
 
-// 迭代连续的所有单元格（包括空单元格）
+// 遍历一行中的所有单元格（包括空单元格）
 row.eachCell({ includeEmpty: true }, function(cell, colNumber) {
   console.log('Cell ' + colNumber + ' = ' + cell.value);
 });
 
-// 剪切一行或多行（下面的行向上移动）
-// 已知问题：如果拼接导致任何合并的单元格移动，则结果可能无法预测
+// 剪切下一行或多行（下面的行向上移动）
+// 已知问题：如果拼接导致任何合并的单元格移动，结果可能是不可预测的
 worksheet.spliceRows(4,3);
 
-// 删除一行并再插入两行。
-//注意：第4行和第4行将向下移动1行。
+// 删除一行，再插入两行。
+// 注意：第4行及以下行将向下移动 1 行。
 var newRow3Values = [1,2,3,4,5];
 var newRow4Values = ['one', 'two', 'three', 'four', 'five'];
 worksheet.spliceRows(3, 1, newRow3Values, newRow4Values);
 
-// 切一个或多个单元格（右边的单元格向左移动）
+// 剪切一个或多个单元格（右侧的单元格向左移动）
 // 注意：此操作不会影响其他行
 row.splice(3,2);
 
-// 移除一个单元格并再插入两个单元格（切割单元格右侧的单元格将向右移动）
+// 删除一个单元格，再插入两个单元格（剪切单元格右侧的单元格将向右移动）
 row.splice(4,1,'new value 1', 'new value 2');
 
-// 提交已完成的行进行流式处理
+// 提交给流一个完成的行
 row.commit();
 
-// 行指标
+// 行尺寸
 var rowSize = row.cellCount;
 var numValues = row.actualCellCount;
 ```
 
-## <a id="handling-individual-cells">处理单个单元格</a>
+## 处理单个单元格
 
 ```javascript
 var cell = worksheet.getCell('C3');
@@ -729,48 +821,73 @@ expect(cell.type).toEqual(Excel.ValueType.Date);
 // 使用单元格的字符串值
 myInput.value = cell.text;
 
-// 使用html-safe字符串进行渲染...
+// 使用 html 安全的字符串进行渲染...
 var html = '<div>' + cell.html + '</div>';
 
 ```
 
-## <a id="merged-cells">合并单元格</a>
+## 合并单元格
 
 ```javascript
 // 合并一系列单元格
 worksheet.mergeCells('A4:B5');
 
-// ... 合并的单元格是链接的
+// ...合并的单元格被链接起来了
 worksheet.getCell('B5').value = 'Hello, World!';
 expect(worksheet.getCell('B5').value).toBe(worksheet.getCell('A4').value);
 expect(worksheet.getCell('B5').master).toBe(worksheet.getCell('A4'));
 
-// ... 合并的单元格共享相同的样式对象
+// ...合并的单元格共享相同的样式对象
 expect(worksheet.getCell('B5').style).toBe(worksheet.getCell('A4').style);
 worksheet.getCell('B5').style.font = myFonts.arial;
 expect(worksheet.getCell('A4').style.font).toBe(myFonts.arial);
 
-// 取消单元格破坏风格链接
+// 取消单元格合并将打破链接的样式
 worksheet.unMergeCells('A4');
 expect(worksheet.getCell('B5').style).not.toBe(worksheet.getCell('A4').style);
 expect(worksheet.getCell('B5').style.font).not.toBe(myFonts.arial);
 
-// 由左上角，右下角合并
-worksheet.mergeCells('G10', 'H11');
-worksheet.mergeCells(10,11,12,13); // 上，左，下，右
+// 按左上，右下合并
+worksheet.mergeCells('K10', 'M12');
+
+// 按开始行，开始列，结束行，结束列合并（相当于 K10:M12）
+worksheet.mergeCells(10,11,12,13);
 ```
-
-## <a id="defined-names">定义的名称</a>
-
-单个单元格（或多组单元格）可以为其分配名称。
- 名称可用于公式和数据验证（可能更多）。
+## 重复行
 
 ```javascript
-// 为单元格分配（或获取）名称（将覆盖单元格具有的任何其他名称）
+duplicateRow(start, amount = 1, insert = true)
+
+const wb = new ExcelJS.Workbook();
+const ws = wb.addWorksheet('duplicateTest');
+ws.getCell('A1').value = 'One';
+ws.getCell('A2').value = 'Two';
+ws.getCell('A3').value = 'Three';
+ws.getCell('A4').value = 'Four';
+
+// 该行将重复复制第一行两次，但将替换第二行和第三行
+// 如果第三个参数为 true，则它将插入2个新行，其中包含行 “One” 的值和样式
+ws.duplicateRow(1,2,false);
+```
+
+| 参数 | 描述 | 默认值 |
+| -------------- | ----------------- | -------- |
+| start          | 要复制的行号（Excel中的第一个是1） |  |
+| amount         | 您要复制行的次数 | 1 |
+| insert         | 如果要为重复项插入新行，则为 `true`，否则为 `false` 将替换已有行 | `true` |
+
+
+
+## 定义名称
+
+单个单元格（或多个单元格组）可以为它们分配名称。名称可用于公式和数据验证（可能还有更多）。
+
+```javascript
+// 为单元格分配（或获取）名称（将覆盖该单元具有的其他任何名称）
 worksheet.getCell('A1').name = 'PI';
 expect(worksheet.getCell('A1').name).to.equal('PI');
 
-// 为单元格分配（或获取）一组名称（单元格可以有多个名称）
+// 为单元格分配（或获取）一组名称（单元可以具有多个名称）
 worksheet.getCell('A1').names = ['thing1', 'thing2'];
 expect(worksheet.getCell('A1').names).to.have.members(['thing1', 'thing2']);
 
@@ -779,52 +896,52 @@ worksheet.getCell('A1').removeName('thing1');
 expect(worksheet.getCell('A1').names).to.have.members(['thing2']);
 ```
 
-## <a id="data-validations">数据验证</a>
+## 数据验证
 
-单元格可以定义哪些值有效，并向用户提供提示以帮助指导它们。
+单元格可以定义哪些值有效或无效，并提示用户以帮助指导它们。
 
 验证类型可以是以下之一：
 
-| Type       | 描述 |
+| 类型       | 描述 |
 | ---------- | ----------- |
-| list       | 定义一组离散的有效值。 Excel将在下拉列表中提供这些内容以便于输入 |
-| whole      | 值必须是整数 |
+| list       | 定义一组离散的有效值。Excel 将在下拉菜单中提供这些内容，以便于输入 |
+| whole      | 该值必须是整数 |
 | decimal    | 该值必须是十进制数 |
-| textLength | 值可以是文本，但长度是受控的 |
+| textLength | 该值可以是文本，但长度是受控的 |
 | custom     | 自定义公式控制有效值 |
 
-对于list或custom以外的类型，以下运算符会影响验证：
+对于 `list` 或 `custom` 以外的其他类型，以下运算符会影响验证：
 
-| Operator              | 描述 |
+| 运算符              | 描述 |
 | --------------------  | ----------- |
-| between               | 值必须位于公式结果之间 |
+| between               | 值必须介于公式结果之间 |
 | notBetween            | 值不能介于公式结果之间 |
 | equal                 | 值必须等于公式结果 |
-| notEqual              | 值必须不等于公式结果 |
+| notEqual              | 值不能等于公式结果 |
 | greaterThan           | 值必须大于公式结果 |
 | lessThan              | 值必须小于公式结果 |
 | greaterThanOrEqual    | 值必须大于或等于公式结果 |
 | lessThanOrEqual       | 值必须小于或等于公式结果 |
 
 ```javascript
-//指定有效值列表（一，二，三，四）。
-// Excel将提供包含这些值的下拉列表。
+// 指定有效值的列表（One，Two，Three，Four）。
+// Excel 将提供一个包含这些值的下拉列表。
 worksheet.getCell('A1').dataValidation = {
   type: 'list',
   allowBlank: true,
   formulae: ['"One,Two,Three,Four"']
 };
 
-// 指定范围中的有效值列表。
-// Excel将提供包含这些值的下拉列表。
+// 指定范围内的有效值列表。
+// Excel 将提供一个包含这些值的下拉列表。
 worksheet.getCell('A1').dataValidation = {
   type: 'list',
   allowBlank: true,
   formulae: ['$D$5:$F$5']
 };
 
-// 指定单元格必须是不是5的整数。
-// 如果用户输入错误，请向用户显示相应的错误消息
+// 指定单元格必须为非5的整数。
+// 向用户显示适当的错误消息（如果他们弄错了）
 worksheet.getCell('A1').dataValidation = {
   type: 'whole',
   operator: 'notEqual',
@@ -835,8 +952,8 @@ worksheet.getCell('A1').dataValidation = {
   error: 'The value must not be Five'
 };
 
-// Specify Cell must be a decimal number between 1.5 and 7.
-// Add 'tooltip' to help guid the user
+// 指定单元格必须为1.5到7之间的十进制数字。
+// 添加“工具提示”以帮助指导用户
 worksheet.getCell('A1').dataValidation = {
   type: 'decimal',
   operator: 'between',
@@ -847,7 +964,7 @@ worksheet.getCell('A1').dataValidation = {
   prompt: 'The value must between 1.5 and 7'
 };
 
-// Specify Cell must be have a text length less than 15
+// 指定单元格的文本长度必须小于15
 worksheet.getCell('A1').dataValidation = {
   type: 'textLength',
   operator: 'lessThan',
@@ -856,7 +973,7 @@ worksheet.getCell('A1').dataValidation = {
   formulae: [15]
 };
 
-// Specify Cell must be have be a date before 1st Jan 2016
+// 指定单元格必须是2016年1月1日之前的日期
 worksheet.getCell('A1').dataValidation = {
   type: 'date',
   operator: 'lessThan',
@@ -866,15 +983,15 @@ worksheet.getCell('A1').dataValidation = {
 };
 ```
 
-## <a id="cell-comments">单元格评论</a>
+## 单元格注释
 
-将旧样式评论添加到单元格
+将旧样式的注释添加到单元格
 
 ```javascript
-// 纯文本评论
+// 纯文字笔记
 worksheet.getCell('A1').note = 'Hello, ExcelJS!';
 
-// 彩色格式的评论
+// 彩色格式化的笔记
 ws.getCell('B1').note = {
   texts: [
     {'font': {'size': 12, 'color': {'theme': 0}, 'name': 'Calibri', 'family': 2, 'scheme': 'minor'}, 'text': 'This is '},
@@ -889,66 +1006,256 @@ ws.getCell('B1').note = {
 };
 ```
 
-## <a id="styles">样式</a>
+## 表格
 
-单元格，行和列各自支持一组丰富的样式和格式，这些样式和格式会影响单元格的显示方式。
+表允许表格内数据的表内操作。
+
+要将表添加到工作表，请定义表模型并调用 `addTable`：
+
+```javascript
+// 将表格添加到工作表
+ws.addTable({
+  name: 'MyTable',
+  ref: 'A1',
+  headerRow: true,
+  totalsRow: true,
+  style: {
+    theme: 'TableStyleDark3',
+    showRowStripes: true,
+  },
+  columns: [
+    {name: 'Date', totalsRowLabel: 'Totals:', filterButton: true},
+    {name: 'Amount', totalsRowFunction: 'sum', filterButton: false},
+  ],
+  rows: [
+    [new Date('2019-07-20'), 70.10],
+    [new Date('2019-07-21'), 70.60],
+    [new Date('2019-07-22'), 70.10],
+  ],
+});
+```
+
+注意：将表格添加到工作表将通过放置表格的标题和行数据来修改工作表。
+结果就是表格覆盖的工作表上的所有数据（包括标题和所有的）都将被覆盖。
+
+### 表格属性
+
+下表定义了表格支持的属性。
+
+| 表属性 | 描述       | 是否需要 | 默认值 |
+| -------------- | ----------------- | -------- | ------------- |
+| name           | 表格名称 | Y |    |
+| displayName    | 表格的显示名称 | N | `name` |
+| ref            | 表格的左上方单元格 | Y |   |
+| headerRow      | 在表格顶部显示标题 | N | true |
+| totalsRow      | 在表格底部显示总计 | N | `false` |
+| style          | 额外的样式属性 | N | {} |
+| columns        | 列定义 | Y |   |
+| rows           | 数据行 | Y |   |
+
+### 表格样式属性
+
+下表定义了表格中支持的属性样式属性。
+
+| 样式属性     | 描述       | 是否需要 | 默认值 |
+| ------------------ | ----------------- | -------- | ------------- |
+| theme              | 桌子的颜色主题 | N |  `'TableStyleMedium2'`  |
+| showFirstColumn    | 突出显示第一列（粗体） | N |  `false`  |
+| showLastColumn     | 突出显示最后一列（粗体） | N |  `false`  |
+| showRowStripes     | 用交替的背景色显示行 | N |  `false`  |
+| showColumnStripes  | 用交替的背景色显示列 | N |  `false`  |
+
+### 表格列属性
+
+下表定义了每个表格列中支持的属性。
+
+| 列属性    | 描述       | 是否需要 | 默认值 |
+| ------------------ | ----------------- | -------- | ------------- |
+| name               | 列名，也用在标题中 | Y |    |
+| filterButton       | 切换标题中的过滤器控件 | N |  false  |
+| totalsRowLabel     | 用于描述统计行的标签（第一列） | N | `'Total'` |
+| totalsRowFunction  | 统计函数名称 | N | `'none'` |
+| totalsRowFormula   | 自定义函数的可选公式 | N |   |
+
+### 统计函数
+
+下表列出了由列定义的 `totalsRowFunction` 属性的有效值。如果使用 `'custom'` 以外的任何值，则无需包括关联的公式，因为该公式将被表格插入。
+
+| 统计函数   | 描述       |
+| ------------------ | ----------------- |
+| none               | 此列没有统计函数 |
+| average            | 计算列的平均值 |
+| countNums          | 统计数字条目数 |
+| count              | 条目数 |
+| max                | 此列中的最大值 |
+| min                | 此列中的最小值 |
+| stdDev             | 该列的标准偏差 |
+| var                | 此列的方差 |
+| sum                | 此列的条目总数 |
+| custom             | 自定义公式。 需要关联的 `totalsRowFormula` 值。 |
+
+### 表格样式主题
+
+有效的主题名称遵循以下模式：
+
+* "TableStyle[Shade][Number]"
+
+Shades（阴影），Number（数字）可以是以下之一：
+
+* Light, 1-21
+* Medium, 1-28
+* Dark, 1-11
+
+对于无主题，请使用值 `null`。
+
+注意：exceljs 尚不支持自定义表格主题。
+
+### 修改表格
+
+表格支持一组操作函数，这些操作函数允许添加或删除数据以及更改某些属性。由于这些操作中的许多操作可能会对工作表产生副作用，因此更改必须在完成后立即提交。
+
+表中的所有索引值均基于零，因此第一行号和第一列号为 `0`。
+
+**添加或删除标题和统计**
+
+```javascript
+const table = ws.getTable('MyTable');
+
+// 打开标题行
+table.headerRow = true;
+
+// 关闭统计行
+table.totalsRow = false;
+
+// 将表更改提交到工作表中
+table.commit();
+```
+
+**重定位表**
+
+```javascript
+const table = ws.getTable('MyTable');
+
+// 表格左上移至 D4
+table.ref = 'D4';
+
+// 将表更改提交到工作表中
+table.commit();
+```
+
+**添加和删除行**
+
+```javascript
+const table = ws.getTable('MyTable');
+
+// 删除前两行
+table.removeRows(0, 2);
+
+// 在索引 5 处插入新行
+table.addRow([new Date('2019-08-05'), 5, 'Mid'], 5);
+
+// 在表格底部追加新行
+table.addRow([new Date('2019-08-10'), 10, 'End']);
+
+// 将表更改提交到工作表中
+table.commit();
+```
+
+**添加和删除列**
+
+```javascript
+const table = ws.getTable('MyTable');
+
+// 删除第二列
+table.removeColumns(1, 1);
+
+// 在索引 1 处插入新列（包含数据）
+table.addColumn(
+  {name: 'Letter', totalsRowFunction: 'custom', totalsRowFormula: 'ROW()', totalsRowResult: 6, filterButton: true},
+  ['a', 'b', 'c', 'd'],
+  2
+);
+
+// 将表更改提交到工作表中
+table.commit();
+```
+
+**更改列属性**
+
+```javascript
+const table = ws.getTable('MyTable');
+
+// 获取第二列的列包装器
+const column = table.getColumn(1);
+
+// 设置一些属性
+column.name = 'Code';
+column.filterButton = true;
+column.style = {font:{bold: true, name: 'Comic Sans MS'}};
+column.totalsRowLabel = 'Totals';
+column.totalsRowFunction = 'custom';
+column.totalsRowFormula = 'ROW()';
+column.totalsRowResult = 10;
+
+// 将表更改提交到工作表中
+table.commit();
+```
+
+
+## 样式
+
+单元格，行和列均支持一组丰富的样式和格式，这些样式和格式会影响单元格的显示方式。
 
 通过分配以下属性来设置样式：
 
-* <a href="#number-formats">数字格式</a>
-* <a href="#fonts">字体</a>
-* <a href="#alignment">对齐方式</a>
-* <a href="#borders">边框</a>
-* <a href="#fills">填充</a>
+* <a href="#数字格式">numFmt</a>
+* <a href="#字体">font</a>
+* <a href="#对齐">alignment</a>
+* <a href="#边框">border</a>
+* <a href="#填充">fill</a>
 
 ```javascript
-// assign a style to a cell
+// 为单元格分配样式
 ws.getCell('A1').numFmt = '0.00%';
 
-// Apply styles to worksheet columns
+// 将样式应用于工作表列
 ws.columns = [
   { header: 'Id', key: 'id', width: 10 },
   { header: 'Name', key: 'name', width: 32, style: { font: { name: 'Arial Black' } } },
   { header: 'D.O.B.', key: 'DOB', width: 10, style: { numFmt: 'dd/mm/yyyy' } }
 ];
 
-// Set Column 3 to Currency Format
+// 将第3列设置为“货币格式”
 ws.getColumn(3).numFmt = '"£"#,##0.00;[Red]\-"£"#,##0.00';
 
-// Set Row 2 to Comic Sans.
+// 将第2行设置为 Comic Sans。
 ws.getRow(2).font = { name: 'Comic Sans MS', family: 4, size: 16, underline: 'double', bold: true };
 ```
 
-将样式应用于行或列时，它将应用于该行或列中的所有当前现有单元格。
- 此外，创建的任何新单元格都将从其所属的行和列继承其初始样式。
+将样式应用于行或列时，它将应用于该行或列中所有当前存在的单元格。另外，创建的任何新单元格都将从其所属的行和列继承其初始样式。
 
-如果单元格的行和列都定义了特定样式（例如字体），则单元格将使用行样式而不是列样式。
- 但是，如果行和列定义了不同的样式（例如column.numFmt和row.font），则单元格将继承行中的字体和列中的numFmt。
+如果单元格的行和列都定义了特定的样式（例如，字体），则该单元格所在行样式比列样式具有更高优先级。但是，如果行和列定义了不同的样式（例如 `column.numFmt` 和 `row.font`），则单元格将继承行的字体和列的 `numFmt`。
 
-警告：所有上述属性（numFmt除外，它是一个字符串）都是JS对象结构。
- 如果将同一样式对象分配给多个电子表格实体，则每个实体将共享相同的样式对象。
- 如果在序列化电子表格之前稍后修改了样式对象，则也将修改引用该样式对象的所有实体。
- 此行为旨在通过减少创建的JS对象的数量来确定性能的优先级。
- 如果希望样式对象是独立的，则需要在分配它们之前克隆它们。
- 此外，默认情况下，如果从文件（或流）读取文档（如果电子表格实体共享相似的样式），则它们也将引用相同的样式对象。
 
-### <a id="number-formats">数字格式</a>
+注意：以上所有属性（`numFmt`（字符串）除外）都是 JS 对象结构。如果将同一样式对象分配给多个电子表格实体，则每个实体将共享同一样式对象。如果样式对象后来在电子表格序列化之前被修改，则所有引用该样式对象的实体也将被修改。此行为旨在通过减少创建的JS对象的数量来优先考虑性能。如果希望样式对象是独立的，则需要先对其进行克隆，然后再分配它们。同样，默认情况下，如果电子表格实体共享相似的样式，则从文件（或流）中读取文档时，它们也将引用相同的样式对象。
+
+### 数字格式
 
 ```javascript
-// 显示值为 '1 3/5'
+// 将值显示为“ 1 3/5”
 ws.getCell('A1').value = 1.6;
 ws.getCell('A1').numFmt = '# ?/?';
 
-// 显示值为 '1.60%'
+// 显示为“ 1.60％”
 ws.getCell('B1').value = 0.016;
 ws.getCell('B1').numFmt = '0.00%';
 ```
 
-### <a id="fonts">字体</a>
+### 字体
 
 ```javascript
 
-// 对于想要那些想要的平面设计师
+// for the wannabe graphic designers out there
 ws.getCell('A1').font = {
   name: 'Comic Sans MS',
   family: 4,
@@ -957,7 +1264,7 @@ ws.getCell('A1').font = {
   bold: true
 };
 
-// 为毕业生平面设计师...
+// for the graduate graphic designers...
 ws.getCell('A2').font = {
   name: 'Arial Black',
   color: { argb: 'FF00FF00' },
@@ -966,50 +1273,50 @@ ws.getCell('A2').font = {
   italic: true
 };
 
-// 用于垂直对齐
+// 垂直对齐
 ws.getCell('A3').font = {
   vertAlign: 'superscript'
 };
 
-// 注意：单元格将存储对指定的字体对象的引用。
-// 如果之后更改了字体对象，则单元格字体也将更改...
+// 注意：该单元格将存储对分配的字体对象的引用。
+// 如果之后更改了字体对象，则单元字体也将更改。
 var font = { name: 'Arial', size: 12 };
 ws.getCell('A3').font = font;
-font.size = 20; // Cell A3现在的字体大小为20！
+font.size = 20; // 单元格 A3 现在具有20号字体！
 
-// 从文件或流中读取工作簿后，共享相似字体的单元格可能会引用相同的字体对象
+// 从文件或流中读取工作簿后，共享相似字体的单元格可能引用相同的字体对象
 ```
 
-| Font Property | 描述       | Example Value(s) |
+| 字体属性 | 描述       | 示例值 |
 | ------------- | ----------------- | ---------------- |
 | name          | 字体名称。 | 'Arial', 'Calibri', etc. |
-| family        | Font family for fallback. An integer value. | 1 - Serif, 2 - Sans Serif, 3 - Mono, Others - unknown |
-| scheme        | Font scheme. | 'minor', 'major', 'none' |
-| charset       | Font charset. An integer value. | 1, 2, etc. |
-| size          | Font size. An integer value. | 9, 10, 12, 16, etc. |
-| color         | Colour description, an object containing an ARGB value. | { argb: 'FFFF0000'} |
-| bold          | Font **weight** | true, false |
-| italic        | Font *slope* | true, false |
-| underline     | Font <u>underline</u> style | true, false, 'none', 'single', 'double', 'singleAccounting', 'doubleAccounting' |
-| strike        | Font <strike>strikethrough</strike> | true, false |
-| outline       | Font outline | true, false |
-| vertAlign     | Vertical align | 'superscript', 'subscript'
+| family        | 备用字体家族。整数值。 | 1 - Serif, 2 - Sans Serif, 3 - Mono, Others - unknown |
+| scheme        | 字体方案。 | 'minor', 'major', 'none' |
+| charset       | 字体字符集。整数值。 | 1, 2, etc. |
+| size          | 字体大小。整数值。 | 9, 10, 12, 16, etc. |
+| color         | 颜色描述，一个包含 ARGB 值的对象。 | { argb: 'FFFF0000'} |
+| bold          | 字体 **粗细** | true, false |
+| italic        | 字体 *倾斜* | true, false |
+| underline     | 字体 <u>下划线</u> 样式 | true, false, 'none', 'single', 'double', 'singleAccounting', 'doubleAccounting' |
+| strike        | 字体 <strike>删除线</strike> | true, false |
+| outline       | 字体轮廓 | true, false |
+| vertAlign     | 垂直对齐 | 'superscript', 'subscript'
 
-### <a id="alignment">对齐方式</a>
+### 对齐
 
 ```javascript
-// set cell alignment to top-left, middle-center, bottom-right
+// 将单元格对齐方式设置为左上，中间居中，右下
 ws.getCell('A1').alignment = { vertical: 'top', horizontal: 'left' };
 ws.getCell('B1').alignment = { vertical: 'middle', horizontal: 'center' };
 ws.getCell('C1').alignment = { vertical: 'bottom', horizontal: 'right' };
 
-// set cell to wrap-text
+// 将单元格设置为自动换行
 ws.getCell('D1').alignment = { wrapText: true };
 
-// set cell indent to 1
+// 将单元格缩进设置为1
 ws.getCell('E1').alignment = { indent: 1 };
 
-// set cell text rotation to 30deg upwards, 45deg downwards and vertical text
+// 将单元格文本旋转设置为向上30deg，向下45deg和垂直文本
 ws.getCell('F1').alignment = { textRotation: 30 };
 ws.getCell('G1').alignment = { textRotation: -45 };
 ws.getCell('H1').alignment = { textRotation: 'vertical' };
@@ -1017,18 +1324,18 @@ ws.getCell('H1').alignment = { textRotation: 'vertical' };
 
 **有效的对齐属性值**
 
-| horizontal       | vertical    | wrapText | indent  | readingOrder | textRotation |
-| ---------------- | ----------- | -------- | ------- | ------------ | ------------ |
-| left             | top         | true     | integer | rtl          | 0 to 90      |
-| center           | middle      | false    |         | ltr          | -1 to -90    |
-| right            | bottom      |          |         |              | vertical     |
-| fill             | distributed |          |         |              |              |
-| justify          | justify     |          |         |              |              |
-| centerContinuous |             |          |         |              |              |
-| distributed      |             |          |         |              |              |
+| 水平的       | 垂直    | 文本换行 | 自适应 | 缩进  | 阅读顺序 | 文本旋转 |
+| ---------------- | ----------- | -------- | ----------- | ------- | ------------ | ------------ |
+| left             | top         | true     | true        | integer | rtl          | 0 to 90      |
+| center           | middle      | false    | false       |         | ltr          | -1 to -90    |
+| right            | bottom      |          |             |         |              | vertical     |
+| fill             | distributed |          |             |         |              |              |
+| justify          | justify     |          |             |         |              |              |
+| centerContinuous |             |          |             |         |              |              |
+| distributed      |             |          |             |         |              |              |
 
 
-### <a id="borders">边框</a>
+### 边框
 
 ```javascript
 // 在A1周围设置单个细边框
@@ -1039,7 +1346,7 @@ ws.getCell('A1').border = {
   right: {style:'thin'}
 };
 
-// 在A3附近设置双细绿边框
+// 在A3周围设置双细绿色边框
 ws.getCell('A3').border = {
   top: {style:'double', color: {argb:'FF00FF00'}},
   left: {style:'double', color: {argb:'FF00FF00'}},
@@ -1047,13 +1354,13 @@ ws.getCell('A3').border = {
   right: {style:'double', color: {argb:'FF00FF00'}}
 };
 
-// 在A5设置厚红十字
+// 在A5中设置厚红十字边框
 ws.getCell('A5').border = {
   diagonal: {up: true, down: true, style:'thick', color: {argb:'FFFF0000'}}
 };
 ```
 
-**有效的边框样式**
+**有效边框样式**
 
 * thin
 * dotted
@@ -1068,17 +1375,17 @@ ws.getCell('A5').border = {
 * double
 * thick
 
-### <a id="fills">填充</a>
+### 填充
 
 ```javascript
-// fill A1 with red darkVertical stripes
+// 用红色深色垂直条纹填充A1
 ws.getCell('A1').fill = {
   type: 'pattern',
   pattern:'darkVertical',
   fgColor:{argb:'FFFF0000'}
 };
 
-// fill A2 with yellow dark trellis and blue behind
+// 在A2中填充深黄色格子和蓝色背景
 ws.getCell('A2').fill = {
   type: 'pattern',
   pattern:'darkTrellis',
@@ -1086,7 +1393,7 @@ ws.getCell('A2').fill = {
   bgColor:{argb:'FF0000FF'}
 };
 
-// fill A3 with blue-white-blue gradient from left to right
+// 从左到右用蓝白蓝渐变填充A3
 ws.getCell('A3').fill = {
   type: 'gradient',
   gradient: 'angle',
@@ -1099,7 +1406,7 @@ ws.getCell('A3').fill = {
 };
 
 
-// fill A4 with red-green gradient from center
+// 从中心开始用红绿色渐变填充A4
 ws.getCell('A4').fill = {
   type: 'gradient',
   gradient: 'path',
@@ -1111,16 +1418,16 @@ ws.getCell('A4').fill = {
 };
 ```
 
-#### <a id="pattern-fills">图案填充</a>
+#### 填充模式
 
-| Property | Required | 描述 |
+| 属性 | 是否需要 | 描述 |
 | -------- | -------- | ----------- |
-| type     | Y        | Value: 'pattern'<br/>Specifies this fill uses patterns |
-| pattern  | Y        | Specifies type of pattern (see <a href="#valid-pattern-types">Valid Pattern Types</a> below) |
-| fgColor  | N        | Specifies the pattern foreground color. Default is black. |
-| bgColor  | N        | Specifies the pattern background color. Default is white. |
+| type     | Y        | 值: `'pattern'`<br/>指定此填充使用模式 |
+| pattern  | Y        | 指定模式类型 (查看下面 <a href="#有效模式类型">有效模式类型</a> ) |
+| fgColor  | N        | 指定图案前景色。默认为黑色。 |
+| bgColor  | N        | 指定图案背景色。默认为白色。 |
 
-**Valid Pattern Types**
+**有效模式类型**
 
 * none
 * solid
@@ -1142,28 +1449,23 @@ ws.getCell('A4').fill = {
 * lightGrid
 * lightTrellis
 
-#### <a id="gradient-fills">渐变填充</a>
+#### 渐变填充
 
-| Property | Required | 描述 |
+| 属性 | 是否需要 | 描述 |
 | -------- | -------- | ----------- |
-| type     | Y        | Value: 'gradient'<br/>Specifies this fill uses gradients |
-| gradient | Y        | Specifies gradient type. One of ['angle', 'path'] |
-| degree   | angle    | For 'angle' gradient, specifies the direction of the gradient. 0 is from the left to the right. Values from 1 - 359 rotates the direction clockwise |
-| center   | path     | For 'path' gradient. Specifies the relative coordinates for the start of the path. 'left' and 'top' values range from 0 to 1 |
-| stops    | Y        | Specifies the gradient colour sequence. Is an array of objects containing position and color starting with position 0 and ending with position 1. Intermediary positions may be used to specify other colours on the path. |
+| type     | Y        | 值: `'gradient'`<br/>指定此填充使用渐变 |
+| gradient | Y        | 指定渐变类型。`['angle'，'path']` 之一 |
+| degree   | angle    | 对于“角度”渐变，指定渐变的方向。`0` 是从左到右。值从 1-359 顺时针旋转方向 |
+| center   | path     | 对于“路径”渐变。指定路径起点的相对坐标。“左”和“顶”值的范围是 0 到 1 |
+| stops    | Y        | 指定渐变颜色序列。是包含位置和颜色（从位置 0 开始到位置 1 结束）的对象的数组。中间位置可用于指定路径上的其他颜色。 |
 
 **注意事项**
 
-使用上面的界面可以创建使用XLSX编辑器程序无法实现的渐变填充效果。
-例如，Excel仅支持0度，45度，90度和135度的角度渐变。
-类似地，停止序列也可以由具有位置[0,1]或[0,0.5,1]作为唯一选项的UI限制。
-注意此填充以确保目标XLSX查看器支持它。
+使用上面的接口，可能会创建使用XLSX编辑器程序无法实现的渐变填充效果。例如，Excel 仅支持0、45、90 和 135 的角度梯度。类似地，stops 的顺序也可能受到 UI 的限制，其中位置 [0,1] 或[0,0.5,1] 是唯一的选择。请谨慎处理此填充，以确保目标 XLSX 查看器支持该填充。
 
-### <a id="rich-text">富文本</a>
+### 富文本
 
-单个单元格现在支持富文本或单元格格式。
- 富文本值可以控制文本值中任意数量子字符串的字体属性。
- 有关支持哪些字体属性的详细信息的完整列表，请参见<a href="font">字体</a>。
+现在，单个单元格支持RTF文本或单元格格式化。富文本值可以控制文本值内任意数量的子字符串的字体属性。有关支持哪些字体属性的详细信息，请参见<a href="font">字体</a>。
 
 ```javascript
 
@@ -1185,11 +1487,203 @@ expect(ws.getCell('A1').type).to.equal(Excel.ValueType.RichText);
 
 ```
 
-## <a id="outline-levels">大纲级别</a>
+### 单元格保护
 
-Excel支持概述;其中可以展开或折叠行或列，具体取决于用户希望查看的详细程度。
+可以使用保护属性来修改单元级别保护。
 
-可以在列设置中定义大纲级别：
+```javascript
+ws.getCell('A1').protection = {
+  locked: false,
+  hidden: true,
+};
+```
+
+**支持的保护属性**
+
+| 属性 | 默认值 | 描述 |
+| -------- | ------- | ----------- |
+| locked   | `true`    | 指定在工作表受保护的情况下是否将单元格锁定。 |
+| hidden   | `false`   | 指定如果工作表受保护，则单元格的公式是否可见。 |
+
+## 条件格式化
+
+条件格式化允许工作表根据单元格值或任意公式显示特定的样式，图标等。
+
+条件格式设置规则是在工作表级别添加的，通常会覆盖一系列单元格。
+
+可以将多个规则应用于给定的单元格范围，并且每个规则都将应用自己的样式。
+
+如果多个规则影响给定的单元格，则规则优先级值将确定如果竞争样式冲突，则哪个规则胜出。优先级值较低的规则获胜。如果没有为给定规则指定优先级值，ExcelJS 将按升序分配它们。
+
+注意：目前，仅支持条件格式设置规则的子集。具体来说，只有格式规则不需要 &lt;extLst&gt 元素内的 XML 呈现。这意味着不支持数据集和三个特定的图标集（3Triangles，3Stars，5Boxes）。
+
+```javascript
+// 根据行和列为偶数或奇数向 A1:E7 添加一个棋盘图案
+worksheet.addConditionalFormatting({
+  ref: 'A1:E7',
+  rules: [
+    {
+      type: 'expression',
+      formulae: ['MOD(ROW()+COLUMN(),2)=0'],
+      style: {fill: {type: 'pattern', pattern: 'solid', bgColor: {argb: 'FF00FF00'}}},
+    }
+  ]
+})
+```
+
+**支持的条件格式设置规则类型**
+
+| 类型         | 描述 |
+| ------------ | ----------- |
+| expression   | 任何自定义功能均可用于激活规则。 |
+| cellIs       | 使用指定的运算符将单元格值与提供的公式进行比较 |
+| top10        | 将格式化应用于值在顶部（或底部）范围内的单元格 |
+| aboveAverage | 将格式化应用于值高于（或低于）平均值的单元格 |
+| colorScale   | 根据其值在范围内的位置将彩色背景应用于单元格 |
+| iconSet      | 根据值将一系列图标之一添加到单元格 |
+| containsText | 根据单元格是否为特定文本来应用格式 |
+| timePeriod   | 根据单元格日期时间值是否在指定范围内应用格式 |
+
+### 表达式
+
+| 属性    | 可选 | 默认值 | 描述 |
+| -------- | -------- | ------- | ----------- |
+| type     |          |         | `'expression'` |
+| priority | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| formulae |          |         | 1个包含真/假值的公式字符串数组。要引用单元格值，请使用左上角的单元格地址 |
+| style    |          |         | 公式返回 `true` 时要应用的样式结构 |
+
+### Cell Is
+
+| 属性    | 可选 | 默认值 | 描述 |
+| -------- | -------- | ------- | ----------- |
+| type     |          |         | `'cellIs'` |
+| priority | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| operator |          |         | 如何将单元格值与公式结果进行比较 |
+| formulae |          |         | 1个公式字符串数组，返回要与每个单元格进行比较的值 |
+| style    |          |         | 如果比较返回 `true`，则应用样式结构 |
+
+**Cell Is 运算符**
+
+| 运算    | 描述 |
+| ----------- | ----------- |
+| equal       | 如果单元格值等于公式值，则应用格式 |
+| greaterThan | 如果单元格值大于公式值，则应用格式 |
+| lessThan    | 如果单元格值小于公式值，则应用格式 |
+| between     | 如果单元格值在两个公式值之间（包括两个值），则应用格式 |
+
+
+### Top 10
+
+| 属性    | 可选 | 默认值 | 描述 |
+| -------- | -------- | ------- | ----------- |
+| type     |          |         | `'top10'` |
+| priority | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| rank     | Y        | 10      | 指定格式中包含多少个顶部（或底部）值 |
+| percent  | Y        | `false`   | 如果为 true，则等级字段为百分比，而不是绝对值 |
+| bottom   | Y        | `false`   | 如果为 true，则包含最低值而不是最高值 |
+| style    |          |         | 如果比较返回 true，则应用样式结构 |
+
+### 高于平均值
+
+| 属性         | 可选 | 默认值 | 描述 |
+| ------------- | -------- | ------- | ----------- |
+| type          |          |         | `'aboveAverage'` |
+| priority      | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| aboveAverage  | Y        | `false`   | 如果为 true，则等级字段为百分比，而不是绝对值 |
+| style         |          |         | 如果比较返回 true，则应用样式结构 |
+
+### 色阶
+
+| 属性         | 可选 | 默认值 | 描述 |
+| ------------- | -------- | ------- | ----------- |
+| type          |          |         | `'colorScale'` |
+| priority      | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| cfvo          |          |         | 2到5个条件格式化值对象的数组，指定值范围内的航路点 |
+| color         |          |         | 在给定的航路点使用的相应颜色数组 |
+| style         |          |         | 如果比较返回 true，则应用样式结构 |
+
+### 图标集
+
+| 属性         | 可选 | 默认值 | 描述 |
+| ------------- | -------- | ------- | ----------- |
+| type          |          |         | `'iconSet'` |
+| priority      | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| iconSet       | Y        | 3TrafficLights | 设置使用的图标名称 |
+| showValue     |          | true    | 指定应用范围内的单元格是显示图标和单元格值，还是仅显示图标 |
+| reverse       |          | false   | 指定是否以保留顺序显示 `iconSet` 中指定的图标集中的图标。 如果 `custom` 等于 `true`，则必须忽略此值 |
+| custom        |          | false   | 指定是否使用自定义图标集 |
+| cfvo          |          |         | 2到5个条件格式化值对象的数组，指定值范围内的航路点 |
+| style         |          |         | 如果比较返回 true，则应用样式结构 |
+
+### 数据条
+
+| 字段      | 可选 | 默认值 | 描述 |
+| ---------- | -------- | ------- | ----------- |
+| type       |          |         | `'dataBar'` |
+| priority   | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| minLength  |          | 0       | 指定此条件格式范围内最短数据条的长度 |
+| maxLength  |          | 100     | 指定此条件格式范围内最长数据条的长度 |
+| showValue  |          | true    | 指定条件格式范围内的单元格是否同时显示数据条和数值或数据条 |
+| gradient   |          | true    | 指定数据条是否具有渐变填充 |
+| border     |          | true    | 指定数据条是否有边框 |
+| negativeBarColorSameAsPositive  |                | true        | 指定数据条是否具有与正条颜色不同的负条颜色 |
+| negativeBarBorderColorSameAsPositive  |          | true        | 指定数据条的负边框颜色是否不同于正边框颜色 |
+| axisPosition  |       | 'auto'             | 指定数据条的轴位置 |
+| direction  |          | 'leftToRight'      | 指定数据条的方向 |
+| cfvo          |          |         | 2 到 5 个条件格式化值对象的数组，指定值范围内的航路点 |
+| style         |          |         | 如果比较返回 true，则应用样式结构 |
+
+### 包含文字
+
+| 属性    | 可选 | 默认值 | 描述 |
+| -------- | -------- | ------- | ----------- |
+| type     |          |         | `'containsText'` |
+| priority | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| operator |          |         | 文本比较类型 |
+| text     |          |         | 要搜索的文本 |
+| style    |          |         | 如果比较返回 true，则应用样式结构 |
+
+**包含文本运算符**
+
+| 运算符          | 描述 |
+| ----------------- | ----------- |
+| containsText      | 如果单元格值包含在 `text` 字段中指定的值，则应用格式 |
+| containsBlanks    | 如果单元格值包含空格，则应用格式 |
+| notContainsBlanks | 如果单元格值不包含空格，则应用格式 |
+| containsErrors    | 如果单元格值包含错误，则应用格式 |
+| notContainsErrors | 如果单元格值不包含错误，则应用格式 |
+
+### 时间段
+
+| 属性      | 可选 | 默认值 | 描述 |
+| ---------- | -------- | ------- | ----------- |
+| type       |          |         | `'timePeriod'` |
+| priority   | Y        | &lt;auto&gt;  | 确定样式的优先顺序 |
+| timePeriod |          |         | 比较单元格值的时间段 |
+| style      |          |         | 如果比较返回 true，则应用样式结构 |
+
+**时间段**
+
+| 时间段       | 描述 |
+| ----------------- | ----------- |
+| lastWeek          | 如果单元格值落在最后一周内，则应用格式 |
+| thisWeek          | 如果单元格值在本周下降，则应用格式 |
+| nextWeek          | 如果单元格值在下一周下降，则应用格式 |
+| yesterday         | 如果单元格值等于昨天，则应用格式 |
+| today             | 如果单元格值等于今天，则应用格式 |
+| tomorrow          | 如果单元格值等于明天，则应用格式 |
+| last7Days         | 如果单元格值在过去7天之内，则应用格式 |
+| lastMonth         | 如果单元格值属于上个月，则应用格式 |
+| thisMonth         | 如果单元格值在本月下降，则应用格式 |
+| nextMonth         | 如果单元格值在下个月下降，则应用格式 |
+
+
+## 大纲级别
+
+Excel 支持大纲；行或列可以根据用户希望查看的详细程度展开或折叠。
+
+大纲级别可以在列设置中定义：
 ```javascript
 worksheet.columns = [
   { header: 'Id', key: 'id', width: 10 },
@@ -1204,16 +1698,16 @@ worksheet.getColumn(3).outlineLevel = 1;
 worksheet.getRow(3).outlineLevel = 1;
 ```
 
-可以在工作表上设置工作表大纲级别
+工作表大纲级别可以在工作表上设置
 ```javascript
 // 设置列大纲级别
 worksheet.properties.outlineLevelCol = 1;
 
-// set row outline level
+// 设置行大纲级别
 worksheet.properties.outlineLevelRow = 1;
 ```
 
-注意：调整行或列上的大纲级别或工作表上的大纲级别将产生副作用，即还修改受属性更改影响的所有行或列的折叠属性。例如。：
+注意：调整行或列上的大纲级别或工作表上的大纲级别将产生副作用，即还修改受属性更改影响的所有行或列的折叠属性。 例如。：
 ```javascript
 worksheet.properties.outlineLevelCol = 1;
 
@@ -1224,7 +1718,7 @@ worksheet.properties.outlineLevelCol = 2;
 expect(worksheet.getColumn(3).collapsed).to.be.false;
 ```
 
-可以在工作表上设置轮廓属性
+大纲属性可以在工作表上设置
 
 ```javascript
 worksheet.properties.outlineProperties = {
@@ -1233,34 +1727,30 @@ worksheet.properties.outlineProperties = {
 };
 ```
 
-## <a id="images">图片</a>
+## 图片
 
-将图像添加到工作表需要两个步骤。
-首先，通过addImage（）函数将图像添加到工作簿，该函数也将返回imageId值。
-然后，使用imageId，可以将图像作为平铺背景或覆盖单元格范围添加到工作表中。
+将图像添加到工作表是一个分为两个步骤的过程。首先，通过 `addImage()` 函数将图像添加到工作簿中，该函数还将返回 `imageId` 值。然后，使用 `imageId`，可以将图像作为平铺背景或覆盖单元格区域添加到工作表中。
 
-注意：从此版本开始，不支持调整或转换图像。
+注意：从此版本开始，不支持调整或变换图像。
 
-### <a id="add-image-to-workbook">将图像添加到工作簿</a>
+### 将图片添加到工作簿
 
-Workbook.addImage函数支持按文件名或缓冲区添加图像。
-请注意，在这两种情况下，都必须指定扩展名。
-有效的扩展值包括'jpeg'，'png'，'gif'。
+`Workbook.addImage` 函数支持按文件名或按 `Buffer` 添加图像。请注意，在两种情况下，都必须指定扩展名。有效的扩展名包括 “jpeg”，“png”，“gif”。
 
 ```javascript
-// add image to workbook by filename
+// 通过文件名将图像添加到工作簿
 var imageId1 = workbook.addImage({
   filename: 'path/to/image.jpg',
   extension: 'jpeg',
 });
 
-// add image to workbook by buffer
+// 通过 buffer 将图像添加到工作簿
 var imageId2 = workbook.addImage({
   buffer: fs.readFileSync('path/to.image.png'),
   extension: 'png',
 });
 
-// add image to workbook by base64
+// 通过 base64  将图像添加到工作簿
 var myBase64Image = "data:image/png;base64,iVBORw0KG...";
 var imageId2 = workbook.addImage({
   base64: myBase64Image,
@@ -1268,46 +1758,43 @@ var imageId2 = workbook.addImage({
 });
 ```
 
-### <a id="add-image-background-to-worksheet">将图像背景添加到工作表</a>
+### 将图片添加到工作表背景
 
-使用Workbook.addImage中的图像ID，可以使用addBackgroundImage函数设置工作表的背景
+使用 `Workbook.addImage` 中的图像 `ID`，可以使用 `addBackgroundImage` 函数设置工作表的背景
 
 ```javascript
-// set background
+// 设置背景
 worksheet.addBackgroundImage(imageId1);
 ```
 
-### <a id="add-image-over-a-range">在范围内添加图像</a>
+### 在一定范围内添加图片
 
-使用Workbook.addImage中的图像ID，可以在工作表中嵌入图像以覆盖范围。
-从该范围计算的坐标将覆盖从第一个单元格的左上角到第二个单元格的右下角。
+使用 `Workbook.addImage` 中的图像 `ID`，可以将图像嵌入工作表中以覆盖一定范围。从该范围计算出的坐标将覆盖从第一个单元格的左上角到第二个单元格的右下角。
 
 ```javascript
-// insert an image over B2:D6
+// 在 B2:D6 上插入图片
 worksheet.addImage(imageId2, 'B2:D6');
 ```
 
 使用结构而不是范围字符串，可以部分覆盖单元格。
 
-请注意，用于此的坐标系统为零，因此A1的左上角将为{col：0，row：0}。
-可以通过使用浮点数来指定单元的分数，例如， A1的中点是{col：0.5，row：0.5}。
+请注意，为此使用的坐标系基于零，因此 A1 的左上角将为 `{col：0，row：0}`。单元格的分数可以通过使用浮点数来指定，例如 A1 的中点是 `{col：0.5，row：0.5}`。
 
 ```javascript
-// insert an image over part of B2:D6
+// 在 B2:D6 的一部分上插入图像
 worksheet.addImage(imageId2, {
   tl: { col: 1.5, row: 1.5 },
   br: { col: 3.5, row: 5.5 }
 });
 ```
 
-单元格范围也可以具有“editAs”属性，它将控制图像如何锚定到单元格
-它可以具有以下值之一：
+单元格区域还可以具有属性 `"editAs"`，该属性将控制将图像锚定到单元格的方式。它可以具有以下值之一：
 
-| Value     | 描述 |
+| 值     | 描述 |
 | --------- | ----------- |
-| undefined | 这是默认值。它指定将使用单元格移动和调整图像大小 |
-| oneCell   | 图像将与单元格一起移动但不是大小 |
-| absolute  | 图像不会随单元格移动或调整大小 |
+| `undefined` | 它指定使图像将根据单元格移动和调整其大小 |
+| `oneCell`   | 这是默认值。图像将与单元格一起移动，但大小不变动 |
+| `absolute`  | 图像将不会随着单元格移动或调整大小 |
 
 ```javascript
 ws.addImage(imageId, {
@@ -1317,9 +1804,9 @@ ws.addImage(imageId, {
 });
 ```
 
-### <a id="add-image-to-a-cell">将图像添加到单元格</a>
+### 将图片添加到单元格
 
-You can add an image to a cell and then define its width and height in pixels at 96dpi.
+您可以将图像添加到单元格，然后以 96dpi 定义其宽度和高度（以像素为单位）。
 
 ```javascript
 worksheet.addImage(imageId2, {
@@ -1328,9 +1815,9 @@ worksheet.addImage(imageId2, {
 });
 ```
 
-### <a id="add-image-with-hyperlinks">添加带超链接的图片</a>
+### 添加带有超链接的图片
 
-You can add an image with hyperlinks to a cell.
+您可以将带有超链接的图像添加到单元格，并在图像范围内定义超链接。
 
 ```javascript
 worksheet.addImage(imageId2, {
@@ -1343,96 +1830,135 @@ worksheet.addImage(imageId2, {
 });
 ```
 
-## <a id="file-io">文件 I/O</a>
+## 工作表保护
 
-### <a id="xlsx">XLSX</a>
-
-#### <a id="reading-xlsx">读 XLSX</a>
+可以通过添加密码来保护工作表免受修改。
 
 ```javascript
-// read from a file
-var workbook = new Excel.Workbook();
-await workbook.xlsx.readFile(filename);
-// ... use workbook
-
-
-// read from a stream
-var workbook = new Excel.Workbook();
-await workbook.xlsx.read(stream);
-// ... use workbook
-
-
-// load from buffer
-var workbook = new Excel.Workbook();
-await workbook.xlsx.load(data);
-// ... use workbook
+await worksheet.protect('the-password', options);
 ```
 
-#### <a id="writing-xlsx">写 XLSX</a>
+工作表保护也可以删除：
 
-````javascript
-// write to a file
+```javascript
+worksheet.unprotect();
+```
+
+
+有关如何修改单个单元格保护的详细信息请查看 <a href="#单元格保护">单元格保护</a>。
+
+**注意：** 当 `protect()` 函数返回一个 Promise 代表它是异步的，当前的实现在主线程上运行，并且在 CPU 上将使用平均大约 600 毫秒。可以通过设置 `spinCount` 进行调整，该值可用于使过程更快或更有弹性。
+
+### 工作表保护选项
+
+| 属性               | 默认值 | 描述 |
+| ------------------- | ------- | ----------- |
+| selectLockedCells   | `true`    | 允许用户选择锁定的单元格 |
+| selectUnlockedCells | `true`    | 允许用户选择未锁定的单元格 |
+| formatCells         | `false`   | 允许用户格式化单元格 |
+| formatColumns       | `false`   | 允许用户格式化列 |
+| formatRows          | `false`   | 允许用户格式化行 |
+| insertRows          | `false`   | 允许用户插入行 |
+| insertColumns       | `false`   | 允许用户插入列 |
+| insertHyperlinks    | `false`   | 允许用户插入超链接 |
+| deleteRows          | `false`   | 允许用户删除行 |
+| deleteColumns       | `false`   | 允许用户删除列 |
+| sort                | `false`   | 允许用户对数据进行排序 |
+| autoFilter          | `false`   | 允许用户过滤表中的数据 |
+| pivotTables         | `false`   | 允许用户使用数据透视表 |
+| spinCount           | 100000  | 保护或取消保护时执行的哈希迭代次数 |
+
+
+## 文件 I/O
+
+### XLSX
+
+#### 读 XLSX
+
+```javascript
+// 从文件读取
+var workbook = new Excel.Workbook();
+await workbook.xlsx.readFile(filename);
+// ... 使用 workbook
+
+
+// 从流读取
+var workbook = new Excel.Workbook();
+await workbook.xlsx.read(stream);
+// ... 使用 workbook
+
+
+// 从 buffer 加载
+var workbook = new Excel.Workbook();
+await workbook.xlsx.load(data);
+// ... 使用 workbook
+```
+
+#### 写 XLSX
+
+```javascript
+// 写入文件
 var workbook = createAndFillWorkbook();
 await workbook.xlsx.writeFile(filename);
 
-// write to a stream
+// 写入流
 await workbook.xlsx.write(stream);
 
-// write to a new buffer
+// 写入 buffer
 const buffer = await workbook.xlsx.writeBuffer();
 ```
 
-### CSV <a id="csv">CSV</a>
+### CSV
 
-#### <a id="reading-csv">读 CSV</a>
+#### 读 CSV
 
-读取CSV文件时支持的选项。
+读取 CSV 文件时支持的选项。
 
-| Field            |  Required   |    Type     |Description  |
+| 属性            |  是否需要   |    类型     | 描述  |
 | ---------------- | ----------- | ----------- | ----------- |
-| dateFormats      |     N       |  Array      | 指定dayjs的日期编码格式 |
-| map              |     N       |  Function   | 自定义 Array.prototype.map() 的callback用于解析数据 |
-| sheetName        |     N       |  String     | 指定工作表名称 |
-| parserOptions    |     N       |  Object     | [parseOptions options](https://c2fo.io/fast-csv/docs/parsing/options) @fast-csv/parse模块以解析csv数据 |
+| dateFormats      |     N       |  Array      | 指定 dayjs 的日期编码格式。 |
+| map              |     N       |  Function   | 自定义`Array.prototype.map()` 回调函数，用于处理数据。 |
+| sheetName        |     N       |  String     | 指定工作表名称。 |
+| parserOptions    |     N       |  Object     | [parseOptions 选项](https://c2fo.io/fast-csv/docs/parsing/options)  @fast-csv/format 模块以写入 csv 数据。 |
 
 ```javascript
-// read from a file
+// 从文件读取
 var workbook = new Excel.Workbook();
 const worksheet = await workbook.csv.readFile(filename);
-// ... use workbook or worksheet
+// ... 使用 workbook 或 worksheet
 
 
-// read from a stream
+// 从流中读取
 var workbook = new Excel.Workbook();
 const worksheet = await workbook.csv.read(stream);
-// ... use workbook or worksheet
+// ... 使用 workbook 或 worksheet
 
 
-// read from a file with European Dates
+// 从带有欧洲日期的文件中读取
 var workbook = new Excel.Workbook();
 var options = {
   dateFormats: ['DD/MM/YYYY']
 };
 const worksheet = await workbook.csv.readFile(filename, options);
-// ... use workbook or worksheet
+// ... 使用 workbook 或 worksheet
 
 
-// read from a file with custom value parsing
+// 从具有自定义值解析的文件中读取
 var workbook = new Excel.Workbook();
 var options = {
   map(value, index) {
     switch(index) {
       case 0:
-        // column 1 is string
+        // 第1列是字符串
         return value;
       case 1:
-        // column 2 is a date
+        // 第2列是日期
         return new Date(value);
       case 2:
-        // column 3 is JSON of a formula value
+        // 第3列是公式值的JSON
         return JSON.parse(value);
       default:
-        // the rest are numbers
+        // 其余的是数字
         return parseFloat(value);
     }
   },
@@ -1443,72 +1969,69 @@ var options = {
   },
 };
 const worksheet = await workbook.csv.readFile(filename, options);
-// ... use workbook or worksheet
+// ... 使用 workbook 或 worksheet
 ```
 
-CSV解析器使用[fast-csv](https://www.npmjs.com/package/fast-csv)来读取CSV文件。
- 传递给上述读取函数的parserOptions选项将传递给@fast-csv/parse模块以解析csv数据。
- 有关详细信息，请参阅fast-csv README.md。
+CSV 解析器使用 [fast-csv](https://www.npmjs.com/package/fast-csv) 读取CSV文件。传递给上述写入函数的选项中的 `formatterOptions` 将传递给 @fast-csv/format 模块以写入 csv 数据。 有关详细信息，请参阅 fast-csv README.md。
 
-使用npm模块[moment](https://www.npmjs.com/package/moment)解析日期。
- 如果未提供dateFormats，则使用以下内容：
+使用 npm 模块 [dayjs](https://www.npmjs.com/package/dayjs) 解析日期。如果未提供 `dateFormats` 数组，则使用以下 dateFormats：
 
 * 'YYYY-MM-DD\[T\]HH:mm:ss'
 * 'MM-DD-YYYY'
 * 'YYYY-MM-DD'
 
-请参阅 [dayjs CustomParseFormat plugin](https://github.com/iamkun/dayjs/blob/HEAD/docs/en/Plugin.md#customparseformat)，以获取有关如何构造dateFormat的详细信息。
+请参阅 [dayjs CustomParseFormat 插件](https://github.com/iamkun/dayjs/blob/HEAD/docs/en/Plugin.md#customparseformat)，以获取有关如何构造 `dateFormat` 的详细信息。
 
-#### <a id="writing-csv">写 CSV</a>
+#### 写 CSV
 
-写入CSV文件时支持的选项。
-| Field            |  Required   |    Type     |Description  |
+写入 CSV 文件时支持的选项。
+
+| 属性            |  是否需要   |    类型     | 描述 |
 | ---------------- | ----------- | ----------- | ----------- |
-| dateFormat       |     N       |  String     | 指定dayjs的日期编码格式 |
-| dateUTC          |     N       |  Boolean    | 指定ExcelJS是否使用`dayjs.utc（）`转换时区以解析日期 |
-| encoding         |     N       |  String     | 指定文件编码格式 |
-| includeEmptyRows |     N       |  Boolean    | 指定是否可以写入空行 |
-| map              |     N       |  Function   | 自定义Array.prototype.map()的callback，用于处理行值 |
-| sheetName        |     N       |  String     | 指定工作表名称 |
-| sheetId          |     N       |  Number     | 指定工作表ID |
-| formatterOptions |     N       |  Object     | [formatterOptions options](https://c2fo.io/fast-csv/docs/formatting/options/) @fast-csv/format模块以写入csv数据 |
+| dateFormat       |     N       |  String     | 指定 dayjs 的日期编码格式。 |
+| dateUTC          |     N       |  Boolean    | 指定 ExcelJS 是否使用`dayjs.utc()`转换时区以解析日期。 |
+| encoding         |     N       |  String     | 指定文件编码格式。 |
+| includeEmptyRows |     N       |  Boolean    | 指定是否可以写入空行。 |
+| map              |     N       |  Function   | 自定义`Array.prototype.map()` 回调函数，用于处理行值。 |
+| sheetName        |     N       |  String     | 指定工作表名称。 |
+| sheetId          |     N       |  Number     | 指定工作表 ID。 |
+| formatterOptions |     N       |  Object     | [formatterOptions 选项](https://c2fo.io/fast-csv/docs/formatting/options/) @fast-csv/format 模块写入csv 数据。 |
 
 ```javascript
 
-// write to a file
+// 写入文件
 var workbook = createAndFillWorkbook();
 await workbook.csv.writeFile(filename);
 
-// write to a stream
-// Be careful that you need to provide sheetName or
-// sheetId for correct import to csv.
+// 写入流
+// 请注意，您需要提供 sheetName 或 sheetId 以正确导入到 csv
 await workbook.csv.write(stream, { sheetName: 'Page name' });
 
-// write to a file with European Date-Times
+// 使用欧洲日期时间写入文件
 var workbook = new Excel.Workbook();
 var options = {
   dateFormat: 'DD/MM/YYYY HH:mm:ss',
-  dateUTC: true, // use utc when rendering dates
+  dateUTC: true, // 呈现日期时使用 utc
 };
 await workbook.csv.writeFile(filename, options);
 
 
-// write to a file with custom value formatting
+// 使用自定义值格式写入文件
 var workbook = new Excel.Workbook();
 var options = {
   map(value, index) {
     switch(index) {
       case 0:
-        // column 1 is string
+        // 第1列是字符串
         return value;
       case 1:
-        // column 2 is a date
+        // 第2列是日期
         return moment(value).format('YYYY-MM-DD');
       case 2:
-        // column 3 is a formula, write just the result
+        // 第3列是一个公式，只写结果
         return value.result;
       default:
-        // the rest are numbers
+        // 其余的是数字
         return value;
     }
   },
@@ -1520,61 +2043,48 @@ var options = {
 };
 await workbook.csv.writeFile(filename, options);
 
-// write to a new buffer
+// 写入新 buffer
 const buffer = await workbook.csv.writeBuffer();
 ```
 
-CSV解析器使用[fast-csv]（https://www.npmjs.com/package/fast-csv）编写CSV文件。
- 传递给上述写入函数的选项中的formatterOptions将传递给@fast-csv/format模块以写入csv数据。
- 有关详细信息，请参阅@fast-csv README.md。
+CSV 解析器使用 [fast-csv](https://www.npmjs.com/package/fast-csv) 编写 CSV 文件。传递给上述写入函数的选项中的 `formatterOptions` 将传递给 @fast-csv/format 模块以写入 csv 数据。有关详细信息，请参阅 fast-csv README.md。
 
-使用npm模块格式化日期[moment]（https://www.npmjs.com/package/moment）。
- 如果未提供dateFormat，则使用moment.ISO_8601。
- 编写CSV时，您可以将布尔值dateUTC设置为true，以使ExcelJS自动解析日期
- 使用`moment.utc（）`转换时区。
+日期使用 npm 模块 [moment](https://www.npmjs.com/package/moment) 格式化。如果未提供 `dateFormat`，则使用 `moment.ISO_8601`。编写 CSV 时，您可以提供布尔值 `dateUTC` 为 `true`，以使 ExcelJS 解析日期，而无需使用 `moment.utc()` 自动转换时区。
 
-### <a id="streaming-io">流 I/O</a>
+### 流式 I/O
 
-上面记录的文件I / O要求在写入文件之前在内存中构建整个工作簿。
- 虽然方便，但由于所需的内存量，它可能会限制文档的大小。
+上面记录的文件 I/O 需要在内存中建立整个工作簿，然后才能写入文件。虽然方便，但是由于所需的内存量，它可能会限制文档的大小。
 
-流编写器（或读取器）在生成时处理工作簿或工作表数据，
- 将其转换为文件格式。通常情况下，这在内存上的效率要高得多
- 内存占用，甚至中间内存占用比文档版本更紧凑，
- 特别是当您认为行和单元格对象在提交后处理时。
+流写入器（或读取器）在生成工作簿或工作表数据时对其进行处理，然后将其转换为文件形式。通常，这在内存上效率要高得多，因为最终的内存占用量，甚至中间的内存占用量都比文档版本要紧凑得多，尤其是当您考虑到行和单元格对象一旦提交就被销毁时，尤其如此。
 
-流工作簿和工作表的界面几乎与文档版本相同，但有一些细微的实际差异：
+流式工作簿和工作表的接口几乎与文档版本相同，但实际存在一些细微差别：
 
-*将工作表添加到工作簿后，无法将其删除。
-*一旦提交了一行，它将不再可访问，因为它将从工作表中删除。
-*不支持unMergeCells（）。
+* 将工作表添加到工作簿后，将无法将其删除。
+* 提交行后，将无法再访问该行，因为该行将从工作表中删除。
+* 不支持 `unMergeCells()`。
 
-请注意，可以在不提交任何行的情况下构建整个工作簿。
- 提交工作簿时，将自动提交所有添加的工作表（包括所有未提交的行）。
- 但是，在这种情况下，文档版本的收益很少。
+请注意，可以在不提交任何行的情况下构建整个工作簿。提交工作簿后，所有添加的工作表（包括所有未提交的行）将自动提交。但是，在这种情况下，与文档版本相比收效甚微。
 
-#### <a id="streaming-xlsx">流 XLSX</a>
+#### 流式 XLSX
 
-##### Streaming XLSX Writer
+##### 流式 XLSX 写入器
 
-流式XLSX编写器在ExcelJS.stream.xlsx命名空间中可用。
+流式 XLSX 写入器在 `ExcelJS.stream.xlsx` 命名空间中可用。
 
-构造函数使用带有以下字段的可选选项对象：
+构造函数采用带有以下字段的可选 `options` 对象：
 
-| Field            | 描述 |
+| 字段            | 描述 |
 | ---------------- | ----------- |
-| stream           | Specifies a writable stream to write the XLSX workbook to. |
-| filename         | If stream not specified, this field specifies the path to a file to write the XLSX workbook to. |
-| useSharedStrings | Specifies whether to use shared strings in the workbook. Default is false |
-| useStyles        | Specifies whether to add style information to the workbook. Styles can add some performance overhead. Default is false |
+| stream           | 指定要写入 XLSX 工作簿的可写流。 |
+| filename         | 如果未指定流，则此字段指定要写入 XLSX 工作簿的文件的路径。 |
+| useSharedStrings | 指定是否在工作簿中使用共享字符串。默认为 `false` |
+| useStyles        | 指定是否将样式信息添加到工作簿。样式会增加一些性能开销。默认为 `false` |
+| zip              | ExcelJS 内部传递给 [Archiver](https://github.com/archiverjs/node-archiver) 的 [Zip选项](https://www.archiverjs.com/global.html#ZipOptions)。默认值为 `undefined` |
 
-如果选项中既未指定流也未指定文件名，则工作簿编写器将创建StreamBuf对象
- 这将把XLSX工作簿的内容存储在内存中。
- 这个StreamBuf对象可以通过属性workbook.stream访问，也可以用于
- 通过stream.read（）直接访问字节或将内容传递给另一个流。
+如果在选项中未指定 `stream` 或 `filename`，则工作簿编写器将创建一个 StreamBuf 对象，该对象将 XLSX 工作簿的内容存储在内存中。可以通过属性 `workbook.stream` 访问此 StreamBuf 对象，该对象可用于通过 `stream.read()` 直接访问字节，或将内容通过管道传输到另一个流。
 
 ```javascript
-// construct a streaming XLSX workbook writer with styles and shared strings
+// 使用样式和共享字符串构造流式 XLSX 工作簿编写器
 var options = {
   filename: './streamed-workbook.xlsx',
   useStyles: true,
@@ -1583,19 +2093,17 @@ var options = {
 var workbook = new Excel.stream.xlsx.WorkbookWriter(options);
 ```
 
-通常，流式XLSX编写器的接口与文档工作簿（和工作表）相同
- 如上所述，实际上行，单元格和样式对象是相同的。
+通常，流式 XLSX 写入器的接口与上述文档工作簿（和工作表）相同，实际上行，单元格和样式对象是相同的。
 
-然而，有一些差异......
+但是有一些区别...
 
-**施工**
+**构造**
 
-如上所示，WorkbookWriter通常需要在构造函数中指定输出流或文件。
+如上所示，WorkbookWriter 通常将要求在构造函数中指定输出流或文件。
 
 **提交数据**
 
-当工作表行准备就绪时，应该提交它以便可以释放行对象和内容。
- 通常，这将在添加每一行时完成...
+当工作表行准备就绪时，应将其提交，以便可以释放行对象和内容。通常，这将在添加每一行时完成...
 
 ```javascript
 worksheet.addRow({
@@ -1605,7 +2113,7 @@ worksheet.addRow({
 }).commit();
 ```
 
-WorksheetWriter在添加行时不提交行的原因是允许跨行合并单元格：
+WorksheetWriter 在添加行时不提交行的原因是允许单元格跨行合并：
 ```javascript
 worksheet.mergeCells('A1:B2');
 worksheet.getCell('A1').value = 'I am merged';
@@ -1617,182 +2125,227 @@ worksheet.getRow(2).commit(); // now rows 1 and two are committed.
 每个工作表完成后，还必须提交：
 
 ```javascript
-// Finished adding data. Commit the worksheet
+// 完成添加数据。 提交工作表
 worksheet.commit();
 ```
 
-要完成XLSX文档，必须提交工作簿。如果未提交工作簿中的任何工作表，
- 它们将作为工作簿提交的一部分自动提交。
+要完成 XLSX 文档，必须提交工作簿。 如果未提交工作簿中的任何工作表，则将在工作簿提交中自动提交它们。
 
 ```javascript
-// Finished the workbook.
+// 完成 workbook.
 await workbook.commit();
-// ... the stream has been written
+// ... 流已被写入
 ```
 
-# <a id="browser">浏览器</a>
+# 浏览器
 
-该库的一部分已经过隔离测试，可在浏览器环境中使用。
+该库的一部分已被隔离，并经过测试可在浏览器环境中使用。
 
-由于工作簿阅读器和工作簿编写器的流媒体特性，因此未包含这些内容。
-只能使用基于文档的工作簿（有关详细信息，请参阅<a href="#create-a-workbook">创建Workbook </a>）。
+由于工作簿读写器的流式传输性质，因此未包括这些内容。只能使用基于文档的工作簿（有关详细信息，请参见 <a href="#创建工作簿">创建工作簿</a>）。
 
-例如，在浏览器中使用ExcelJS的代码，请查看github中的<a href="https://github.com/exceljs/exceljs/tree/master/spec/browser"> spec / browser </a>文件夹回购。
+例如，在浏览器中使用 ExcelJS 的代码可查看 github 中的<a href="https://github.com/exceljs/exceljs/tree/master/spec/browser"> spec / browser </a>文件夹。
 
-## 预先捆绑
+## 预捆绑
 
-以下文件已预先捆绑并包含在dist文件夹中。
+以下文件已预先捆绑在一起，并包含在 *dist* 文件夹中。
 
 * exceljs.js
 * exceljs.min.js
 
-# <a id="value-types">值类型</a>
+# 值类型
 
 支持以下值类型。
 
-## <a id="null-value">空值</a>
+## Null 值
 
-Enum: Excel.ValueType.Null
+Enum: `Excel.ValueType.Null`
 
-空值表示缺少值，并且在写入文件时通常不会存储（合并单元格除外）。
-  它可用于从单元格中删除值。
-
-例如
+空值表示没有值，通常在写入文件时将不存储（合并的单元格除外）。可用于从单元格中删除该值。例如：
 
 ```javascript
 worksheet.getCell('A1').value = null;
 ```
 
-## <a id="merge-cell">合并单元格</a>
+## 合并单元格
 
-Enum: Excel.ValueType.Merge
+Enum: `Excel.ValueType.Merge`
 
-合并单元格的值与另一个“主”单元格绑定。
-  分配给合并单元将导致修改主单元。
+合并单元格是其值绑定到另一个“主”单元格的单元格。分配给合并单元将导致修改单元格。
 
-## <a id="number-value">数值</a>
+## 数字值
 
-Enum: Excel.ValueType.Number
+Enum: `Excel.ValueType.Number`
 
-A numeric value.
+一个数字值。
 
-E.g.
+例如：
 
 ```javascript
 worksheet.getCell('A1').value = 5;
 worksheet.getCell('A2').value = 3.14159;
 ```
 
-## <a id="string-value">字符串值</a>
+## 字符串值
 
-Enum: Excel.ValueType.String
+Enum: `Excel.ValueType.String`
 
-A simple text string.
+一个简单的文本字符串。
 
-E.g.
+例如：
 
 ```javascript
 worksheet.getCell('A1').value = 'Hello, World!';
 ```
 
-## <a id="date-value">日期值</a>
+## 日期值
 
-Enum: Excel.ValueType.Date
+Enum: `Excel.ValueType.Date`
 
-A date value, represented by the JavaScript Date type.
+日期值，由 JavaScript Date 类型表示。
 
-E.g.
+例如：
 
 ```javascript
 worksheet.getCell('A1').value = new Date(2017, 2, 15);
 ```
 
-## <a id="hyperlink-value">超链接值</a>
+## 超链接值
 
-Enum: Excel.ValueType.Hyperlink
+Enum: `Excel.ValueType.Hyperlink`
 
-A URL with both text and link value.
+具有文本和链接值的 URL。
 
-E.g.
+例如：
 ```javascript
-// link to web
+// 链接到网络
 worksheet.getCell('A1').value = {
   text: 'www.mylink.com',
   hyperlink: 'http://www.mylink.com',
   tooltip: 'www.mylink.com'
 };
 
-// internal link
+// 内部链接
 worksheet.getCell('A1').value = { text: 'Sheet2', hyperlink: '#\'Sheet2\'!A1' };
 ```
 
-## <a id="formula-value">公式值</a>
+## 公式值
 
-Enum: Excel.ValueType.Formula
+Enum: `Excel.ValueType.Formula`
 
-An Excel formula for calculating values on the fly.
-  Note that while the cell type will be Formula, the cell may have an effectiveType value that will
-  be derived from the result value.
+一个 Excel 公式，用于即时计算值。请注意，虽然单元格类型将为“公式”，但该单元格可能具有一个有效类型值，该值将从结果值中得出。
 
-Note that ExcelJS cannot process the formula to generate a result, it must be supplied.
+请注意，ExcelJS 无法处理公式以生成结果，必须提供该公式。
 
-E.g.
+例如：
 
 ```javascript
 worksheet.getCell('A3').value = { formula: 'A1+A2', result: 7 };
 ```
 
-Cells also support convenience getters to access the formula and result:
+单元格还支持便捷的获取器，以访问公式和结果：
 
 ```javascript
 worksheet.getCell('A3').formula === 'A1+A2';
 worksheet.getCell('A3').result === 7;
 ```
 
-### <a id="shared-formula">共享公式</a>
+### 共享公式
 
-Shared formulae enhance the compression of the xlsx document by increasing the repetition
-of text within the worksheet xml.
+共享的公式通过减少工作表 xml 中文本的重复来增强 xlsx 文档的压缩。范围中左上角的单元格是指定的母版，它将保留该范围内的所有其他单元格都将引用的公式。然后，其他“从属”单元格可以引用此主单元格，而不必再次重新定义整个公式。请注意，主公式将以常用的 Excel 方式转换为从属单元格，以便对其他单元格的引用将根据从属单元相对于主单元的偏移量向右下移。例如：如果主单元格A2具有引用A1的公式，则如果单元格B2共享A2的公式，则它将引用B1。
 
-A shared formula can be assigned to a cell using a new value form:
-
-```javascript
-worksheet.getCell('B3').value = { sharedFormula: 'A3', result: 10 };
-```
-
-This specifies that the cell B3 is a formula that will be derived from the formula in
-A3 and its result is 10.
-
-The formula convenience getter will translate the formula in A3 to what it should be in B3:
+可以将主公式与该范围内的从属单元格一起分配给该单元格
 
 ```javascript
-worksheet.getCell('B3').formula === 'B1+B2';
+worksheet.getCell('A2').value = {
+  formula: 'A1',
+  result: 10,
+  shareType: 'shared',
+  ref: 'A2:B3'
+};
 ```
 
-### <a id="formula-type">公式类型</a>
+可以使用新的值形式将共享公式分配给单元格：
 
-To distinguish between real and translated formula cells, use the formulaType getter:
+```javascript
+worksheet.getCell('B2').value = { sharedFormula: 'A2', result: 10 };
+```
+
+这指定单元格B2是将从A2中的公式派生的公式，其结果为10。
+
+公式便捷获取器会将A2中的公式转换为B2中应具有的公式：
+
+```javascript
+expect(worksheet.getCell('B2').formula).to.equal('B1');
+```
+
+可以使用 `fillFormula` 方法将共享的公式分配到工作表中：
+
+```javascript
+// 将 A1 设置为起始编号
+worksheet.getCell('A1').value = 1;
+
+// 从 A1 开始以递增计数将 A2 填充到 A10
+worksheet.fillFormula('A2:A10', 'A1+1', [2,3,4,5,6,7,8,9,10]);
+```
+
+`fillFormula` 也可以使用回调函数来计算每个单元格的值
+
+```javascript
+// 从A1开始以递增计数将 A2 填充到 A100
+worksheet.fillFormula('A2:A100', 'A1+1', (row, col) => row);
+```
+
+### 公式类型
+
+要区分真正的和转换后的公式单元格，请使用 FormulaType getter：
 
 ```javascript
 worksheet.getCell('A3').formulaType === Enums.FormulaType.Master;
 worksheet.getCell('B3').formulaType === Enums.FormulaType.Shared;
 ```
 
-Formula type has the following values:
+公式类型具有以下值：
 
-| Name                       |  Value  |
+| 名称                       |  值  |
 | -------------------------- | ------- |
 | Enums.FormulaType.None     |   0     |
 | Enums.FormulaType.Master   |   1     |
 | Enums.FormulaType.Shared   |   2     |
 
-## <a id="rich-text-value">富文本值</a>
+### 数组公式
 
-枚举： Excel.ValueType.RichText
+在 Excel 中表示共享公式的一种新方法是数组公式。以这种形式，主单元格是唯一包含与公式有关的任何信息的单元格。它包含 shareType 'array' 以及适用于其的单元格范围以及将要复制的公式。其余单元格是具有常规值的常规单元格。
 
-富文本格式。
+注意：数组公式不会以共享公式的方式转换。因此，如果主单元A2引用A1，则从单元B2也将引用A1。
 
-例如
+例如：
+```javascript
+// 将数组公式分配给 A2:B3
+worksheet.getCell('A2').value = {
+  formula: 'A1',
+  result: 10,
+  shareType: 'array',
+  ref: 'A2:B3'
+};
+
+// 可能没有必要填写工作表中的其余值
+```
+
+`fillFormula` 方法也可以用于填充数组公式
+
+```javascript
+// 用数组公式 "A1" 填充 A2:B3
+worksheet.fillFormula('A2:B3', 'A1', [1,1,1,1], 'array');
+```
+
+
+## 富文本值
+
+Enum: `Excel.ValueType.RichText`
+
+样式丰富的文本。
+
+例如：
 ```javascript
 worksheet.getCell('A1').value = {
   richText: [
@@ -1802,22 +2355,22 @@ worksheet.getCell('A1').value = {
 };
 ```
 
-## <a id="boolean-value">布尔值</a>
+## 布尔值
 
-枚举：Excel.ValueType.Boolean
+Enum: `Excel.ValueType.Boolean`
 
-例如
+例如：
 
 ```javascript
 worksheet.getCell('A1').value = true;
 worksheet.getCell('A2').value = false;
 ```
 
-## <a id="error-value">错误值</a>
+## 错误值
 
-枚举：Excel.ValueType.Error
+Enum: `Excel.ValueType.Error`
 
-例如
+例如：
 
 ```javascript
 worksheet.getCell('A1').value = { error: '#N/A' };
@@ -1826,7 +2379,7 @@ worksheet.getCell('A2').value = { error: '#VALUE!' };
 
 当前有效的错误文本值为：
 
-| Name                           | Value       |
+| 名称                           | 值       |
 | ------------------------------ | ----------- |
 | Excel.ErrorValue.NotApplicable | #N/A        |
 | Excel.ErrorValue.Ref           | #REF!       |
@@ -1838,87 +2391,85 @@ worksheet.getCell('A2').value = { error: '#VALUE!' };
 
 # 接口变化
 
-我们尽一切努力建立一个良好的一致界面，不会突破版本，但令人遗憾的是，现在有些事情必须改变以获得更大的利益。
+我们会尽一切努力创建一个良好的，一致的接口，该接口不会在版本之间不兼容，但令人遗憾的是，为了实现更大的利益，有时需要进行一些更改。
 
 ## 0.1.0
 
 ### Worksheet.eachRow
 
-Worksheet.eachRow的回调函数中的参数已被交换和更改;它是函数（rowNumber，rowValues），现在它是函数（row，rowNumber），它使它看起来更像是下划线（_.each）函数，并将行对象优先于行号。
+在 `Worksheet.eachRow` 的回调函数中的参数已被交换和更改；它是 `function(rowNumber，rowValues)`，现在是 `function(row，rowNumber)`，使它的外观更像 *underscore(`_.each`)方法，并且行对象优先于行号。*
 
 ### Worksheet.getRow
 
-此函数已从返回稀疏的单元格值数组更改为返回Row对象。这样可以访问行属性，并有助于管理行样式等。
+此函数已从返回稀疏的单元格数组更改为返回 `Row` 对象。这样可以访问行属性，并有助于管理行样式等。
 
-通过Worksheet.getRow（rowNumber）.values仍然可以获得稀疏的单元格值数组;
+仍可通过 `Worksheet.getRow(rowNumber).values;` 获得稀疏的单元格值的数组。
 
 ## 0.1.1
 
 ### cell.model
 
-cell.styles重命名为cell.style
+`cell.styles` 重命名为 `cell.style`
 
 ## 0.2.44
 
-从Bluebird切换到本机节点Promise的函数返回Promise，如果它们依赖Bluebird的额外功能，它可以破坏调用代码。
+从 Bluebird 切换到 Node 原生 Promise 的函数返回的 Promise 如果依赖 Bluebird 的额外功能，则可能会破坏调用代码。
 
-为了缓解这种情况，将以下两个更改添加到0.3.0：
+为了减少这种情况的出现，在0.3.0中添加了以下两个更改：
 
-* 默认情况下使用功能更全面且仍然与浏览器兼容的promise lib。这个lib支持Bluebird的许多功能，但占用空间要小得多。
-* 注入不同Promise实现的选项。有关详细信息，请参阅<a href="#config">配置</a>部分。
+* 默认情况下使用功能更全且仍与浏览器兼容的 promise lib。 该库支持 Bluebird 的许多功能，但占用空间少得多。
+* 注入其他 Promise 实现的选项。有关更多详细信息，请参见<a href="#配置">配置</a>部分。
 
-# <a id="config">配置</a>
 
-ExcelJS现在支持promise库的依赖注入。
-您可以通过在模块中包含以下代码来恢复Bluebird承诺...
+
+# 配置
+
+ExcelJS现在支持对 Promise 库的依赖项注入。您可以通过在模块中包含以下代码来还原 Bluebird Promise。
 
 ```javascript
 ExcelJS.config.setValue('promise', require('bluebird'));
 ```
 
-请注意：我已经专门用蓝鸟测试了ExcelJS（因为直到最近这是它使用的库）。
-从我所做的测试来看，它不适用于Q.
+请注意：我已经使用 bluebird 专门测试了 ExcelJS（直到最近，这是它使用的库）。根据我所做的测试，它不适用于 Q。
 
 # 注意事项
 
-## Dist文件夹
+## Dist 文件夹
 
-在发布此模块之前，源代码将被转换并以其他方式处理，然后再放入dist/文件夹中。
-本自述文件识别两个文件 - 浏览器化的捆绑包和缩小版本。
-除了package.json中指定为“main”的文件之外，不保证dist/文件夹的其他任何内容
+在发布此模块之前，先对源代码进行编译和其他处理，然后再将它们放置在 *dist/* 文件夹中。该自述文件标识两个文件-浏览器捆绑和压缩版本。除了在 package.json 中指定为  `"main"` 的文件外，不能保证 *dist/* 文件夹的其他内容。
 
 
-# <a id="known-issues">已知的问题</a>
+# 已知的问题
 
-## 使用Puppeteer进行测试
+## 使用 Puppeteer 进行测试
 
-此lib中包含的测试套件包括在无头浏览器中执行的小脚本，以验证捆绑的包。在撰写本文时，似乎该测试在Windows Linux子系统中不能很好地发挥作用。
+该 lib 中包含的测试套件包括一个在无头浏览器中执行的小脚本，以验证捆绑的软件包。 在撰写本文时，其表现出该测试在 Windows Linux 子系统中不能很好地进行。
 
-因此，可以通过名为.disable-test-browser的文件来禁用浏览器测试
+因此，可以通过存在名为 *.disable-test-browser* 的文件来禁用浏览器测试。
 
 ```bash
 sudo apt-get install libfontconfig
 ```
 
-## Splice vs Merge
+## splice 与合并
 
-如果任何拼接操作影响合并的单元格，则不会正确移动合并组
+如果任何 `splice` 操作影响合并的单元格，则合并组将无法正确移动
 
-# <a id="release-history">发布历史</a>
+# 发布历史
 
-| Version | Changes |
+| 版本 | 变化 |
 | ------- | ------- |
-| 0.0.9   | <ul><li><a href="#number-formats">Number Formats</a></li></ul> |
-| 0.1.0   | <ul><li>Bug Fixes<ul><li>"&lt;" and "&gt;" text characters properly rendered in xlsx</li></ul></li><li><a href="#columns">Better Column control</a></li><li><a href="#rows">Better Row control</a></li></ul> |
-| 0.1.1   | <ul><li>Bug Fixes<ul><li>More textual data written properly to xml (including text, hyperlinks, formula results and format codes)</li><li>Better date format code recognition</li></ul></li><li><a href="#fonts">Cell Font Style</a></li></ul> |
-| 0.1.2   | <ul><li>Fixed potential race condition on zip write</li></ul> |
-| 0.1.3   | <ul><li><a href="#alignment">Cell Alignment Style</a></li><li><a href="#rows">Row Height</a></li><li>Some Internal Restructuring</li></ul> |
-| 0.1.5   | <ul><li>Bug Fixes<ul><li>Now handles 10 or more worksheets in one workbook</li><li>theme1.xml file properly added and referenced</li></ul></li><li><a href="#borders">Cell Borders</a></li></ul> |
-| 0.1.6   | <ul><li>Bug Fixes<ul><li>More compatible theme1.xml included in XLSX file</li></ul></li><li><a href="#fills">Cell Fills</a></li></ul> |
-| 0.1.8   | <ul><li>Bug Fixes<ul><li>More compatible theme1.xml included in XLSX file</li><li>Fixed filename case issue</li></ul></li><li><a href="#fills">Cell Fills</a></li></ul> |
-| 0.1.9   | <ul><li>Bug Fixes<ul><li>Added docProps files to satisfy Mac Excel users</li><li>Fixed filename case issue</li><li>Fixed worksheet id issue</li></ul></li><li><a href="#set-workbook-properties">Core Workbook Properties</a></li></ul> |
-| 0.1.10  | <ul><li>Bug Fixes<ul><li>Handles File Not Found error</li></ul></li><li><a href="#csv">CSV Files</a></li></ul> |
-| 0.1.11  | <ul><li>Bug Fixes<ul><li>Fixed Vertical Middle Alignment Issue</li></ul></li><li><a href="#styles">Row and Column Styles</a></li><li><a href="#rows">Worksheet.eachRow supports options</a></li><li><a href="#rows">Row.eachCell supports options</a></li><li><a href="#columns">New function Column.eachCell</a></li></ul> |
+| 0.0.9   | <ul><li><a href="#数字格式">数字格式</a></li></ul> |
+| 0.1.0   | <ul><li>Bug 修复<ul><li>"&lt;" and "&gt;" 在 xlsx 中正确呈现的文本字符</li></ul></li><li><a href="#列">更好的列控制</a></li><li><a href="#行">更好的行控制</a></li></ul> |
+| 0.1.1   | <ul><li>Bug 修复<ul><li>可以将更多文本数据正确写入xml（包括文本，超链接，公式结果和格式代码）</li><li>更好的日期格式代码识别</li></ul></li><li><a href="#字体">单元格字体样式</a></li></ul> |
+| 0.1.2   | <ul><li>修复了 zip 写入时潜在的竞争条件</li></ul> |
+| 0.1.3   | <ul><li><a href="#对齐">单元格对齐样式</a></li><li><a href="#行">行高</a></li><li>一些内部重构</li></ul> |
+| 0.1.5   | <ul><li>Bug 修复<ul><li>现在可以在一本工作簿中处理10个或更多工作表</li><li>正确添加并引用了 theme1.xml 文件</li></ul></li><li><a href="#边框">单元格边框</a></li></ul> |
+| 0.1.6   | <ul><li>Bug 修复<ul><li>XLSX 文件中包含更兼容的 theme1.xml</li></ul></li><li><a href="#填充">单元格填充</a></li></ul> |
+| 0.1.8   | <ul><li>Bug 修复<ul><li>XLSX 文件中包含更兼容的theme1.xml</li><li>修复文件名大小写问题</li></ul></li><li><a href="#填充">单元格填充</a></li></ul> |
+| 0.1.9   | <ul><li>Bug 修复<ul><li>添加了 docProps 文件以满足 Mac Excel 用户</li><li>修复文件名大小写问题</li><li>修复工作表 ID 问题</li></ul></li><li><a href="#设置工作薄属性">核心工作簿属性</a></li></ul> |
+| 0.1.10  | <ul><li>Bug 修复<ul><li>处理找不到文件错误</li></ul></li><li><a href="#csv">CSV 文件</a></li></ul> |
+| 0.1.11  | <ul><li>Bug 修复<ul><li>修复垂直中间对齐问题</li></ul></li><li><a href="#样式">行与列样式</a></li><li><a href="#行">`Worksheet.eachRow` 支持选项参数</a></li><li><a href="#行">`Row.eachCell` 支持选项参数</a></li><li><a href="#列">新的方法 `Column.eachCell`</a></li></ul> |
 | 0.2.0   | <ul><li><a href="#streaming-xlxs-writer">Streaming XLSX Writer</a><ul><li>At long last ExcelJS can support writing massive XLSX files in a scalable memory efficient manner. Performance has been optimised and even smaller spreadsheets can be faster to write than the document writer. Options have been added to control the use of shared strings and styles as these can both have a considerable effect on performance</li></ul></li><li><a href="#rows">Worksheet.lastRow</a><ul><li>Access the last editable row in a worksheet.</li></ul></li><li><a href="#rows">Row.commit()</a><ul><li>For streaming writers, this method commits the row (and any previous rows) to the stream. Committed rows will no longer be editable (and are typically deleted from the worksheet object). For Document type workbooks, this method has no effect.</li></ul></li></ul> |
 | 0.2.2   | <ul><li><a href="https://pbs.twimg.com/profile_images/2933552754/fc8c70829ee964c5542ae16453503d37.jpeg">One Billion Cells</a><ul><li>Achievement Unlocked: A simple test using ExcelJS has created a spreadsheet with 1,000,000,000 cells. Made using random data with 100,000,000 rows of 10 cells per row. I cannot validate the file yet as Excel will not open it and I have yet to implement the streaming reader but I have every confidence that it is good since 1,000,000 rows loads ok.</li></ul></li></ul> |
 | 0.2.3   | <ul><li>Bug Fixes<ul><li><a href="https://github.com/exceljs/exceljs/issues/18">Merge Cell Styles</a><ul><li>Merged cells now persist (and parse) their styles.</li></ul></li></ul></li><li><a href="#streaming-xlxs-writer">Streaming XLSX Writer</a><ul><li>At long last ExcelJS can support writing massive XLSX files in a scalable memory efficient manner. Performance has been optimised and even smaller spreadsheets can be faster to write than the document writer. Options have been added to control the use of shared strings and styles as these can both have a considerable effect on performance</li></ul></li><li><a href="#rows">Worksheet.lastRow</a><ul><li>Access the last editable row in a worksheet.</li></ul></li><li><a href="#rows">Row.commit()</a><ul><li>For streaming writers, this method commits the row (and any previous rows) to the stream. Committed rows will no longer be editable (and are typically deleted from the worksheet object). For Document type workbooks, this method has no effect.</li></ul></li></ul> |
@@ -2025,4 +2576,21 @@ sudo apt-get install libfontconfig
 | 1.11.0  | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/776">Add the ability to bail out of parsing if the number of columns exceeds a given limit #776</a>. Many thanks to <a href="https://github.com/papandreou">Andreas Lind</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/799">Add support for repeated columns on every page when printing. #799</a>. Many thanks to <a href="https://github.com/FreakenK">Jasmin Auger</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/815">Do not use a promise polyfill on modern setups #815</a>. Many thanks to <a href="https://github.com/alubbe">Andreas Lubbe</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/807">copy LICENSE to the dist folder #807</a>. Many thanks to <a href="https://github.com/zypA13510">Yuping Zuo</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/813">Avoid unhandled rejection on XML parse error #813</a>. Many thanks to <a href="https://github.com/papandreou">Andreas Lind</a> for this contribution. </li> </ul> |
 | 1.12.0  | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/819">(chore) increment unzipper to 0.9.12 to address npm advisory 886 #819</a>. Many thanks to <a href="https://github.com/kreig303">Kreig Zimmerman</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/817">docs(README): improve docs #817</a>. Many thanks to <a href="https://github.com/zypA13510">Yuping Zuo</a> for this contribution. </li> <li> <p> Merged <a href="https://github.com/exceljs/exceljs/pull/823">add comment support #529 #823</a>. Many thanks to <a href="https://github.com/ilimei">ilimei</a> for this contribution. </p> <p>This fixes the following issues:</p> <ul> <li><a href="https://github.com/exceljs/exceljs/issues/202">Is it possible to add comment on a cell? #202</a></li> <li><a href="https://github.com/exceljs/exceljs/issues/451">Add comment to cell #451</a></li> <li><a href="https://github.com/exceljs/exceljs/issues/503">Excel add comment on cell #503</a></li> <li><a href="https://github.com/exceljs/exceljs/issues/529">How to add Cell comment #529</a></li> <li><a href="https://github.com/exceljs/exceljs/issues/707">Please add example to how I can insert comments for a cell #707</a></li> </ul> </li> </ul> |
 | 1.12.1  | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/822">fix issue with print area defined name corrupting file #822</a>. Many thanks to <a href="https://github.com/donaldsonjulia">Julia Donaldson</a> for this contribution. This fixes issue <a href="https://github.com/exceljs/exceljs/issues/664">Defined Names Break/Corrupt Excel File into Repair Mode #664</a>. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/831">Only keep at most 31 characters for sheetname #831</a>. Many thanks to <a href="https://github.com/kaleo211">Xuebin He</a> for this contribution. This fixes issue <a href="https://github.com/exceljs/exceljs/issues/398">Limit worksheet name length to 31 characters #398</a>. </li> </ul> |
-
+| 1.12.2  | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/834">add cn doc #834</a> and <a href="https://github.com/exceljs/exceljs/pull/852">update cn doc #852</a>. Many thanks to <a href="https://github.com/loverto">flydragon</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/853">fix minor spelling mistake in readme #853</a>. Many thanks to <a href="https://github.com/ridespirals">John Varga</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/855">Fix defaultRowHeight not working #855</a>. Many thanks to <a href="https://github.com/autukill">autukill</a> for this contribution. This should fix <a href="https://github.com/exceljs/exceljs/issues/422">row height doesn't apply to row #422</a>, <a href="https://github.com/exceljs/exceljs/issues/634">The worksheet.properties.defaultRowHeight can't work!! How to set the rows height, help!! #634</a> and <a href="https://github.com/exceljs/exceljs/issues/696">Default row height doesn't work ? #696</a>. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/854">Always keep first font #854</a>. Many thanks to <a href="https://github.com/dogusev">Dmitriy Gusev</a> for this contribution. This should fix <a href="https://github.com/exceljs/exceljs/issues/816">document scale (width only) is different after read & write #816</a>, <a href="https://github.com/exceljs/exceljs/issues/833">Default font from source document can not be parsed. #833</a> and <a href="https://github.com/exceljs/exceljs/issues/849">Wrong base font: hardcoded Calibri instead of font from the document #849</a>. </li> </ul> |
+| 1.13.0  | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/862">zip: allow tuning compression for performance or size #862</a>. Many thanks to <a href="https://github.com/myfreeer">myfreeer</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/863">Feat configure headers and footers #863</a>. Many thanks to <a href="https://github.com/autukill">autukill</a> for this contribution. </li> <li> Fixed an issue with defaultRowHeight where the default value resulted in 'customHeight' property being set. </li> </ul> |
+| 1.14.0  | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/874">Fix header and footer text format error in README.md #874</a>. Many thanks to <a href="https://github.com/autukill">autukill</a> for this contribution. </li> <li> Added Tables. See <a href="#tables">Tables</a> for details. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/887">fix: #877 and #880</a>. Many thanks to <a href="https://github.com/aexei">Alexander Heinrich</a> for this contribution. This fixes <a href="https://github.com/exceljs/exceljs/pull/877">bug: Hyperlink without text crashes write #877</a> and <a href="https://github.com/exceljs/exceljs/pull/880">bug: malformed comment crashes on write #880</a> </li> </ul> |
+| 1.15.0  | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/889">Add Compression level option to WorkbookWriterOptions for streaming #889</a>. Many thanks to <a href="https://github.com/ABenassi87">Alfredo Benassi</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/903">Feature/Cell Protection #903</a> and <a href="https://github.com/exceljs/exceljs/pull/907">Feature/Sheet Protection #907</a>. Many thanks to <a href="https://github.com/karabaesh">karabaesh</a> for these contributions. </li> </ul> |
+| 2.0.1   | <h2>Major Version Change</h2> <p>Introducing async/await to ExcelJS!</p> <p>The new async and await features of JavaScript can help a lot to make code more readable and maintainable. To avoid confusion, particularly with returned promises from async functions, we have had to remove the Promise class configuration option and from v2 onwards ExcelJS will use native Promises. Since this is potentially a breaking change we're bumping the major version for this release.</p> <h2>Changes</h2> <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/829">Introduce async/await #829</a>. Many thanks to <a href="https://github.com/alubbe">Andreas Lubbe</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/930">Update index.d.ts #930</a>. Many thanks to <a href="https://github.com/cosmonovallc">cosmonovallc</a> for this contributions. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/940">TS: Add types for addTable function #940</a>. Many thanks to <a href="https://github.com/egmen">egmen</a> for this contributions. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/926">added explicit return types to the type definitions of Worksheet.protect() and Worksheet.unprotect() #926</a>. Many thanks to <a href="https://github.com/drjokepu">Tamas Czinege</a> for this contributions. </li> <li> Dropped dependencies on Promise libraries. </li> </ul> |
+| 3.0.0   | <h2>Another Major Version Change</h2> <p>Javascript has changed a lot over the years, and so have the modules and technologies surrounding it. To this end, this major version of ExcelJS changes the structure of the publish artefacts:</p> <h3>Main Export is now the Original Javascript Source</h3> <p>Prior to this release, the transpiled ES5 code was exported as the package main. From now on, the package main comes directly from the lib/ folder. This means a number of dependencies have been removed, including the polyfills.</p> <h3>ES5 and Browserify are Still Included</h3> <p>In order to support those that still require ES5 ready code (e.g. as dependencies in web apps) the source code will still be transpiled and available  in dist/es5.</p> <p>The ES5 code is also browserified and available as dist/exceljs.js or dist/exceljs.min.js</p> <p><i>See the section <a href="#importing">Importing</a> for details</i></p> |
+| 3.1.0   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/873">Uprev fast-csv to latest version which does not use unsafe eval #873</a>. Many thanks to <a href="https://github.com/miketownsend">Mike Townsend</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/906">Exclude Infinity on createInputStream #906</a>. Many thanks to <a href="https://github.com/sophiedophie">Sophie Kwon</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/911">Feature/Add comments/notes to stream writer #911</a>. Many thanks to <a href="https://github.com/brunoargolo">brunoargolo</a> for this contribution. This fixes <a href="https://github.com/exceljs/exceljs/issues/868">Can't add cell comment using streaming WorkbookWriter #868</a> </li> <li> Fixed an issue with reading .xlsx files containing notes. This should resolve the following issues: <ul> <li><a href="https://github.com/exceljs/exceljs/issues/941">Reading comment/note from xlsx #941</a></li> <li><a href="https://github.com/exceljs/exceljs/issues/944">Excel.js doesn't parse comments/notes. #944</a></li> </ul> </li> </ul> |
+| 3.2.0   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/923">Add document for zip options of streaming WorkbookWriter #923</a>. Many thanks to <a href="https://github.com/piglovesyou">Soichi Takamura</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/933">array formula #933</a>. Many thanks to <a href="https://github.com/yoann-antoviaque">yoann-antoviaque</a> for this contribution. This fixes <a href="https://github.com/exceljs/exceljs/issues/932">broken array formula #932</a> and adds <a href="#array-formula">Array Formulae</a> to ExcelJS. </li> </ul> |
+| 3.3.0   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/892">Fix anchor.js #892</a>. Many thanks to <a href="https://github.com/wwojtkowski">Wojciech Wojtkowski</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/896">add xml:space="preserve" for all whitespaces #896</a>. Many thanks to <a href="https://github.com/sebikeller">Sebastian Keller</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/959">Add `shrinkToFit` to document and typing #959</a>. Many thanks to <a href="https://github.com/mozisan">('3')</a> for this contribution. This fixes <a href="https://github.com/exceljs/exceljs/issues/943">shrinkToFit property not on documentation #943</a>. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/980">#951: Force formula re-calculation on file open from Excel #980</a>. Many thanks to <a href="https://github.com/zymon">zymon</a> for this contribution. This fixes <a href="https://github.com/exceljs/exceljs/issues/951">Force formula re-calculation on file open from Excel #951</a>. </li> <li> Fixed <a href="https://github.com/exceljs/exceljs/issues/989">Lib contains class syntax, not compatible with IE11 #989</a>. </li> </ul> |
+| 3.3.1   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1000">Add headerFooter to worksheet model when importing from file #1000</a>. Many thanks to <a href="https://github.com/kigh-ota">Kaiichiro Ota</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1005">Update eslint plugins and configs #1005</a>, <a href="https://github.com/exceljs/exceljs/pull/1006">Drop grunt-lib-phantomjs #1006</a> and <a href="https://github.com/exceljs/exceljs/pull/1007">Rename .browserslintrc.txt to .browserslistrc #1007</a>. Many thanks to <a href="https://github.com/takenspc">Takeshi Kurosawa</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1012">Fix issue #988 #1012</a>. This fixes <a href="https://github.com/exceljs/exceljs/issues/988">Can not read excel file #988</a>. Many thanks to <a href="https://github.com/thambley">Todd Hambley</a> for this contribution. </li> </ul> |
+| 3.4.0   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1016">Feature/stream writer add background images #1016</a>. Many thanks to <a href="https://github.com/brunoargolo">brunoargolo</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1019">Fix issue # 991 #1019</a>. This fixes <a href="https://github.com/exceljs/exceljs/issues/991">read csv file issue #991</a>. Many thanks to <a href="https://github.com/LibertyNJ">Nathaniel J. Liberty</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1018">Large excels - optimize performance of writing file by excelJS + optimize generated file (MS excel opens it much faster) #1018</a>. Many thanks to <a href="https://github.com/pzawadzki82">Piotr</a> for this contribution. </li> </ul> |
+| 3.5.0   | <ul> <li> <a href="#conditional-formatting">Conditional Formatting</a> A subset of Excel Conditional formatting has been implemented! Specifically the formatting rules that do not require XML to be rendered inside an &lt;extLst&gt; node, or in other words everything except databar and three icon sets (3Triangles, 3Stars, 5Boxes). These will be implemented in due course </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1030">remove core-js/ import #1030</a>. Many thanks to <a href="https://github.com/bleuscyther">jeffrey n. carre</a> for this contribution. This change is used to create a new browserified bundle artefact that does not include any polyfills. See <a href="#browserify">Browserify</a> for details. </li> </ul> |
+| 3.6.0   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1042">1041 multiple print areas #1042</a>. Many thanks to <a href="https://github.com/AlexanderPruss">Alexander Pruss</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1058">fix typings for cell.note #1058</a>. Many thanks to <a href="https://github.com/xydens">xydens</a> for this contribution. </li> <li> <a href="#conditional-formatting">Conditional Formatting</a> has been completed. The &lt;extLst&gt; conditional formattings including dataBar and the three iconSet types (3Triangles, 3Stars, 5Boxes) are now available. </li> </ul> |
+| 3.6.1   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1047">Clarify merging cells by row/column numbers #1047</a>. Many thanks to <a href="https://github.com/kendallroth">Kendall Roth</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1048">Fix README mistakes concerning freezing views #1048</a>. Many thanks to <a href="https://github.com/overlookmotel">overlookmotel</a> for this contribution. </li> <li> Merged: <ul> <li><a href="https://github.com/exceljs/exceljs/pull/1073">fix issue #1045 horizontalCentered & verticalCentered in page not working #1073</a></li> <li><a href="https://github.com/exceljs/exceljs/pull/1082">Fix the problem of anchor failure of readme_zh.md file #1082</a></li> <li><a href="https://github.com/exceljs/exceljs/pull/1065">Fix problems caused by case of worksheet names #1065</a></li> </ul> Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> </ul> |
+| 3.7.0   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1076">Fix Issue #1075: Unable to read/write defaultColWidth attribute in &lt;sheetFormatPr&gt; node #1076</a>. Many thanks to <a href="https://github.com/kigh-ota">Kaiichiro Ota</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1078">function duplicateRows added #1078</a> and <a href="https://github.com/exceljs/exceljs/pull/1088">Duplicate rows #1088</a>. Many thanks to <a href="https://github.com/cbeltrangomez84">cbeltrangomez84</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1087">Prevent from unhandled promise rejection durning workbook load #1087</a>. Many thanks to <a href="https://github.com/sohai">Wojtek</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1071">fix issue #899 Support for inserting pictures with hyperlinks #1071</a>. Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1089">Update TS definition to reference proper internal libraries #1089</a>. Many thanks to <a href="https://github.com/jakawell">Jesse Kawell</a> for this contribution. </li> </ul> |
+| 3.8.0   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1090">Issue/Corrupt workbook using stream writer with background image #1090</a>. Many thanks to <a href="https://github.com/brunoargolo">brunoargolo</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1092">Fix index.d.ts #1092</a>. Many thanks to <a href="https://github.com/Siemienik">Siemienik Paweł</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1093">Wait for writing to tmp fiels before handling zip stream close #1093</a>. Many thanks to <a href="https://github.com/sohai">Wojtek</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1095">Support ArrayBuffer as an xlsx.load argument #1095</a>. Many thanks to <a href="https://github.com/sohai">Wojtek</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1099">Export shared strings with RichText #1099</a>. Many thanks to <a href="https://github.com/kigh-ota">Kaiichiro Ota</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1102">Keep borders of merged cells after rewriting an Excel workbook #1102</a>. Many thanks to <a href="https://github.com/kigh-ota">Kaiichiro Ota</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1104">Fix #1103: `editAs` not working #1104</a>. Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1105">Fix to issue #1101 #1105</a>. Many thanks to <a href="https://github.com/cbeltrangomez84">Carlos Andres Beltran Gomez</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1107">fix some errors and typos in readme #1107</a>. Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1112">Update issue templates #1112</a>. Many thanks to <a href="https://github.com/Siemienik">Siemienik Paweł</a> for this contribution. </li> </ul> |
+| 3.8.1   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1112">Update issue templates #1112</a>. Many thanks to <a href="https://github.com/Siemienik">Siemienik Paweł</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1124">Typo: Replace 'allways' with 'always' #1124</a>. Many thanks to <a href="https://github.com/Siemienik">Siemienik Paweł</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1125">Replace uglify with terser #1125</a>. Many thanks to <a href="https://github.com/alubbe">Andreas Lubbe</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1126">Apply codestyles on each commit and run lint:fix #1126</a>. Many thanks to <a href="https://github.com/alubbe">Andreas Lubbe</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1127">[WIP] Replace sax with saxes #1127</a>. Many thanks to <a href="https://github.com/alubbe">Andreas Lubbe</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1128">Add PR, Feature Request and Question github templates #1128</a>. Many thanks to <a href="https://github.com/alubbe">Andreas Lubbe</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1137">fix issue #749 Fix internal link example errors in readme #1137</a>. Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> </ul> |
+| 3.8.2   | <ul> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1133">Update @types/node version to latest lts #1133</a>. Many thanks to <a href="https://github.com/Siemienik">Siemienik Paweł</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1134">fix issue #1118 Adding Data Validation and Conditional Formatting to the same sheet causes corrupt workbook #1134</a>. Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1139">Add benchmarking #1139</a>. Many thanks to <a href="https://github.com/alubbe">Andreas Lubbe</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1148">fix issue #731 image extensions not be case sensitive #1148</a>. Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> <li> Merged <a href="https://github.com/exceljs/exceljs/pull/1169">fix issue #1165 and update index.d.ts #1169</a>. Many thanks to <a href="https://github.com/Alanscut">Alan Wang</a> for this contribution. </li> </ul> |


### PR DESCRIPTION
I re-translated the simplified Chinese document (zh-cn) by myself. The following are the reasons why I did this:

- When I used the `xlsx` package in my project, I encountered that exporting xlsx files could not add styles (it is said to be only available in the pro version). I found` exceljs` as an alternative and it was very easy to use.
- I found a Chinese document (#834 ) while viewing the document, but after reading it, I found it very disappointing, and the traces of machine translation are also obvious.

Therefore, I plan to re-translate to avoid misleading others. I am not a professional translator, but the documents will be corrected manually sentence by sentence. Due to the limitations of my personal level, errors inevitably occur. However, I can guarantee that most of them are correct.

---

The body part of the document has been completely translated, and the "Release History" part has not been completely translated yet. I will take the time to improve later.