### PR TITLE
Compare asset sizes on pull requests

### DIFF
--- a/.github/workflows/asset-size.yml
+++ b/.github/workflows/asset-size.yml
@@ -1,0 +1,18 @@
+name: Asset size
+
+on: [pull_request]
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: chrysanthos/simple-asset-size-reporter@1.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          files: '["dist/*.js"]'
+          with-same: "false"
+          build-assets: "npm run install-build"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "benchmark": "node --expose-gc benchmark",
     "benchmark:debug": "node --expose-gc --inspect-brk --trace-deopt benchmark",
     "build": "grunt build",
+    "install-build": "npm install && grunt build",
     "preversion": "npm run clean && npm run build && npm run test:version",
     "postversion": "git push --no-verify && git push --tags --no-verify"
   },


### PR DESCRIPTION
## Summary

This PR adds a Github Action that runs on PRs that compares the build output asset sizes with master. This way, it is much easier to notice if a PR adds considerable size to the library.

This should help with issues like https://github.com/exceljs/exceljs/issues/1236 in the future.

It looks like this in action:
https://github.com/mydea/exceljs/pull/2

