### PR TITLE
fix: load tables correctly when reading from disk

### DIFF
--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -768,6 +768,7 @@ class Worksheet {
   }
 
   set model(value) {
+    const that = this;
     this.name = value.name;
     this._columns = Column.fromModel(this, value.cols);
     this._parseRows(value);
@@ -782,8 +783,32 @@ class Worksheet {
     this._media = value.media.map(medium => new Image(this, medium));
     this.sheetProtection = value.sheetProtection;
     this.tables = value.tables.reduce((tables, table) => {
-      const t = new Table();
-      t.model = table;
+      /**
+       * Once we have the table information and the sheet we can add the rows related to it.
+       * We parse the start and end via the reference and then we iterate over all the
+       * cells the sheet has to see if they are inside the table to add their values to its rows.
+       */
+      const [,startColumnStr, startRowStr, endColumnStr, endRowStr] = /(\D+)(\d+):(\D+)(\d+)/i.exec(table.tableRef);
+      const startColumn = startColumnStr.toUpperCase().charCodeAt(0) - 64;
+      const endColumn = endColumnStr.toUpperCase().charCodeAt(0) - 64;
+      const startRow = parseInt(startRowStr, 10);
+      const endRow = parseInt(endRowStr, 10);
+      const offset = table.headerRow ? 1 : 0;
+      const rows = [];
+
+      for(let i = (startRow + offset); i <= endRow; i++){
+        const rowValues = [];
+        that.getRow(i).eachCell((cell, colNumber) =>{
+          if(colNumber >= startColumn && colNumber <= endColumn){
+            rowValues.push(cell.value);
+          }
+        });
+      }
+
+      table.rows = rows;
+
+      // Need to pass `that` so the table has a sheet associated
+      const t = new Table(that, table);
       tables[table.name] = t;
       return tables;
     }, {});

--- a/lib/xlsx/xform/table/table-xform.js
+++ b/lib/xlsx/xform/table/table-xform.js
@@ -64,6 +64,7 @@ class TableXform extends BaseXform {
         this.model = {
           name: attributes.name,
           displayName: attributes.displayName || attributes.name,
+          ref: attributes.ref,
           tableRef: attributes.ref,
           totalsRow: attributes.totalsRowCount === '1',
           headerRow: attributes.headerRowCount === '1',

--- a/spec/unit/xlsx/xform/table/data/table.1.3.json
+++ b/spec/unit/xlsx/xform/table/data/table.1.3.json
@@ -1,6 +1,7 @@
 {
   "name": "TestTable",
   "displayName": "TestTable",
+  "ref": "A1:C16",
   "tableRef": "A1:C16",
   "autoFilterRef": "A1:C15",
   "totalsRow": true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fix #1062

When reading the tables from a xlsx file on disk the row information was completely missing and thus causing issues when trying to add new ones.
Also when reading from disk the property `ref ` of table was missing. I saw it was being added in `render` but `validate` will crash unless it's there so I added it as well.

## Test plan

I've updated the tests to pass. Also if you run the code in #1062 it should work now and append a new row.

Also there seems to be some `eslint` issues in `worksheet.js`. I haven't fixed them but I had to do the commit using `--no-verify`.