### PR TITLE
Fixed #1276

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -62,6 +62,7 @@ module.exports = function(grunt) {
         output: {
           preamble: '/*! ExcelJS <%= grunt.template.today("dd-mm-yyyy") %> */\n',
         },
+        ascii_only: true
       },
       dist: {
         files: {


### PR DESCRIPTION
## Summary
Fixed [BUG] Invalid regular expression: /^[ -íŸ¿î€€-ï¿½ð€€-ô¿¿]$/: Range out of order in character class.
This was due to terser wrongly converting characters inside string literals.
Ref: https://github.com/terser/terser/issues/410

## Test plan
Tried new min js. Works fine. No such issue exists. 
