### PR TITLE
xlsx: use TextDecoder and TextEncoder in browser

### DIFF
--- a/lib/utils/browser-buffer-decode.js
+++ b/lib/utils/browser-buffer-decode.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
+const textDecoder = typeof TextDecoder === 'undefined' ? null : new TextDecoder('utf-8');
+
+function bufferToString(chunk) {
+  if (typeof chunk === 'string') {
+    return chunk;
+  }
+  if (textDecoder) {
+    return textDecoder.decode(chunk);
+  }
+  return chunk.toString();
+}
+
+exports.bufferToString = bufferToString;

--- a/lib/utils/browser-buffer-encode.js
+++ b/lib/utils/browser-buffer-encode.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
+const textEncoder = typeof TextEncoder === 'undefined' ? null : new TextEncoder('utf-8');
+const {Buffer} = require('buffer');
+
+function stringToBuffer(str) {
+  if (typeof str !== 'string') {
+    return str;
+  }
+  if (textEncoder) {
+    return Buffer.from(textEncoder.encode(str).buffer);
+  }
+  return Buffer.from(str);
+}
+
+exports.stringToBuffer = stringToBuffer;

--- a/lib/utils/parse-sax.js
+++ b/lib/utils/parse-sax.js
@@ -1,5 +1,6 @@
 const {SaxesParser} = require('saxes');
 const {PassThrough} = require('readable-stream');
+const {bufferToString} = require('./browser-buffer-decode');
 
 module.exports = async function* (iterable) {
   // TODO: Remove once node v8 is deprecated
@@ -17,7 +18,7 @@ module.exports = async function* (iterable) {
   saxesParser.on('text', value => events.push({eventType: 'text', value}));
   saxesParser.on('closetag', value => events.push({eventType: 'closetag', value}));
   for await (const chunk of iterable) {
-    saxesParser.write(chunk.toString());
+    saxesParser.write(bufferToString(chunk));
     // saxesParser.write and saxesParser.on() are synchronous,
     // so we can only reach the below line once all events have been emitted
     if (error) throw error;

--- a/lib/utils/zip-stream.js
+++ b/lib/utils/zip-stream.js
@@ -2,6 +2,7 @@ const events = require('events');
 const JSZip = require('jszip');
 
 const StreamBuf = require('./stream-buf');
+const {stringToBuffer} = require('./browser-buffer-encode');
 
 // =============================================================================
 // The ZipWriter class
@@ -25,6 +26,11 @@ class ZipWriter extends events.EventEmitter {
     if (options.hasOwnProperty('base64') && options.base64) {
       this.zip.file(options.name, data, {base64: true});
     } else {
+      // https://www.npmjs.com/package/process
+      if (process.browser && typeof data === 'string') {
+        // use TextEncoder in browser
+        data = stringToBuffer(data);
+      }
       this.zip.file(options.name, data);
     }
   }

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -6,6 +6,7 @@ const StreamBuf = require('../utils/stream-buf');
 
 const utils = require('../utils/utils');
 const XmlStream = require('../utils/xml-stream');
+const {bufferToString} = require('../utils/browser-buffer-decode');
 
 const StylesXform = require('./xform/style/styles-xform');
 
@@ -283,11 +284,27 @@ class XLSX {
         if (entryName[0] === '/') {
           entryName = entryName.substr(1);
         }
-        const stream = new PassThrough();
-        if (entryName.match(/xl\/media\//)) {
+        let stream;
+        if (entryName.match(/xl\/media\//) ||
+          // themes are not parsed as stream
+          entryName.match(/xl\/theme\/([a-zA-Z0-9]+)[.]xml/)) {
+          stream = new PassThrough();
           stream.write(await entry.async('nodebuffer'));
         } else {
-          const content = await entry.async('string');
+          // use object mode to avoid buffer-string convention
+          stream = new PassThrough({
+            writableObjectMode: true,
+            readableObjectMode: true,
+          });
+          let content;
+          // https://www.npmjs.com/package/process
+          if (process.browser) {
+            // running in browser, use TextDecoder if possible
+            content = bufferToString(await entry.async('nodebuffer'));
+          } else {
+            // running in node.js
+            content = await entry.async('string');
+          }
           const chunkSize = 16 * 1024;
           for (let i = 0; i < content.length; i += chunkSize) {
             stream.write(content.substring(i, i + chunkSize));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Doing a profiling in chrome dev tools shows that the `Buffer.toString()` and `Buffer.from(string)` is using unexpected long cpu time. With the native TextDecoder and TextEncoder it can get much faster in browsers supporting it.
On browsers not supporting TextDecoder, like Internet Explorer, this would fallback to original `Buffer.toString()` and `Buffer.from(string)`.
This implements almost the same of https://github.com/exceljs/exceljs/pull/1458 in a non monkey-patching way covering xlsx only.
Closes https://github.com/exceljs/exceljs/pull/1458

References:
https://github.com/feross/buffer/issues/268
https://github.com/feross/buffer/issues/60
https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder
https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Profiling below is based on reading `spec/integration/data/huge.xlsx`.

<details> 
  <summary>Profiling result before this</summary>

![before](https://user-images.githubusercontent.com/17702502/94983326-495b5680-0574-11eb-9cfb-1e12e938f048.PNG)
[Profile-before.json.gz](https://github.com/exceljs/exceljs/files/5321093/Profile-before.json.gz)

</details>

<details> 
  <summary>Profiling result after this</summary>

![after](https://user-images.githubusercontent.com/17702502/95050933-fc67b380-071e-11eb-9810-5846c6d28899.PNG)
[Profile-after.json.gz](https://github.com/exceljs/exceljs/files/5325842/Profile-after.json.gz)


</details>