### PR TITLE
Fix cell.text return an empty object when cell is empty

### DIFF
--- a/lib/xlsx/xform/strings/shared-string-xform.js
+++ b/lib/xlsx/xform/strings/shared-string-xform.js
@@ -33,7 +33,7 @@ class SharedStringXform extends BaseXform {
     if (model && model.hasOwnProperty('richText') && model.richText) {
       if (model.richText.length) {
         model.richText.forEach(text => {
-          this.map.render(xmlStream, text);
+          this.map.r.render(xmlStream, text);
         });
       } else {
         this.map.t.render(xmlStream, '');

--- a/lib/xlsx/xform/strings/shared-string-xform.js
+++ b/lib/xlsx/xform/strings/shared-string-xform.js
@@ -31,10 +31,13 @@ class SharedStringXform extends BaseXform {
   render(xmlStream, model) {
     xmlStream.openNode(this.tag);
     if (model && model.hasOwnProperty('richText') && model.richText) {
-      const {r} = this.map;
-      model.richText.forEach(text => {
-        r.render(xmlStream, text);
-      });
+      if (model.richText.length) {
+        model.richText.forEach(text => {
+          this.map.render(xmlStream, text);
+        });
+      } else {
+        this.map.t.render(xmlStream, '');
+      }
     } else if (model !== undefined && model !== null) {
       this.map.t.render(xmlStream, model);
     }

--- a/spec/unit/xlsx/xform/strings/shared-string-xform.spec.js
+++ b/spec/unit/xlsx/xform/strings/shared-string-xform.spec.js
@@ -1,4 +1,4 @@
-const testXformHelper = require('./../test-xform-helper');
+const testXformHelper = require('../test-xform-helper');
 
 const SharedStringXform = verquire('xlsx/xform/strings/shared-string-xform');
 
@@ -51,6 +51,18 @@ const expectations = [
       ],
     },
     tests: ['render', 'renderIn', 'parse'],
+  },
+  {
+    title: 'richText is empty',
+    create() {
+      return new SharedStringXform();
+    },
+    preparedModel: {
+      richText: [],
+    },
+    xml: '<si><t></t></si>',
+    parsedModel: '',
+    tests: ['parse'],
   },
   {
     title: 'text + phonetic',


### PR DESCRIPTION
## Summary
* Fix cell.text return an empty object when cell is empty.
* Fix issue for #1299 .

## Test plan
`spec/unit/xlsx/xform/strings/shared-string-xform.spec.js`