### PR TITLE
Performance improvement in col-cache

### DIFF
--- a/lib/utils/col-cache.js
+++ b/lib/utils/col-cache.js
@@ -47,6 +47,9 @@ const colCache = {
     let l2;
     let l3;
     let n = 1;
+    if (level >= 4) {
+      throw new Error(`Out of bounds. Excel supports columns from 1 to 16384`);
+    }
     if (level >= 1) {
       while (n <= 26) {
         c = this._dictionary[n - 1];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Certain XLSX files have references to "TRUE" and "FALSE" that get ultimately passed over to the col-cache l2n method. When l2n is passed a string of 4 characters or more, it ends up regenerating the dictionary from scratch each time.

For a particular XLSX file I was working with, this change resulted in an overall 2x performance improvement. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

This change doesn't affect behavior, as `l2n` already throws when it encounters a string which is out of range. This change makes it throw earlier- before repopulating a 16384-length array each time. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
