### PR TITLE
docs: fix default options for streaming xlsx reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -2491,10 +2491,10 @@ The constructor takes a required input argument and an optional options argument
 | --------------------- | ----------- |
 | input (required)      | Specifies the name of the file or the readable stream from which to read the XLSX workbook. |
 | options (optional)    | Specifies how to handle the event types occuring during the read parsing. |
-| options.entries       | Specifies whether to emit entries (`'emit'`) or not (`'ignore'`). Default is `'emit'`. |
+| options.entries       | Specifies whether to emit entries (`'emit'`) or not (`'ignore'`). Default is `'ignore'`. |
 | options.sharedStrings | Specifies whether to cache shared strings (`'cache'`), which inserts them into the respective cell values, or whether to emit them (`'emit'`) or ignore them (`'ignore'`), in both of which case the cell value will be a reference to the shared string's index. Default is `'cache'`. |
-| options.hyperlinks    | Specifies whether to cache hyperlinks (`'cache'`), which inserts them into their respective cells, whether to emit them (`'emit'`) or whether to ignore them (`'ignore'`). Default is `'cache'`. |
-| options.styles        | Specifies whether to cache styles (`'cache'`), which inserts them into their respective rows and cells, or whether to ignore them (`'ignore'`). Default is `'cache'`. |
+| options.hyperlinks    | Specifies whether to cache hyperlinks (`'cache'`), which inserts them into their respective cells, whether to emit them (`'emit'`) or whether to ignore them (`'ignore'`). Default is `'ignore'`. |
+| options.styles        | Specifies whether to cache styles (`'cache'`), which inserts them into their respective rows and cells, or whether to ignore them (`'ignore'`). Default is `'ignore'`. |
 | options.worksheets    | Specifies whether to emit worksheets (`'emit'`) or not (`'ignore'`). Default is `'emit'`. |
 
 ```js


### PR DESCRIPTION
## Summary

The docs do not match the implementation or the type information: https://github.com/exceljs/exceljs/blob/4e38ad8ed2a18b6fe3999528cd30bf8b6579c249/index.d.ts#L1958

Closes https://github.com/exceljs/exceljs/issues/1430


## Semi-related

- I think it would improve the docs to identify what "styles" means to the user - it isn't clear that type information (dates, for example) are a style and without `styles: 'cache'` all dates are unusable.
- The default values for these options seem like a bit of a footgun, maybe worth revisiting why these are the defaults?