### PR TITLE
Fix the error that comment does not delete at spliceColumn

### DIFF
--- a/lib/doc/row.js
+++ b/lib/doc/row.js
@@ -91,9 +91,13 @@ class Row {
           cDst = this.getCell(i);
           cDst.value = cSrc.value;
           cDst.style = cSrc.style;
+          // eslint-disable-next-line no-underscore-dangle
+          cDst._comment = cSrc._comment;
         } else if (cDst) {
           cDst.value = null;
           cDst.style = {};
+          // eslint-disable-next-line no-underscore-dangle
+          cDst._comment = undefined;
         }
       }
     } else if (nExpand > 0) {
@@ -104,6 +108,8 @@ class Row {
           cDst = this.getCell(i + nExpand);
           cDst.value = cSrc.value;
           cDst.style = cSrc.style;
+          // eslint-disable-next-line no-underscore-dangle
+          cDst._comment = cSrc._comment;
         } else {
           this._cells[i + nExpand - 1] = undefined;
         }
@@ -115,6 +121,8 @@ class Row {
       cDst = this.getCell(start + i);
       cDst.value = inserts[i];
       cDst.style = {};
+      // eslint-disable-next-line no-underscore-dangle
+      cDst._comment = undefined;
     }
   }
 

--- a/spec/integration/pr/test-pr-1334.spec.js
+++ b/spec/integration/pr/test-pr-1334.spec.js
@@ -1,0 +1,38 @@
+const ExcelJS = verquire('exceljs');
+
+const TEST_XLSX_FILE_NAME = './spec/out/wb.test.xlsx';
+
+describe('github issues', () => {
+  it('pull request 1334 - Fix the error that comment does not delete at spliceColumn', async () => {
+    (async () => {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('testSheet');
+
+      ws.addRow([
+        'test1',
+        'test2',
+        'test3',
+        'test4',
+        'test5',
+        'test6',
+        'test7',
+        'test8',
+      ]);
+
+      const row = ws.getRow(1);
+      row.getCell(1).note = 'test1';
+      row.getCell(2).note = 'test2';
+      row.getCell(3).note = 'test3';
+      row.getCell(4).note = 'test4';
+
+      ws.spliceColumns(2, 1);
+
+      expect(row.getCell(1).note).to.equal('test1');
+      expect(row.getCell(2).note).to.equal('test3');
+      expect(row.getCell(3).note).to.equal('test4');
+      expect(row.getCell(4).note).to.equal(undefined);
+
+      await wb.xlsx.writeFile(TEST_XLSX_FILE_NAME);
+    })();
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix the error that comment does not delete at spliceColumn

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Test Source Code**
```javascript
const Excel = require('./lib/exceljs.nodejs');

(async () => {
    const wb = new Excel.Workbook();
    const ws = wb.addWorksheet('testSheet');

    ws.addRow(['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8']);

    const row = ws.getRow(1);
    row.getCell(1).note = 'test1';
    row.getCell(2).note = 'test2';
    row.getCell(3).note = 'test3';
    row.getCell(4).note = 'test4';

    ws.spliceColumns(2, 1);

    await wb.xlsx.writeFile('data.xlsx');
})();
```

**Existing Results**
![image](https://user-images.githubusercontent.com/40787013/84849776-080c6d00-b091-11ea-8691-acb3d1cc075f.png)

**Result**
![image](https://user-images.githubusercontent.com/40787013/84849556-874d7100-b090-11ea-9688-32f7ef08ce26.png)
