### PR TITLE
Upgrade tmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "proxyquire": "^2.1.3",
     "readable-stream": "^3.6.0",
     "saxes": "^5.0.1",
-    "tmp": "^0.1.0",
+    "tmp": "^0.2.0",
     "unzipper": "^0.10.11",
     "uuid": "^7.0.3"
   },


### PR DESCRIPTION
This finally resolves #882
I've checked the changelog and none of the breaking changes affect us. `tmp` is also still compatbile with node v8, it just bumped its minimum requirement to the latest version of v8 to satifsfy its linter.