### PR TITLE
grunt: skip babel transpile for core-js

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -53,6 +53,10 @@ module.exports = function(grunt) {
         dest: './dist/exceljs.js',
       },
       spec: {
+        options: {
+          transform: null,
+          browserifyOptions: null,
+        },
         src: ['./build/spec/browser/exceljs.spec.js'],
         dest: './build/web/exceljs.spec.js',
       },

--- a/lib/exceljs.browser.js
+++ b/lib/exceljs.browser.js
@@ -2,8 +2,23 @@
 require('core-js/modules/es.promise');
 require('core-js/modules/es.object.assign');
 require('core-js/modules/es.object.keys');
+require('core-js/modules/es.object.values');
 require('core-js/modules/es.symbol');
 require('core-js/modules/es.symbol.async-iterator');
+// required by core-js/modules/es.promise Promise.all
+require('core-js/modules/es.array.iterator');
+// required by node_modules/saxes/saxes.js SaxesParser.captureTo
+require('core-js/modules/es.array.includes');
+// required by lib/doc/workbook.js Workbook.model
+require('core-js/modules/es.array.find-index');
+// required by lib/doc/workbook.js Workbook.addWorksheet and Workbook.getWorksheet
+require('core-js/modules/es.array.find');
+// required by node_modules/saxes/saxes.js SaxesParser.getCode10
+require('core-js/modules/es.string.from-code-point');
+// required by lib/xlsx/xform/sheet/data-validations-xform.js DataValidationsXform.parseClose
+require('core-js/modules/es.string.includes');
+// required by lib/utils/utils.js utils.validInt and lib/csv/csv.js CSV.read
+require('core-js/modules/es.number.is-nan');
 require('regenerator-runtime/runtime');
 
 const ExcelJS = {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jasmine": "^2.1.0",
     "grunt-contrib-watch": "^1.1.0",
+    "grunt-exorcise": "^2.1.1",
     "grunt-terser": "^1.0.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.13",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Previously grunt build would transpile the output of browserify to transpile all dependencies, but this would make some dependencies, such as core-js, unexpectedly transpiled. Also, this way of transpiling would create source maps only targeting the browserify output instead of original source, and makes the final `dist/exceljs.js` larger than expected.

* Fix Symbol.toString() related errors on IE11 caused by transpiling core-js
* Reduce size for compiled dist
* Keep original source maps before browserify

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Existing ci builds and manually tested in browser.
<details>
<summary>screenshot of source map</summary>

![source_map](https://user-images.githubusercontent.com/17702502/93469682-67457c00-f923-11ea-99d8-a81a25029247.PNG)

</details>