### PR TITLE
Fix issue #1431 Streaming WorkbookReader _parseSharedStrings doesn't handle rich text within shared string nodes

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -170,28 +170,100 @@ class WorkbookReader extends EventEmitter {
         return;
     }
 
-    let inT = false;
     let text = null;
+    let richText = [];
     let index = 0;
+    let font = null;
     for await (const events of parseSax(iterateStream(entry))) {
       for (const {eventType, value} of events) {
         if (eventType === 'opentag') {
           const node = value;
-          if (node.name === 't') {
-            text = null;
-            inT = true;
+          switch (node.name) {
+            case 'b':
+              font = font || {};
+              font.bold = true;
+              break;
+            case 'charset':
+              font = font || {};
+              font.charset = parseInt(node.attributes.charset, 10);
+              break;
+            case 'color':
+              font = font || {};
+              font.color = {};
+              if (node.attributes.rgb) {
+                font.color.argb = node.attributes.argb;
+              }
+              if (node.attributes.val) {
+                font.color.argb = node.attributes.val;
+              }
+              if (node.attributes.theme) {
+                font.color.theme = node.attributes.theme;
+              }
+              break;
+            case 'family':
+              font = font || {};
+              font.family = parseInt(node.attributes.val, 10);
+              break;
+            case 'i':
+              font = font || {};
+              font.italic = true;
+              break;
+            case 'outline':
+              font = font || {};
+              font.outline = true;
+              break;
+            case 'rFont':
+              font = font || {};
+              font.name = node.value;
+              break;
+            case 'si':
+              font = null;
+              richText = [];
+              text = null;
+              break;
+            case 'sz':
+              font = font || {};
+              font.size = parseInt(node.attributes.val, 10);
+              break;
+            case 'strike':
+              break;
+            case 't':
+              text = null;
+              break;
+            case 'u':
+              font = font || {};
+              font.underline = true;
+              break;
+            case 'vertAlign':
+              font = font || {};
+              font.vertAlign = node.attributes.val;
+              break;
           }
         } else if (eventType === 'text') {
           text = text ? text + value : value;
         } else if (eventType === 'closetag') {
           const node = value;
-          if (inT && node.name === 't') {
-            if (this.options.sharedStrings === 'cache') {
-              this.sharedStrings.push(text);
-            } else if (this.options.sharedStrings === 'emit') {
-              yield {index: index++, text};
-            }
-            text = null;
+          switch (node.name) {
+            case 'r':
+              richText.push({
+                font,
+                text,
+              });
+
+              font = null;
+              text = null;
+              break;
+            case 'si':
+              if (this.options.sharedStrings === 'cache') {
+                this.sharedStrings.push(richText.length ? {richText} : text);
+              } else if (this.options.sharedStrings === 'emit') {
+                yield {index: index++, text: richText.length ? {richText} : text};
+              }
+
+              richText = [];
+              font = null;
+              text = null;
+              break;
           }
         }
       }

--- a/spec/integration/pr/test-pr-1431.spec.js
+++ b/spec/integration/pr/test-pr-1431.spec.js
@@ -23,19 +23,26 @@ describe('github issues', () => {
 
     await workbook.commit();
 
-    const workbookReader = new ExcelJS.stream.xlsx.WorkbookReader('./test.xlsx', {
-      entries: 'emit',
-      hyperlinks: 'cache',
-      sharedStrings: 'cache',
-      styles: 'cache',
-      worksheets: 'emit',
-    });
+    return new Promise((resolve, reject) => {
+      const workbookReader = new ExcelJS.stream.xlsx.WorkbookReader('./test.xlsx', {
+        entries: 'emit',
+        hyperlinks: 'cache',
+        sharedStrings: 'cache',
+        styles: 'cache',
+        worksheets: 'emit',
+      });
 
-    for await (const worksheetReader of workbookReader) {
-      for await (const row of worksheetReader) {
-        expect(row.values[1]).to.eql(rowData[0]);
-        expect(row.values[2]).to.equal(rowData[1]);
-      }
-    }
+      workbookReader.on('worksheet', worksheet =>
+        worksheet.on('row', row => {
+          expect(row.values[1]).to.eql(rowData[0]);
+          expect(row.values[2]).to.equal(rowData[1]);
+
+          resolve();
+        })
+      );
+      workbookReader.on('error', reject);
+
+      workbookReader.read();
+    });
   });
 });

--- a/spec/integration/pr/test-pr-1431.spec.js
+++ b/spec/integration/pr/test-pr-1431.spec.js
@@ -33,9 +33,7 @@ describe('github issues', () => {
 
     for await (const worksheetReader of workbookReader) {
       for await (const row of worksheetReader) {
-        // actual: 'This Should '
         expect(row.values[1]).to.eql(rowData[0]);
-        // actual: 'be one shared string value'
         expect(row.values[2]).to.equal(rowData[1]);
       }
     }

--- a/spec/integration/pr/test-pr-1431.spec.js
+++ b/spec/integration/pr/test-pr-1431.spec.js
@@ -1,0 +1,43 @@
+const ExcelJS = verquire('exceljs');
+
+describe('github issues', () => {
+  it('pull request 1431 - streaming reader should handle rich text within shared strings', async () => {
+    const rowData = [
+      {
+        richText: [
+          {font: {bold: true}, text: 'This should '},
+          {font: {italic: true}, text: 'be one shared string value'},
+        ],
+      },
+      'this should be the second shared string',
+    ];
+
+    const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
+      filename: './test.xlsx',
+      useSharedStrings: true,
+    });
+
+    const sheet = workbook.addWorksheet('data');
+
+    sheet.addRow(rowData);
+
+    await workbook.commit();
+
+    const workbookReader = new ExcelJS.stream.xlsx.WorkbookReader('./test.xlsx', {
+      entries: 'emit',
+      hyperlinks: 'cache',
+      sharedStrings: 'cache',
+      styles: 'cache',
+      worksheets: 'emit',
+    });
+
+    for await (const worksheetReader of workbookReader) {
+      for await (const row of worksheetReader) {
+        // actual: 'This Should '
+        expect(row.values[1]).to.eql(rowData[0]);
+        // actual: 'be one shared string value'
+        expect(row.values[2]).to.equal(rowData[1]);
+      }
+    }
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fix bug #1431 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Create worksheet with rich text, use the streaming reader to read it in and ensure you receive richText back.

`spec/integration/pr/test-pr-1431.spec.js`
