### PR TITLE
add A3 paperSize number

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ worksheet.pageSetup.printTitlesColumn = 'A:C';
 | Letter                        | undefined |
 | Legal                         |  5        |
 | Executive                     |  7        |
+| A3                            |  8        |
 | A4                            |  9        |
 | A5                            |  11       |
 | B5 (JIS)                      |  13       |

--- a/README_zh.md
+++ b/README_zh.md
@@ -442,6 +442,7 @@ worksheet.pageSetup.printTitlesColumn = 'A:C';
 | Letter                        | `undefined` |
 | Legal                         | 5           |
 | Executive                     | 7           |
+| A3                            | 8           |
 | A4                            | 9           |
 | A5                            | 11          |
 | B5 (JIS)                      | 13          |


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Add the corresponding papersize for A3 to improve the document.
I didn't see any unit tests about papersize, so I didn't add unit tests, but I think Microsoft's excel file specifications are the same.
I only tested the papersize of A3. [Reference documents](https://docs.microsoft.com/zh-cn/office/vba/api/excel.xlpapersize)

The origin of the problem. #1406 