### PR TITLE
Remove const enum and add ErrorValue in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare interface Buffer extends ArrayBuffer { }
 
-export const enum RelationshipType {
+export declare enum RelationshipType {
 	None = 0,
 	OfficeDocument = 1,
 	Worksheet = 2,
@@ -11,7 +11,7 @@ export const enum RelationshipType {
 	Hyperlink = 7
 }
 
-export const enum DocumentType {
+export declare enum DocumentType {
 	Xlsx = 1
 }
 
@@ -272,7 +272,7 @@ export interface Margins {
 	footer: number;
 }
 
-export const enum ReadingOrder {
+export declare enum ReadingOrder {
 	LeftToRight = 1,
 	RightToLeft = 2,
 }
@@ -318,6 +318,16 @@ export interface DataValidation {
 	showInputMessage?: boolean;
 }
 
+export declare enum ErrorValue {
+	NotApplicable = '#N/A',
+	Ref = '#REF!',
+	Name = '#NAME?',
+	DivZero = '#DIV/0!',
+	Null = '#NULL!',
+	Value = '#VALUE!',
+	Num = '#NUM!',
+}
+
 export interface CellErrorValue {
 	error: '#N/A' | '#REF!' | '#NAME?' | '#DIV/0!' | '#NULL!' | '#VALUE!' | '#NUM!';
 }
@@ -349,7 +359,7 @@ export interface CellSharedFormulaValue {
 	date1904: boolean;
 }
 
-export const enum ValueType {
+export declare enum ValueType {
 	Null = 0,
 	Merge = 1,
 	Number = 2,
@@ -363,7 +373,7 @@ export const enum ValueType {
 	Error = 10
 }
 
-export const enum FormulaType {
+export declare enum FormulaType {
 	None = 0,
 	Master = 1,
 	Shared = 2


### PR DESCRIPTION
##  Summary

Using `const enum` in .d.ts files breaks compilation with `--isolatedModules`. Instead, normal `enum`s have been used where a corresponding object exists at runtime. `PaperSize` does not exist at runtime, and so has been left as `const enum` for backwards compatibility.

This also adds a declaration for `ErrorValue` since it exists at runtime but had no TS definition. This does result in some duplication with `CellErrorValue`, but changing `CellErrorValue` to use `ErrorValue` would be a breaking change.

A comparable fix and explanation for the problem with using `const enum` can be found at https://github.com/chalk/chalk/pull/296, and some further explanation at https://ncjamieson.com/dont-export-const-enums/ and [this comment](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23002#issuecomment-359051201).

## Test plan

I created a small project to test this while making changes. Example file:

```typescript
import { ValueType, CellModel } from 'exceljs';

let vt: ValueType = ValueType.Date;
const vtString = ValueType.String;

export const cm1: Partial<CellModel> = { type: vt };
export const cm2: Partial<CellModel> = { type: vtString };
export const cm3: Partial<CellModel> = { type: ValueType.Boolean };
```

Before this PR:
- No errors with `isolatedModules: false`
- Errors with `isolatedModules: true`

With this PR:
- No errors with `isolatedModules: false`
- No errors with `isolatedModules: true`
