### PR TITLE
Deprecate createInputStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1932,21 +1932,20 @@ faster or more resilient.
 ```javascript
 // read from a file
 var workbook = new Excel.Workbook();
-workbook.xlsx.readFile(filename)
-  .then(function() {
-    // use workbook
-  });
+await workbook.xlsx.readFile(filename);
+// ... use workbook
 
-// pipe from stream
+
+// read from a stream
 var workbook = new Excel.Workbook();
-stream.pipe(workbook.xlsx.createInputStream());
+await workbook.xlsx.read(stream);
+// ... use workbook
+
 
 // load from buffer
 var workbook = new Excel.Workbook();
-workbook.xlsx.load(data)
-  .then(function() {
-    // use workbook
-  });
+await workbook.xlsx.load(data);
+// ... use workbook
 ```
 
 #### Writing XLSX
@@ -1954,22 +1953,13 @@ workbook.xlsx.load(data)
 ```javascript
 // write to a file
 var workbook = createAndFillWorkbook();
-workbook.xlsx.writeFile(filename)
-  .then(function() {
-    // done
-  });
+await workbook.xlsx.writeFile(filename);
 
 // write to a stream
-workbook.xlsx.write(stream)
-  .then(function() {
-    // done
-  });
+await workbook.xlsx.write(stream);
 
 // write to a new buffer
-workbook.xlsx.writeBuffer()
-  .then(function(buffer) {
-    // done
-  });
+const buffer = await workbook.xlsx.writeBuffer();
 ```
 
 ### CSV
@@ -1988,31 +1978,24 @@ Options supported when reading CSV files.
 ```javascript
 // read from a file
 var workbook = new Excel.Workbook();
-workbook.csv.readFile(filename)
-  .then(worksheet => {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.readFile(filename);
+// ... use workbook or worksheet
+
 
 // read from a stream
 var workbook = new Excel.Workbook();
-workbook.csv.read(stream)
-  .then(worksheet => {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.read(stream);
+// ... use workbook or worksheet
 
-// pipe from stream
-var workbook = new Excel.Workbook();
-stream.pipe(workbook.csv.createInputStream());
 
 // read from a file with European Dates
 var workbook = new Excel.Workbook();
 var options = {
   dateFormats: ['DD/MM/YYYY']
 };
-workbook.csv.readFile(filename, options)
-  .then(worksheet => {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.readFile(filename, options);
+// ... use workbook or worksheet
+
 
 // read from a file with custom value parsing
 var workbook = new Excel.Workbook();
@@ -2039,10 +2022,8 @@ var options = {
     quote: false,
   },
 };
-workbook.csv.readFile(filename, options)
-  .then(function(worksheet) {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.readFile(filename, options);
+// ... use workbook or worksheet
 ```
 
 The CSV parser uses [fast-csv](https://www.npmjs.com/package/fast-csv) to read the CSV file.
@@ -2077,18 +2058,12 @@ Options supported when writing to a CSV file.
 
 // write to a file
 var workbook = createAndFillWorkbook();
-workbook.csv.writeFile(filename)
-  .then(() => {
-    // done
-  });
+await workbook.csv.writeFile(filename);
 
 // write to a stream
 // Be careful that you need to provide sheetName or
 // sheetId for correct import to csv.
-workbook.csv.write(stream, { sheetName: 'Page name' })
-  .then(() => {
-    // done
-  });
+await workbook.csv.write(stream, { sheetName: 'Page name' });
 
 // write to a file with European Date-Times
 var workbook = new Excel.Workbook();
@@ -2096,10 +2071,7 @@ var options = {
   dateFormat: 'DD/MM/YYYY HH:mm:ss',
   dateUTC: true, // use utc when rendering dates
 };
-workbook.csv.writeFile(filename, options)
-  .then(() => {
-    // done
-  });
+await workbook.csv.writeFile(filename, options);
 
 
 // write to a file with custom value formatting
@@ -2127,16 +2099,10 @@ var options = {
     quote: false,
   },
 };
-workbook.csv.writeFile(filename, options)
-  .then(() => {
-    // done
-  });
+await workbook.csv.writeFile(filename, options);
 
 // write to a new buffer
