### PR TITLE
Merge cells after row insert

### DIFF
--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -399,7 +399,6 @@ class Worksheet {
     // now copy styles...
     for (let i = 0; i < count; i++) {
       const rDst = this._rows[rowNum + i];
-      rDst.values = rSrc.values;
       rDst.style = rSrc.style;
       rDst.height = rSrc.height;
       // eslint-disable-next-line no-loop-func
@@ -440,7 +439,7 @@ class Worksheet {
       for (i = nEnd; i >= nKeep; i--) {
         rSrc = this._rows[i - 1];
         if (rSrc) {
-          var rDst = this.getRow(i + nExpand);
+          const rDst = this.getRow(i + nExpand);
           rDst.values = rSrc.values;
           rDst.style = rSrc.style;
           rDst.height = rSrc.height;

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -399,6 +399,7 @@ class Worksheet {
     // now copy styles...
     for (let i = 0; i < count; i++) {
       const rDst = this._rows[rowNum + i];
+      rDst.values = rSrc.values;
       rDst.style = rSrc.style;
       rDst.height = rSrc.height;
       // eslint-disable-next-line no-loop-func
@@ -411,7 +412,8 @@ class Worksheet {
   spliceRows(start, count, ...inserts) {
     // same problem as row.splice, except worse.
     const nKeep = start + count;
-    const nExpand = inserts.length - count;
+    const nInserts = inserts.length;
+    const nExpand = nInserts - count;
     const nEnd = this._rows.length;
     let i;
     let rSrc;
@@ -438,13 +440,23 @@ class Worksheet {
       for (i = nEnd; i >= nKeep; i--) {
         rSrc = this._rows[i - 1];
         if (rSrc) {
-          const rDst = this.getRow(i + nExpand);
+          var rDst = this.getRow(i + nExpand);
           rDst.values = rSrc.values;
           rDst.style = rSrc.style;
           rDst.height = rSrc.height;
           // eslint-disable-next-line no-loop-func
           rSrc.eachCell({includeEmpty: true}, (cell, colNumber) => {
             rDst.getCell(colNumber).style = cell.style;
+
+            // remerge cells accounting for insert offset
+            if (cell._value.constructor.name === 'MergeValue') {
+              const cellToBeMerged = this.getRow(cell._row._number + nInserts).getCell(colNumber);
+              const prevMaster = cell._value._master;
+              const newMaster = this
+                .getRow(prevMaster._row._number + nInserts)
+                .getCell(prevMaster._column._number)
+              cellToBeMerged.merge(newMaster);
+            }
           });
         } else {
           this._rows[i + nExpand - 1] = undefined;
@@ -453,14 +465,14 @@ class Worksheet {
     }
 
     // now copy over the new values
-    for (i = 0; i < inserts.length; i++) {
+    for (i = 0; i < nInserts; i++) {
       const rDst = this.getRow(start + i);
       rDst.style = {};
       rDst.values = inserts[i];
     }
 
     // account for defined names
-    this.workbook.definedNames.spliceRows(this.name, start, count, inserts.length);
+    this.workbook.definedNames.spliceRows(this.name, start, count, nInserts);
   }
 
   // iterate over every row in the worksheet, including maybe empty rows

--- a/spec/unit/doc/worksheet.merge.spec.js
+++ b/spec/unit/doc/worksheet.merge.spec.js
@@ -212,5 +212,37 @@ describe('Worksheet', () => {
         testUtils.styles.numFmts.numFmt1
       );
     });
+
+    it('preserves merges after row inserts', function() {
+      const wb = new Excel.Workbook();
+      const ws = wb.addWorksheet('testMergeAfterInsert');
+
+      ws.addRow([1,2]);
+      ws.addRow([3,4]);
+      ws.mergeCells('A1:B2');
+      ws.insertRow(1, ['Inserted Row Text']);
+
+      const r2 = ws.getRow(2);
+      const r3 = ws.getRow(3);
+
+      let cellVals = [];
+      for (const r of [r2, r3]) {
+        for (const cell of r._cells) {
+          cellVals.push(cell._value);
+        }
+      }
+
+      let nNumberVals = 0;
+      let nMergeVals = 0;
+      for (let cellVal of cellVals) {
+          const name = cellVal.constructor.name; 
+          if (name === 'NumberValue') nNumberVals += 1;
+          if (name === 'MergeValue' && cellVal.model.master === "A2") {
+              nMergeVals += 1;
+          }
+      }
+      expect(nNumberVals).to.deep.equal(1);
+      expect(nMergeVals).to.deep.equal(3);
+    })
   });
 });


### PR DESCRIPTION
## Summary

Merges aren't preserved when cells containing merges get overwritten after row inserts. Instead, the value of a merged cell gets applied to all cells in the merge separately.

| A1 and B1 | C1 |
|---|---|
| merged cell text || 


becomes

| A1 | B1 | C1 |
|---|---|---|
| merged cell text | merged cell text ||

This is because the values for the previously merged cells are pulled from the source row (`rSrc.values` in `spliceRows`). The source row's values repeat the merged value for each cell in the merge. For example, the source row values for the row in the first table would be `["merged cell text", "merged cell text"]`. These values are what gets applied to the cells in the destination row (`rDst`), and the merge is lost.

The extra lines I wrote in `spliceRows` to fix this reapply merges to cells while accounting for the offset caused by a row insert.

## Test plan
I added a test to spec/unit/doc/worksheet.merge.spec for this issue and verified that it passes with the changes I made.
