### PR TITLE
Fixed undefined ref error when setting a data validation that is a range of cells at the worksheet level

### DIFF
--- a/lib/xlsx/xform/sheet/data-validations-xform.js
+++ b/lib/xlsx/xform/sheet/data-validations-xform.js
@@ -51,7 +51,15 @@ function optimiseDataValidations(model) {
   return dvList
     .map(dv => {
       if (!dv.marked) {
-        const addr = colCache.decodeAddress(dv.address);
+        const addr = colCache.decodeEx(dv.address);
+        if (addr.dimensions) {
+          // If we comeback with a dimensions, we can assume this was sone on purpose and should not be optimized
+          dvMap[addr.dimensions].marked = true;
+          return {
+            ...dv.dataValidation,
+            sqref: dv.address,
+          };
+        }
 
         // iterate downwards - finding matching cells
         let height = 1;

--- a/lib/xlsx/xform/sheet/data-validations-xform.js
+++ b/lib/xlsx/xform/sheet/data-validations-xform.js
@@ -53,7 +53,6 @@ function optimiseDataValidations(model) {
       if (!dv.marked) {
         const addr = colCache.decodeEx(dv.address);
         if (addr.dimensions) {
-          // If we comeback with a dimensions, we can assume this was sone on purpose and should not be optimized
           dvMap[addr.dimensions].marked = true;
           return {
             ...dv.dataValidation,

--- a/spec/integration/issues/issue-1027-sheet-defined-data-validate.spec.js
+++ b/spec/integration/issues/issue-1027-sheet-defined-data-validate.spec.js
@@ -1,0 +1,27 @@
+const ExcelJS = verquire('exceljs');
+
+// this file to contain integration tests created from github issues
+const TEST_XLSX_FILE_NAME = './spec/out/wb.test.xlsx';
+
+describe('github issues', () => {
+  it('issue 1027 - Broken due to Cannot set property \'marked\' of undefined error', () => {
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('Sheet1');
+
+    const range = 'A2:A1048576';
+
+    ws.dataValidations.model[range] = {
+      allowBlank: true,
+      error: 'Please use the drop down to select a valid value',
+      errorTitle: 'Invalid Selection',
+      formulae: ['"Apples,Bananas,Oranges"'],
+      showErrorMessage: true,
+      type: 'list',
+    };
+
+    return wb.xlsx.writeFile(TEST_XLSX_FILE_NAME).then(() => {
+      // arriving here is success
+      expect(true).to.equal(true);
+    });
+  });
+});

--- a/spec/integration/issues/issue-1027-sheet-defined-data-validate.spec.js
+++ b/spec/integration/issues/issue-1027-sheet-defined-data-validate.spec.js
@@ -1,6 +1,5 @@
 const ExcelJS = verquire('exceljs');
 
-// this file to contain integration tests created from github issues
 const TEST_XLSX_FILE_NAME = './spec/out/wb.test.xlsx';
 
 describe('github issues', () => {
@@ -19,9 +18,6 @@ describe('github issues', () => {
       type: 'list',
     };
 
-    return wb.xlsx.writeFile(TEST_XLSX_FILE_NAME).then(() => {
-      // arriving here is success
-      expect(true).to.equal(true);
-    });
+    return wb.xlsx.writeFile(TEST_XLSX_FILE_NAME);
   });
 });


### PR DESCRIPTION
Fixed undefined ref error when setting a data validation that is a range of cells at the worksheet level

## Summary

In the case where a data validation is set at the worksheet level with a range of cells "A1:A100" the error `Cannot set property 'marked' of undefined` would occur.

From what I could tell the original code would call `const addr = colCache.decodeAddress(dv.address);` this would return the value "A1" in the case of the following "A1:A100". Later on in the code it would try to mark "A1" `dvMap[otherAddress].marked = true;`, but in the dvMap it would be "A1:A100" and the error occurs.

I changed decodeAddress to decodeEx so that we can detect if the address is a single cell vs a range(dimension?). If a  dimensions property exist on the return object from decodeEx, it will shortcircuit and use the range.


## Test plan
I added a integration test demonstrating it now works with no error: `spec/integration/issues/issue-1027-sheet-defined-data-validate.spec.js`
