### PR TITLE
Clarify `encoding` option is just for `.writeFile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2226,7 +2226,7 @@ Options supported when writing to a CSV file.
 | ---------------- | ----------- | ----------- | ----------- |
 | dateFormat       |     N       |  String     | Specify the date encoding format of dayjs. |
 | dateUTC          |     N       |  Boolean    | Specify whether ExcelJS uses `dayjs.utc ()` to convert time zone for parsing dates. |
-| encoding         |     N       |  String     | Specify file encoding format. |
+| encoding         |     N       |  String     | Specify file encoding format. (Only applies to `.writeFile`.) |
 | includeEmptyRows |     N       |  Boolean    | Specifies whether empty rows can be written. |
 | map              |     N       |  Function   | Custom Array.prototype.map() callback function for processing row values. |
 | sheetName        |     N       |  String     | Specify worksheet name. |


### PR DESCRIPTION
This is a docs improvement. It notes that the `encoding` option is for `workbook.csv.writeFile`, and not `workbook.csv.write`.

## Summary

The motivation is that the encoding option wasn't fully clear which methods it applied to. See also #1473.

## Test plan

N/A

## Other

This change is extremely minor... I can add it to #1495 if wanted, since they're both related to this `encoding` option.
