### PR TITLE
Add support for calculated column formulas to tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,13 +1250,14 @@ style property.
 The following table defines the properties supported within each table
 column.
 
-| Column Property    | Description       | Required | Default Value |
-| ------------------ | ----------------- | -------- | ------------- |
-| name               | The name of the column, also used in the header | Y |    |
-| filterButton       | Switches the filter control in the header | N |  false  |
-| totalsRowLabel     | Label to describe the totals row (first column) | N | 'Total' |
-| totalsRowFunction  | Name of the totals function | N | 'none' |
-| totalsRowFormula   | Optional formula for custom functions | N |   |
+| Column Property         | Description       | Required | Default Value |
+| ----------------------- | ----------------- | -------- | ------------- |
+| name                    | The name of the column, also used in the header | Y |    |
+| filterButton            | Switches the filter control in the header | N |  false  |
+| totalsRowLabel          | Label to describe the totals row (first column) | N | 'Total' |
+| totalsRowFunction       | Name of the totals function | N | 'none' |
+| totalsRowFormula        | Optional formula for custom functions | N |   |
+| calculatedColumnFormula | Optional formula to apply to the whole column | N |   |
 
 ### Totals Functions[⬆](#contents)<!-- Link generated with jump2header -->
 
@@ -1277,6 +1278,29 @@ by the table.
 | var                | The variance for this column |
 | sum                | The sum of entries for this column |
 | custom             | A custom formula. Requires an associated totalsRowFormula value. |
+
+### Calculated column formulas[⬆](#contents)<!-- Link generated with jump2header -->
+
+When using a calculated column formula you need to set the cells value to null when adding it, this was it will be converted into a shared formula.
+If you set it to a value other than null, it will use that value instead.
+
+```javascript
+ws.addTable({
+  name: 'MyTable',
+  ref: 'A1',
+  // ...
+  columns: [
+    {name: 'Id'},
+    {name: 'ByTwo', calculatedColumnFormula: 'A2*2'},
+  ],
+  rows: [
+    [1, null],
+    [2, null],
+    [3, 'Will override'],
+    [4, null]
+  ],
+});
+```
 
 ### Table Style Themes[⬆](#contents)<!-- Link generated with jump2header -->
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1777,6 +1777,10 @@ export interface TableColumnProperties {
 	  * Optional formula for custom functions
 	  */
 	totalsRowFormula?: string;
+	/**
+	 * Optional formula to apply to the entire column
+	 */
+	calculatedColumnFormula?: string
 }
 
 

--- a/lib/doc/table.js
+++ b/lib/doc/table.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-const colCache = require('./../utils/col-cache');
+const colCache = require('../utils/col-cache');
 
 class Column {
   // wrapper around column model, allowing access and manipulation
@@ -200,13 +200,33 @@ class Table {
         assignStyle(cell, style);
       });
     }
+
+    const calculatedColumnFormulas = {};
     table.rows.forEach(data => {
       const r = worksheet.getRow(row + count++);
       data.forEach((value, j) => {
+        const tableColumn = table.columns[j];
         const cell = r.getCell(col + j);
+
+        if (tableColumn.calculatedColumnFormula && value === null) {
+          if (!calculatedColumnFormulas[j]) {
+            const column = worksheet.getColumn(col + j);
+            calculatedColumnFormulas[j] = cell.address;
+            value = {
+              formula: tableColumn.calculatedColumnFormula,
+              shareType: 'shared',
+              ref: `${cell.address}:${column.letter}${row + data.length}`,
+            };
+          } else {
+            value = {
+              sharedFormula: calculatedColumnFormulas[j],
+            };
+          }
+        }
+
         cell.value = value;
 
-        assignStyle(cell, table.columns[j].style);
+        assignStyle(cell, tableColumn.style);
       });
     });
 

--- a/lib/xlsx/xform/table/calculated-column-formula-xform.js
+++ b/lib/xlsx/xform/table/calculated-column-formula-xform.js
@@ -1,0 +1,31 @@
+const BaseXform = require('../base-xform');
+
+class CalculatedColumnFormulaXform extends BaseXform {
+  get tag() {
+    return 'calculatedColumnFormula';
+  }
+
+  render(xmlStream, model) {
+    xmlStream.leafNode(this.tag, null, model);
+    return true;
+  }
+
+  parseOpen(node) {
+    if (node.name === this.tag) {
+      this.model = null;
+      return true;
+    }
+
+    return false;
+  }
+
+  parseText(text) {
+    this.model = text;
+  }
+
+  parseClose() {
+    return false;
+  }
+}
+
+module.exports = CalculatedColumnFormulaXform;

--- a/lib/xlsx/xform/table/table-column-xform.js
+++ b/lib/xlsx/xform/table/table-column-xform.js
@@ -1,6 +1,15 @@
 const BaseXform = require('../base-xform');
