### PR TITLE
Use rest args instead of slicing arguments

### DIFF
--- a/lib/doc/row.js
+++ b/lib/doc/row.js
@@ -3,7 +3,7 @@
 const _ = require('../utils/under-dash');
 
 const Enums = require('./enums');
-const colCache = require('./../utils/col-cache');
+const colCache = require('../utils/col-cache');
 const Cell = require('./cell');
 
 class Row {
@@ -74,8 +74,7 @@ class Row {
   }
 
   // remove cell(s) and shift all higher cells down by count
-  splice(start, count) {
-    const inserts = Array.prototype.slice.call(arguments, 2);
+  splice(start, count, ...inserts) {
     const nKeep = start + count;
     const nExpand = inserts.length - count;
     const nEnd = this._cells.length;

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -211,9 +211,7 @@ class Worksheet {
     return this._columns[c - 1];
   }
 
-  spliceColumns(start, count) {
-    // each member of inserts is a column of data.
-    const inserts = Array.prototype.slice.call(arguments, 2);
+  spliceColumns(start, count, ...inserts) {
     const rows = this._rows;
     const nRows = rows.length;
     if (inserts.length > 0) {
@@ -368,9 +366,8 @@ class Worksheet {
     }
   }
 
-  spliceRows(start, count) {
+  spliceRows(start, count, ...inserts) {
     // same problem as row.splice, except worse.
-    const inserts = Array.prototype.slice.call(arguments, 2);
     const nKeep = start + count;
     const nExpand = inserts.length - count;
     const nEnd = this._rows.length;
@@ -476,13 +473,13 @@ class Worksheet {
   // Merge
 
   // convert the range defined by ['tl:br'], [tl,br] or [t,l,b,r] into a single 'merged' cell
-  mergeCells() {
-    const dimensions = new Range(Array.prototype.slice.call(arguments, 0)); // convert arguments into Array
+  mergeCells(...cells) {
+    const dimensions = new Range(cells);
     this._mergeCellsInternal(dimensions);
   }
 
-  mergeCellsWithoutStyle() {
-    const dimensions = new Range(Array.prototype.slice.call(arguments, 0)); // convert arguments into Array
+  mergeCellsWithoutStyle(...cells) {
+    const dimensions = new Range(cells);
     this._mergeCellsInternal(dimensions, true);
   }
 
@@ -530,8 +527,8 @@ class Worksheet {
   // scan the range defined by ['tl:br'], [tl,br] or [t,l,b,r] and if any cell is part of a merge,
   // un-merge the group. Note this function can affect multiple merges and merge-blocks are
   // atomic - either they're all merged or all un-merged.
-  unMergeCells() {
-    const dimensions = new Range(Array.prototype.slice.call(arguments, 0)); // convert arguments into Array
+  unMergeCells(...cells) {
+    const dimensions = new Range(cells);
 
     // find any cells in that range and unmerge them
     for (let i = dimensions.top; i <= dimensions.bottom; i++) {

--- a/lib/stream/xlsx/worksheet-writer.js
+++ b/lib/stream/xlsx/worksheet-writer.js
@@ -420,9 +420,9 @@ class WorksheetWriter {
     return row.getCellEx(address);
   }
 
-  mergeCells() {
+  mergeCells(...cells) {
     // may fail if rows have been comitted
-    const dimensions = new Dimensions(Array.prototype.slice.call(arguments, 0)); // convert arguments into Array
+    const dimensions = new Dimensions(cells);
 
     // check cells aren't already merged
     this._merges.forEach(merge => {

--- a/lib/utils/under-dash.js
+++ b/lib/utils/under-dash.js
@@ -3,7 +3,7 @@ const {toString} = Object.prototype;
 const _ = {
   each: function each(obj, cb) {
     if (obj) {
-      if (_.isArray(obj)) {
+      if (Array.isArray(obj)) {
         obj.forEach(cb);
       } else {
         Object.keys(obj).forEach(key => {
@@ -15,7 +15,7 @@ const _ = {
 
   some: function some(obj, cb) {
     if (obj) {
-      if (_.isArray(obj)) {
+      if (Array.isArray(obj)) {
         return obj.some(cb);
       }
       return Object.keys(obj).some(key => cb(obj[key], key));
@@ -25,7 +25,7 @@ const _ = {
 
   every: function every(obj, cb) {
     if (obj) {
-      if (_.isArray(obj)) {
+      if (Array.isArray(obj)) {
         return obj.every(cb);
       }
       return Object.keys(obj).every(key => cb(obj[key], key));
@@ -35,7 +35,7 @@ const _ = {
 
   map: function map(obj, cb) {
     if (obj) {
-      if (_.isArray(obj)) {
+      if (Array.isArray(obj)) {
         return obj.map(cb);
       }
       return Object.keys(obj).map(key => cb(obj[key], key));
@@ -53,8 +53,8 @@ const _ = {
   isEqual: function isEqual(a, b) {
     const aType = typeof a;
     const bType = typeof b;
-    const aArray = _.isArray(a);
-    const bArray = _.isArray(b);
+    const aArray = Array.isArray(a);
+    const bArray = Array.isArray(b);
 
     if (aType !== bType) {
       return false;
@@ -102,10 +102,6 @@ const _ = {
     return toString.call(val) === '[object Undefined]';
   },
 
-  isArray(val) {
-    return toString.call(val) === '[object Array]';
-  },
-
   isObject(val) {
     return toString.call(val) === '[object Object]';
   },
@@ -118,11 +114,11 @@ const _ = {
 
     function assignValue(val, key) {
       src = target[key];
-      copyIsArray = _.isArray(val);
+      copyIsArray = Array.isArray(val);
       if (_.isObject(val) || copyIsArray) {
         if (copyIsArray) {
           copyIsArray = false;
-          clone = src && _.isArray(src) ? src : [];
+          clone = src && Array.isArray(src) ? src : [];
         } else {
           clone = src && _.isObject(src) ? src : {};
         }

--- a/lib/xlsx/xform/comment/vml-textbox-xform.js
+++ b/lib/xlsx/xform/comment/vml-textbox-xform.js
@@ -1,5 +1,4 @@
 const BaseXform = require('../base-xform');
-const _ = require('../../../utils/under-dash');
 
 class VmlTextboxXform extends BaseXform {
   get tag() {
@@ -22,7 +21,7 @@ class VmlTextboxXform extends BaseXform {
     };
     if (model && model.note) {
       let {inset} = model.note && model.note.margins;
-      if (_.isArray(inset)) {
+      if (Array.isArray(inset)) {
         inset = inset
           .map(margin => {
             return this.conversionUnit(margin, 10, 'mm');

--- a/spec/utils/tools.js
+++ b/spec/utils/tools.js
@@ -23,8 +23,7 @@ const tools = {
     return clone;
   },
 
-  concatenateFormula() {
-    const args = Array.prototype.slice.call(arguments);
+  concatenateFormula(...args) {
     const values = args.map(value => `"${value}"`);
     return {
       formula: `CONCATENATE(${values.join(',')})`,


### PR DESCRIPTION
I came across this while investigating our usages of `__proto__` and `prototype` as part of https://github.com/exceljs/exceljs/issues/1302