### PR TITLE
col listed in different order in the excel xml breaks props load

### DIFF
--- a/lib/doc/column.js
+++ b/lib/doc/column.js
@@ -294,6 +294,7 @@ class Column {
 
   static fromModel(worksheet, cols) {
     cols = cols || [];
+    cols.sort((a, b) => a.min - b.min);
     const columns = [];
     let count = 1;
     let index = 0;


### PR DESCRIPTION
## Summary

Sometimes xlsx generated from 3rd party libraries (360EntSecGroup-Skylar/excelize or jxls-poi) has the <col> tag in a different order vs the min/max on them.
```
  <cols>
    <col min="4" max="4" customWidth="true" style="164" width="12.6640625" collapsed="true"/>
    <col min="1" max="1" customWidth="true" width="73.6640625" collapsed="false"/>
    <col min="2" max="2" customWidth="true" hidden="true" width="3.5" collapsed="false"/>
    <col min="3" max="3" customWidth="true" style="164" width="12.6640625" collapsed="false"/>
```

This causes the properties to be lost (not with, hidden .. etc)

## Test plan

Wrote unit test.
