### PR TITLE
Typing Table add row optional rowNumber

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1857,7 +1857,7 @@ export interface Table extends Required<TableProperties> {
 	/**
 	 * Add a row of data, either insert at rowNumber or append
 	 */
-	addRow: (values: any[], rowNumber: number) => void
+	addRow: (values: any[], rowNumber?: number) => void
 	/**
 	 * Get column
 	 */


### PR DESCRIPTION
## Summary

Using typescript the Table function `addRow` has a `rowNumber` parameter which is required but should be optional.

In the implementation https://github.com/exceljs/exceljs/blob/master/lib/doc/table.js#L341 there is a checks for undefined. And described in the comment above `either insert at rowNumber or append`