### PR TITLE
Fix type definition for DefinedNamesRanges

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1626,7 +1626,7 @@ export interface CellMatrix {
 
 export interface DefinedNamesRanges {
 	name: string;
-	range: string[];
+	ranges: string[];
 }
 
 export type DefinedNamesModel = DefinedNamesRanges[];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The `DefinedNamesRanges` type actually has a `ranges` property, not a `range` property. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This is the code that populates the named ranges list: https://github.com/exceljs/exceljs/blob/master/lib/doc/defined-names.js#L143

As you can tell the field is named `ranges`, not `range`