### PR TITLE
add A3 paperSize number

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ worksheet.pageSetup.printTitlesColumn = 'A:C';
 | Letter                        | undefined |
 | Legal                         |  5        |
 | Executive                     |  7        |
+| A3                            |  8        |
 | A4                            |  9        |
 | A5                            |  11       |
 | B5 (JIS)                      |  13       |

--- a/README_zh.md
+++ b/README_zh.md
@@ -442,6 +442,7 @@ worksheet.pageSetup.printTitlesColumn = 'A:C';
 | Letter                        | `undefined` |
 | Legal                         | 5           |
 | Executive                     | 7           |
+| A3                            | 8           |
 | A4                            | 9           |
 | A5                            | 11          |
 | B5 (JIS)                      | 13          |

--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -50,6 +50,11 @@ class Workbook {
       // eslint-disable-next-line no-console
       console.warn(`Worksheet name ${name} exceeds 31 chars. This will be truncated`);
     }
+
+    if (this.containIllegalSheetName(name)) {
+      throw new Error(`Worksheet name cannot contain the characters * ? : / \\ [ ] : ${name}`);
+    }
+
     name = (name || `sheet${id}`).substring(0, 31);
     if (this._worksheets.find(ws => ws && ws.name.toLowerCase() === name.toLowerCase())) {
       throw new Error(`Worksheet name already exists: ${name}`);
@@ -95,6 +100,12 @@ class Workbook {
 
     this._worksheets[id] = worksheet;
     return worksheet;
+  }
+
+  // Illegal character in worksheet name: asterisk (*), question mark (?),
+  // colon (:), forward slash (/ \), or bracket ([])
+  containIllegalSheetName(sheetName) {
+    return /(\*)|(\?)|(:)|(\/)|(\\)|(\[)|(\])/.test(sheetName);
   }
 
   removeWorksheetEx(worksheet) {

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -659,6 +659,22 @@ describe('Worksheet', () => {
       });
     });
 
+    context('when the worksheet name contains illegal characters', () => {
+      it('when the worksheet name contain < > * ? " | : / \\ [ ]', () => {
+        const workbook = new ExcelJS.Workbook();
+
+        const invalideNames = ['*', '?', ':', '/', '\\', '[', ']'];
+        const expectedError =
+          'Worksheet name cannot contain the characters * ? : / \\ [ ] : ';
+
+        invalideNames.forEach(invalideName => {
+          expect(() => workbook.addWorksheet(invalideName)).to.throw(
+            expectedError + invalideName
+          );
+        });
+      });
+    });
+
     context('when worksheet name already exists', () => {
       it('throws an error', () => {
         const wb = new ExcelJS.Workbook();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Add the corresponding papersize for A3 to improve the document.
I didn't see any unit tests about papersize, so I didn't add unit tests, but I think Microsoft's excel file specifications are the same.
I only tested the papersize of A3. [Reference documents](https://docs.microsoft.com/zh-cn/office/vba/api/excel.xlpapersize)