+const CalculatedColumnFormulaXform = require('./calculated-column-formula-xform');
 
 class TableColumnXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      calculatedColumnFormula: new CalculatedColumnFormulaXform(),
+    };
+  }
+
   get tag() {
     return 'tableColumn';
   }
@@ -10,33 +19,65 @@ class TableColumnXform extends BaseXform {
   }
 
   render(xmlStream, model) {
-    xmlStream.leafNode(this.tag, {
+    const nodeAttributes = {
       id: model.id.toString(),
       name: model.name,
       totalsRowLabel: model.totalsRowLabel,
       totalsRowFunction: model.totalsRowFunction,
       dxfId: model.dxfId,
-    });
+    };
+    if (!model.calculatedColumnFormula) {
+      xmlStream.leafNode(this.tag, nodeAttributes);
+      return true;
+    }
+
+    xmlStream.openNode(this.tag, nodeAttributes);
+    this.map.calculatedColumnFormula.render(xmlStream, model.calculatedColumnFormula);
+    xmlStream.closeNode();
+
     return true;
   }
 
   parseOpen(node) {
-    if (node.name === this.tag) {
-      const {attributes} = node;
-      this.model = {
-        name: attributes.name,
-        totalsRowLabel: attributes.totalsRowLabel,
-        totalsRowFunction: attributes.totalsRowFunction,
-        dxfId: attributes.dxfId,
-      };
-      return true;
+    switch (node.name) {
+      case this.tag: {
+        const {attributes} = node;
+        this.model = {
+          name: attributes.name,
+          totalsRowLabel: attributes.totalsRowLabel,
+          totalsRowFunction: attributes.totalsRowFunction,
+          dxfId: attributes.dxfId,
+        };
+        return true;
+      }
+      default: {
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+          return true;
+        }
+        break;
+      }
     }
+
     return false;
   }
 
-  parseText() {}
+  parseText(text) {
+    if (this.parser) {
+      this.parser.parseText(text);
+    }
+  }
 
-  parseClose() {
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.model.calculatedColumnFormula = this.parser.model;
+        this.parser = undefined;
+      }
+      return true;
+    }
+
     return false;
   }
 }

--- a/spec/unit/xlsx/xform/table/calculated-column-formula-xform.spec.js
+++ b/spec/unit/xlsx/xform/table/calculated-column-formula-xform.spec.js
@@ -1,0 +1,22 @@
+const testXformHelper = require('../test-xform-helper');
+
+const CalculatedColumnFormulaXform = verquire(
+  'xlsx/xform/table/calculated-column-formula-xform'
+);
+
+const expectations = [
+  {
+    title: 'text',
+    create() {
+      return new CalculatedColumnFormulaXform();
+    },
+    preparedModel: 'A2*2',
+    xml: '<calculatedColumnFormula>A2*2</calculatedColumnFormula>',
+    parsedModel: 'A2*2',
+    tests: ['render', 'renderIn', 'parse'],
+  },
+];
+
+describe('CalculatedColumnFormulaXform', () => {
+  testXformHelper(expectations);
+});

--- a/spec/unit/xlsx/xform/table/table-column-xform.spec.js
+++ b/spec/unit/xlsx/xform/table/table-column-xform.spec.js
@@ -1,4 +1,4 @@
-const testXformHelper = require('./../test-xform-helper');
+const testXformHelper = require('../test-xform-helper');
 
 const TableColumnXform = verquire('xlsx/xform/table/table-column-xform');
 
@@ -21,6 +21,26 @@ const expectations = [
     preparedModel: {id: 1, name: 'Foo', totalsRowFunction: 'Baz'},
     xml: '<tableColumn id="1" name="Foo" totalsRowFunction="Baz" />',
     parsedModel: {name: 'Foo', totalsRowFunction: 'Baz'},
+    tests: ['render', 'renderIn', 'parse'],
+  },
+  {
+    title: 'calculatedColumnFormula',
+    create() {
+      return new TableColumnXform();
+    },
+    preparedModel: {
+      id: 1,
+      name: 'Foo',
+      totalsRowFunction: 'Baz',
+      calculatedColumnFormula: 'A2*2',
+    },
+    xml:
+      '<tableColumn id="1" name="Foo" totalsRowFunction="Baz"><calculatedColumnFormula>A2*2</calculatedColumnFormula></tableColumn>',
+    parsedModel: {
+      name: 'Foo',
+      totalsRowFunction: 'Baz',
+      calculatedColumnFormula: 'A2*2',
+    },
     tests: ['render', 'renderIn', 'parse'],
   },
 ];


### PR DESCRIPTION
## Summary

This PR is the implementation for the feature request #1417 to add calculated column formula support.
I set it so that it will take null values as input and replace them with the calculated column formula when adding data to the table. It also adds the calculatedColumnFormula xml entity. 

## Test plan

I added unit tests for this feature and ran npm run test:unit whilst developing and ran npm run test before creating this PR.

