### PR TITLE
update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -877,9 +877,7 @@ export interface WorksheetProtection {
 	autoFilter: boolean;
 	pivotTables: boolean;
 }
-
-export interface 
-{
+export interface Images {
 	extension: 'jpeg' | 'png' | 'gif';
 	base64?: string;
 	filename?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -877,7 +877,7 @@ export interface WorksheetProtection {
 	autoFilter: boolean;
 	pivotTables: boolean;
 }
-export interface Images {
+export interface Image {
 	extension: 'jpeg' | 'png' | 'gif';
 	base64?: string;
 	filename?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -878,7 +878,8 @@ export interface WorksheetProtection {
 	pivotTables: boolean;
 }
 
-export interface Image {
+export interface 
+{
 	extension: 'jpeg' | 'png' | 'gif';
 	base64?: string;
 	filename?: string;
@@ -907,8 +908,8 @@ export class Anchor implements IAnchor {
 	constructor(model?: IAnchor | object);
 }
 export interface ImageRange {
-	tl: { col: number; row: number } | Anchor;
-	br: { col: number; row: number } | Anchor;
+	tl: Anchor;
+	br: Anchor;
 }
 
 export interface ImagePosition {


### PR DESCRIPTION
When I was working on https://github.com/Siemienik/xlsx-renderer/pull/31 I note that we have redundant type definition. Because All images added into worksheet was mapped into Anchor.
Anchor contains `{ col: number; row: number } ` 

So removing `{ col: number; row: number } ` from typings make our library easier to use (it's not required to use the keyword `as` to access `nativeCol`, `nativeRow` etc)