### PR TITLE
Change typing for colorScale colour to array of colours

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1035,7 +1035,7 @@ export interface AboveAverageRuleType extends ConditionalFormattingBaseRule {
 export interface ColorScaleRuleType extends ConditionalFormattingBaseRule {
 	type: 'colorScale';
 	cfvo?: Cvfo[];
-	color?: Partial<Color>;
+	color?: Partial<Color>[];
 }
 
 export interface IconSetRuleType extends ConditionalFormattingBaseRule {


### PR DESCRIPTION
The ColorScaleRuleType should accept an array of Colours instead of a singular Colour.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
TypeScript currently complains when providing an array of colours as part of a colour scale conditional formatting rule. This PR fixes the type definition to allow for an array of colours.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Before  
![image](https://user-images.githubusercontent.com/13886925/91514869-cba28c00-e8df-11ea-958e-e6bb2b577883.png)

After  
![image](https://user-images.githubusercontent.com/13886925/91514897-da893e80-e8df-11ea-9955-859f5b785b7e.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