-workbook.csv.writeBuffer()
-  .then(function(buffer) {
-    // done
-  });
+const buffer = await workbook.csv.writeBuffer();
 ```
 
 The CSV parser uses [fast-csv](https://www.npmjs.com/package/fast-csv) to write the CSV file.
@@ -2242,10 +2208,8 @@ To complete the XLSX document, the workbook must be committed. If any worksheet 
 
 ```javascript
 // Finished the workbook.
-workbook.commit()
-  .then(function() {
-    // the stream has been written
-  });
+await workbook.commit();
+// ... the stream has been written
 ```
 
 # Browser

--- a/README_zh.md
+++ b/README_zh.md
@@ -1352,44 +1352,34 @@ worksheet.addImage(imageId2, {
 ```javascript
 // read from a file
 var workbook = new Excel.Workbook();
-workbook.xlsx.readFile(filename)
-  .then(function() {
-    // use workbook
-  });
+await workbook.xlsx.readFile(filename);
+// ... use workbook
 
-// pipe from stream
+
+// read from a stream
 var workbook = new Excel.Workbook();
-stream.pipe(workbook.xlsx.createInputStream());
+await workbook.xlsx.read(stream);
+// ... use workbook
+
 
 // load from buffer
 var workbook = new Excel.Workbook();
-workbook.xlsx.load(data)
-  .then(function() {
-    // use workbook
-  });
+await workbook.xlsx.load(data);
+// ... use workbook
 ```
 
 #### <a id="writing-xlsx">写 XLSX</a>
 
-```javascript
+````javascript
 // write to a file
 var workbook = createAndFillWorkbook();
-workbook.xlsx.writeFile(filename)
-  .then(function() {
-    // done
-  });
+await workbook.xlsx.writeFile(filename);
 
 // write to a stream
-workbook.xlsx.write(stream)
-  .then(function() {
-    // done
-  });
+await workbook.xlsx.write(stream);
 
 // write to a new buffer
-workbook.xlsx.writeBuffer()
-  .then(function(buffer) {
-    // done
-  });
+const buffer = await workbook.xlsx.writeBuffer();
 ```
 
 ### CSV <a id="csv">CSV</a>
@@ -1408,31 +1398,24 @@ workbook.xlsx.writeBuffer()
 ```javascript
 // read from a file
 var workbook = new Excel.Workbook();
