### PR TITLE
Typing FillPattern fgColor should be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,7 +167,7 @@ export type FillPatterns =
 export interface FillPattern {
 	type: 'pattern';
 	pattern: FillPatterns;
-	fgColor: Partial<Color>;
+	fgColor?: Partial<Color>;
 	bgColor?: Partial<Color>;
 }
 


### PR DESCRIPTION
## Summary

Using typescript the FillPattern the `fgColor` should be optional.

This is described in the documentation https://github.com/exceljs/exceljs/blame/master/README.md#L1722

