### PR TITLE
rename slave to aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -2569,15 +2569,15 @@ Shared formulae enhance the compression of the xlsx document by decreasing the r
 of text within the worksheet xml.
 The top-left cell in a range is the designated master and will hold the
 formula that all the other cells in the range will derive from.
-The other 'slave' cells can then refer to this master cell instead of redefining the
+The other 'aligned' cells can then refer to this master cell instead of redefining the
 whole formula again.
-Note that the master formula will be translated to the slave cells in the usual
+Note that the master formula will be translated to the aligned cells in the usual
 Excel fashion so that references to other cells will be shifted down and
-to the right depending on the slave's offset to the master.
+to the right depending on the aligned cell's offset to the master.
 For example: if the master cell A2 has a formula referencing A1 then
 if cell B2 shares A2's formula, then it will reference B1.
 
-A master formula can be assigned to a cell along with the slave cells in its range
+A master formula can be assigned to a cell along with the aligned cells in its range
 
 ```javascript
 worksheet.getCell('A2').value = {
@@ -2645,7 +2645,7 @@ It contains the shareType 'array' along with the range of cells it applies to an
 The rest of the cells are regular cells with regular values.
 
 Note: array formulae are not translated in the way shared formulae are.
-So if master cell A2 refers to A1, then slave cell B2 will also refer to A1.
+So if master cell A2 refers to A1, then aligned cell B2 will also refer to A1.
 
 E.g.
 ```javascript

--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -458,7 +458,7 @@ class CellXform extends BaseXform {
             // master
             options.formulae[model.si] = model.address;
           } else {
-            // slave
+            // aligned
             model.sharedFormula = options.formulae[model.si];
             delete model.shareType;
           }

--- a/spec/unit/doc/cell.spec.js
+++ b/spec/unit/doc/cell.spec.js
@@ -180,7 +180,7 @@ describe('Cell', () => {
     expect(a2.master).to.equal(a1);
     expect(a1.master).to.equal(a1);
 
-    // assignment of slaves write to the master
+    // assignment of aligned write to the master
     a2.value = 7;
     expect(a1.value).to.equal(7);
 

--- a/spec/unit/doc/worksheet.shared-formula.spec.js
+++ b/spec/unit/doc/worksheet.shared-formula.spec.js
@@ -30,7 +30,7 @@ describe('Worksheet', () => {
       });
     });
 
-    it('Translates formulae to slave cells', () => {
+    it('Translates formulae to aligned cells', () => {
       const wb = new Excel.Workbook();
       const ws = wb.addWorksheet();
 

--- a/spec/unit/xlsx/xform/sheet/cell-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/cell-xform.spec.js
@@ -1,4 +1,4 @@
-const testXformHelper = require('./../test-xform-helper');
+const testXformHelper = require('../test-xform-helper');
 
 const CellXform = verquire('xlsx/xform/sheet/cell-xform');
 const SharedStringsXform = verquire('xlsx/xform/strings/shared-strings-xform');
@@ -433,7 +433,7 @@ const expectations = [
     },
   },
   {
-    title: 'Shared Formula Slave',
+    title: 'Shared Formula Alignment',
     create() {
       return new CellXform();
     },


### PR DESCRIPTION
## Summary

Slave is an antiquated word and can easily be replaced with something less insensitive. I took inspiration from the [ag-grid project and their improved naming scheme](https://github.com/ag-grid/ag-grid/commit/432bf120cac8b2d050b89f940b31c5bff95abb93).

## Test plan

I can the tests and everything seems to be working just fine. Since I only changed a comment in the actual code and all other changes relate to docs/tests, I feel very confident that I didn't break anything.