### PR TITLE
Fixed return type on getRows

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1244,7 +1244,7 @@ export interface Worksheet {
 	/**
 	 * Get or create rows by 1-based index
 	 */
-	getRows(start: number, length: number): Row[];
+	getRows(start: number, length: number): Row[] | undefined;
 
 	/**
 	 * Iterate over all rows that have values in a worksheet

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -639,6 +639,13 @@ describe('Worksheet', () => {
       expect(count).to.equal(7);
     });
 
+    it('returns undefined when row range is less than 1', () => {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('blort');
+
+      expect(ws.getRows(1, 0)).to.equal(undefined);
+    });
+
     context('when worksheet name is less than or equal 31', () => {
       it('save the original name', () => {
         const wb = new ExcelJS.Workbook();


### PR DESCRIPTION
## Summary

This PR updates the typescript definition file to have the correct return type for getRows. 

## Test plan

As you can see from this file https://github.com/exceljs/exceljs/blob/d76dc388d6b0914262feff24eb6386d4c030e4bb/lib/doc/worksheet.js#L352 when the range is < 1 it will return undefined.

I have also added a unit test to demonstrate that when the range is < 1 it returns undefined
