### PR TITLE
Do not include IE11 fix by default, let the users import it when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ const ExcelJS = require('exceljs/dist/es5');
 ```javascript
 // polyfills required by exceljs
 require('core-js/modules/es.promise');
+require('core-js/modules/es.string.includes');
 require('core-js/modules/es.object.assign');
 require('core-js/modules/es.object.keys');
 require('regenerator-runtime/runtime');

--- a/README_zh.md
+++ b/README_zh.md
@@ -190,6 +190,7 @@ const ExcelJS = require('exceljs/dist/es5');
 ```javascript
 // exceljs 所需的 polyfills
 require('core-js/modules/es.promise');
+require('core-js/modules/es.string.includes');
 require('core-js/modules/es.object.assign');
 require('core-js/modules/es.object.keys');
 require('regenerator-runtime/runtime');

--- a/lib/exceljs.browser.js
+++ b/lib/exceljs.browser.js
@@ -1,25 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies,node/no-unpublished-require */
 require('core-js/modules/es.promise');
-require('core-js/modules/es.string.includes');
 require('core-js/modules/es.object.assign');
 require('core-js/modules/es.object.keys');
 require('regenerator-runtime/runtime');
-
-const rewritePattern = require('regexpu-core');
-const {generateRegexpuOptions} = require('@babel/helper-create-regexp-features-plugin/lib/util');
-
-const {RegExp} = global;
-try {
-  RegExp('a', 'u');
-} catch (err) {
-  global.RegExp = function(pattern, flags) {
-    if (flags && flags.includes('u')) {
-      return new RegExp(rewritePattern(pattern, flags, generateRegexpuOptions({flags, pattern})));
-    }
-    return new RegExp(pattern, flags);
-  };
-  global.RegExp.prototype = RegExp;
-}
 
 const ExcelJS = {
   Workbook: require('./doc/workbook'),

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
   "devDependencies": {
     "@babel/cli": "^7.6.4",
     "@babel/core": "^7.9.0",
-    "@babel/helper-create-regexp-features-plugin": "^7.8.8",
     "@babel/preset-env": "^7.9.5",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
@@ -140,7 +139,6 @@
     "prettier-eslint": "^9.0.0",
     "prettier-eslint-cli": "^5.0.0",
     "regenerator-runtime": "^0.13.5",
-    "regexpu-core": "^4.7.0",
     "ts-node": "^8.9.0",
     "typescript": "^3.8.3"
   }


### PR DESCRIPTION
It adds 20KB to the build, which not everyone needs
See https://github.com/exceljs/exceljs/issues/1236