### PR TITLE
[F] #1363 - Add support for excluding AutoFilter columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,17 @@ worksheet.autoFilter = {
 }
 ```
 
+Additionally, specific columns can be excluded from showing an auto filter button using `exclude`. The `exclude` property takes an array of columns to exclude (with 0 being the leftmost column), and hides the filter button on said columns. 
+
+```javascript
+// Set an auto filter from A1 to E1, while hiding the filter button on the A and C columns
+worksheet.autoFilter = {
+  from: 'A1',
+  to: 'E1',
+  exclude: [0, 2]
+}
+```
+
 ## Columns[⬆](#contents)<!-- Link generated with jump2header -->
 
 ```javascript

--- a/lib/xlsx/xform/sheet/auto-filter-xform.js
+++ b/lib/xlsx/xform/sheet/auto-filter-xform.js
@@ -22,7 +22,16 @@ class AutoFilterXform extends BaseXform {
         const firstAddress = getAddress(model.from);
         const secondAddress = getAddress(model.to);
         if (firstAddress && secondAddress) {
-          xmlStream.leafNode('autoFilter', {ref: `${firstAddress}:${secondAddress}`});
+          if (model.exclude) {
+            xmlStream.openNode('autoFilter');
+            xmlStream.addAttribute('ref', `${firstAddress}:${secondAddress}`); 
+            for (let i = 0; i < model.exclude.length; i++) {
+              xmlStream.leafNode('filterColumn', {colId: model.exclude[i], showButton: '0'}); 
+            }
+            xmlStream.closeNode(); 
+          } else {
+            xmlStream.leafNode('autoFilter', {ref: `${firstAddress}:${secondAddress}`});
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

I brought this up in #1363 several days back. Basically, Excel allows you to exclude specific columns from showing the AutoFilter button when setting an AutoFilter range, which is extremely helpful when you want a field to span more than one column and/or with merged cells. This would implement support for that in ExcelJS. 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
This implementation is intended to be as minimally invasive and non-destructive as possible - it merely adds on a property, `exclude`, that can be (optionally) passed onto the `autoFilter` property. The readme has also been updated with an example of this. 

If the user opts not to use said `exclude` property, then autoFilter will behave exactly the same way as before. 

Example: 
```javascript
const sheet = workbook.addWorksheet('My Sheet');

sheet.autoFilter = {
    from: 'A1', 
    to: 'E1', 
    exclude: [1, 2] // excludes columns B and C from showing the AutoFilter button
}
```