### PR TITLE
browser: use TextDecoder and TextEncoder for buffer

### DIFF
--- a/lib/exceljs.bare.js
+++ b/lib/exceljs.bare.js
@@ -1,4 +1,6 @@
 // this bundle is built without polyfill leaving apps the freedom to add their own
+require('./utils/browser-patch-buffer');
+
 const ExcelJS = {
   Workbook: require('./doc/workbook'),
 };

--- a/lib/exceljs.browser.js
+++ b/lib/exceljs.browser.js
@@ -20,6 +20,7 @@ require('core-js/modules/es.string.includes');
 // required by lib/utils/utils.js utils.validInt and lib/csv/csv.js CSV.read
 require('core-js/modules/es.number.is-nan');
 require('regenerator-runtime/runtime');
+require('./utils/browser-patch-buffer');
 
 const ExcelJS = {
   Workbook: require('./doc/workbook'),

--- a/lib/utils/browser-patch-buffer.js
+++ b/lib/utils/browser-patch-buffer.js
@@ -1,0 +1,34 @@
+/* eslint-disable node/no-unsupported-features/node-builtins */
+// Note: this is included only in browser
+if (typeof TextDecoder !== 'undefined' || typeof TextEncoder !== 'undefined') {
+  const {Buffer} = require('buffer');
+  if (typeof TextEncoder !== 'undefined') {
+    const textEncoder = new TextEncoder('utf-8');
+    const {from} = Buffer;
+    Buffer.from = function(str, encoding) {
+      if (typeof str === 'string') {
+        if (encoding) {
+          encoding = encoding.toLowerCase();
+        }
+        if (!encoding || encoding === 'utf8' || encoding === 'utf-8') {
+          return from.call(this, textEncoder.encode(str).buffer);
+        }
+      }
+      return from.apply(this, arguments);
+    };
+  }
+  if (typeof TextDecoder !== 'undefined') {
+    const textDecoder =  new TextDecoder('utf-8');
+    const {toString} = Buffer.prototype;
+    Buffer.prototype.toString = function(encoding, start, end) {
+      if (encoding) {
+        encoding = encoding.toLowerCase();
+      }
+      if (!start && end === undefined &&
+        (!encoding || encoding === 'utf8' || encoding === 'utf-8')) {
+        return textDecoder.decode(this);
+      }
+      return toString.apply(this, arguments);
+    };
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Doing a profiling in chrome dev tools shows that the `Buffer.toString()` and `Buffer.from(string)` is using unexpected long cpu time. With the native TextDecoder and TextEncoder it can get much faster in browsers supporting it.
On browsers not supporting TextDecoder, like Internet Explorer, `Buffer.toString()` and `Buffer.from(string)` would not be changed.

References:
https://github.com/feross/buffer/issues/268
https://github.com/feross/buffer/issues/60
https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder
https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Profiling below is based on reading `spec/integration/data/huge.xlsx`.

<details> 
  <summary>Profiling result before patch</summary>

![before](https://user-images.githubusercontent.com/17702502/92994557-eefb4700-f52d-11ea-8909-8301b42d8410.PNG)
[Profile-before.json.gz](https://github.com/exceljs/exceljs/files/5212581/Profile-before.json.gz)
</details>

<details> 
  <summary>Profiling result after patch</summary>

![after](https://user-images.githubusercontent.com/17702502/92994586-3386e280-f52e-11ea-8a4f-880f8d86146e.PNG)
[Profile-after.json.gz](https://github.com/exceljs/exceljs/files/5212584/Profile-after.json.gz)

</details>