-workbook.csv.readFile(filename)
-  .then(worksheet => {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.readFile(filename);
+// ... use workbook or worksheet
+
 
 // read from a stream
 var workbook = new Excel.Workbook();
-workbook.csv.read(stream)
-  .then(worksheet => {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.read(stream);
+// ... use workbook or worksheet
 
-// pipe from stream
-var workbook = new Excel.Workbook();
-stream.pipe(workbook.csv.createInputStream());
 
 // read from a file with European Dates
 var workbook = new Excel.Workbook();
 var options = {
   dateFormats: ['DD/MM/YYYY']
 };
-workbook.csv.readFile(filename, options)
-  .then(worksheet => {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.readFile(filename, options);
+// ... use workbook or worksheet
+
 
 // read from a file with custom value parsing
 var workbook = new Excel.Workbook();
@@ -1459,10 +1442,8 @@ var options = {
     quote: false,
   },
 };
-workbook.csv.readFile(filename, options)
-  .then(function(worksheet) {
-    // use workbook or worksheet
-  });
+const worksheet = await workbook.csv.readFile(filename, options);
+// ... use workbook or worksheet
 ```
 
 CSV解析器使用[fast-csv](https://www.npmjs.com/package/fast-csv)来读取CSV文件。
@@ -1496,18 +1477,12 @@ CSV解析器使用[fast-csv](https://www.npmjs.com/package/fast-csv)来读取CSV
 
 // write to a file
 var workbook = createAndFillWorkbook();
-workbook.csv.writeFile(filename)
-  .then(() => {
-    // done
-  });
+await workbook.csv.writeFile(filename);
 
 // write to a stream
 // Be careful that you need to provide sheetName or
 // sheetId for correct import to csv.
-workbook.csv.write(stream, { sheetName: 'Page name' })
-  .then(() => {
-    // done
-  });
+await workbook.csv.write(stream, { sheetName: 'Page name' });
 
 // write to a file with European Date-Times
 var workbook = new Excel.Workbook();
@@ -1515,10 +1490,7 @@ var options = {
   dateFormat: 'DD/MM/YYYY HH:mm:ss',
   dateUTC: true, // use utc when rendering dates
 };
-workbook.csv.writeFile(filename, options)
-  .then(() => {
-    // done
-  });
+await workbook.csv.writeFile(filename, options);
 
 
 // write to a file with custom value formatting
@@ -1546,16 +1518,10 @@ var options = {
     quote: false,
   },
 };
-workbook.csv.writeFile(filename, options)
-  .then(() => {
-    // done
-  });
+await workbook.csv.writeFile(filename, options);
 
 // write to a new buffer
-workbook.csv.writeBuffer()
-  .then(function(buffer) {
-    // done
-  });
+const buffer = await workbook.csv.writeBuffer();
 ```
 
 CSV解析器使用[fast-csv]（https://www.npmjs.com/package/fast-csv）编写CSV文件。
@@ -1660,10 +1626,8 @@ worksheet.commit();
 
 ```javascript
 // Finished the workbook.
-workbook.commit()
-  .then(function() {
-    // the stream has been written
-  });
+await workbook.commit();
+// ... the stream has been written
 ```
 
 # <a id="browser">浏览器</a>

--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -53,8 +53,11 @@ class CSV {
     });
   }
 
+  /**
+   * @deprecated since version 4.0. You should use `CSV#read` instead. Please follow upgrade instruction: https://github.com/exceljs/exceljs/blob/master/UPGRADE-4.0.md
+   */
   createInputStream(options) {
-    console.warn('`CSV#createInputStream` is deprecated. You should use `CSV#read` instead. This method will be removed in version 4.0');
+    console.warn('`CSV#createInputStream` is deprecated. You should use `CSV#read` instead. This method will be removed in version 4.0. Please follow upgrade instruction: https://github.com/exceljs/exceljs/blob/master/UPGRADE-4.0.md');
     return this._createInputStream(options);
   }
 

--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -45,7 +45,7 @@ class CSV {
   read(stream, options) {
     options = options || {};
     return new Promise((resolve, reject) => {
-      const csvStream = this.createInputStream(options)
+      const csvStream = this._createInputStream(options)
         .on('worksheet', resolve)
         .on('error', reject);
 
@@ -54,6 +54,11 @@ class CSV {
   }
 
   createInputStream(options) {
+    console.warn('`CSV#createInputStream` is deprecated. You should use `CSV#read` instead. This method will be removed in version 4.0');
+    return this._createInputStream(options);
+  }
+
+  _createInputStream(options) {
     options = options || {};
     const worksheet = this.workbook.addWorksheet(options.sheetName);
 

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -222,6 +222,11 @@ class XLSX {
   }
 
   createInputStream(options) {
+    console.warn('`XLSX#createInputStream` is deprecated. You should use `XLSX#read` instead. This method will be removed in version 4.0');
+    return this._createInputStream(options);
+  }
+
+  _createInputStream(options) {
     const model = {
       worksheets: [],
       worksheetHash: {},
@@ -362,7 +367,7 @@ class XLSX {
   read(stream, options) {
     return new Promise((resolve, reject) => {
       options = options || {};
-      const zipStream = this.createInputStream(options);
+      const zipStream = this._createInputStream(options);
       zipStream
         .on('done', () => {
           resolve(this.workbook);
@@ -378,7 +383,7 @@ class XLSX {
     if (options === undefined) {
       options = {};
     }
-    const zipStream = this.createInputStream();
+    const zipStream = this._createInputStream();
     return new Promise((resolve, reject) => {
       zipStream
         .on('done', () => {

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -221,8 +221,11 @@ class XLSX {
     });
   }
 
+   /**
+   * @deprecated since version 4.0. You should use `#read` instead. Please follow upgrade instruction: https://github.com/exceljs/exceljs/blob/master/UPGRADE-4.0.md
+   */
   createInputStream(options) {
-    console.warn('`XLSX#createInputStream` is deprecated. You should use `XLSX#read` instead. This method will be removed in version 4.0');
+    console.warn('`XLSX#createInputStream` is deprecated. You should use `XLSX#read` instead. This method will be removed in version 4.0. Please follow upgrade instruction: https://github.com/exceljs/exceljs/blob/master/UPGRADE-4.0.md');
     return this._createInputStream(options);
   }
 


### PR DESCRIPTION
As discussed in https://github.com/exceljs/exceljs/pull/1135, let's deprecate `createInputStream` in favour of the `read` methods in 4.0