### PR TITLE
fix: cell.style.fill problems

### DIFF
--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -4,6 +4,7 @@ const _ = require('../utils/under-dash');
 const Enums = require('./enums');
 const {slideFormula} = require('../utils/shared-formula');
 const Note = require('./note');
+const utils = require('../utils/utils');
 // Cell requirements
 //  Operate inside a worksheet
 //  Store and retrieve a value with a range of types: text, number, date, hyperlink, reference, formula, etc.
@@ -349,7 +350,7 @@ class Cell {
     }
 
     if (value.style) {
-      this.style = value.style;
+      this.style = utils.cloneDeep(value.style);
     } else {
       this.style = {};
     }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -165,6 +165,25 @@ const utils = {
   toIsoDateString(dt) {
     return dt.toIsoString().subsstr(0, 10);
   },
+
+  cloneDeep(value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Date) {
+      return value;
+    }
+    if (!(value instanceof Array) && !(typeof value === 'object')) {
+      return value;
+    }
+    const cloneObject = new value.constructor();
+    Object.keys(value).forEach(attr => {
+      cloneObject[attr] =
+        typeof value[attr] === 'object' ? this.cloneDeep(value[attr]) : value[attr];
+    });
+
+    return cloneObject;
+  },
 };
 
 module.exports = utils;

--- a/spec/unit/utils/utils.spec.js
+++ b/spec/unit/utils/utils.spec.js
@@ -66,4 +66,51 @@ describe('utils', () => {
       expect(dateConverted).to.deep.equal(myDate);
     });
   });
+
+  describe('cloneDeep', () => {
+    it('should be null', () => {
+      const clone = utils.cloneDeep(null);
+
+      expect(clone).to.be.equal(null);
+    });
+    it('should be date', () => {
+      const myDate = new Date(Date.UTC(2017, 11, 15, 17, 0, 0, 0));
+      const cloneDate = utils.cloneDeep(myDate);
+
+      expect(cloneDate).to.deep.equal(myDate);
+    });
+    it('should be string', () => {
+      const clone = utils.cloneDeep('string');
+
+      expect(clone).to.equal('string');
+    });
+    it('should be array', () => {
+      const origin = [1, 2, [3, undefined, [5]]];
+      const clone = utils.cloneDeep(origin);
+
+      expect(clone).to.deep.equal(origin);
+
+      origin.push(6);
+
+      expect(clone).not.to.deep.equal(origin);
+    });
+    it('should be object', () => {
+      const origin = {
+        name: 'test',
+        goods: [1, 2, 3, [4]],
+        theme: {
+          font: 'red',
+          size: 12,
+          border: undefined,
+        },
+      };
+      const clone = utils.cloneDeep(origin);
+
+      expect(clone).to.deep.equal(origin);
+
+      origin.theme.size = 13;
+
+      expect(clone).not.to.deep.equal(origin);
+    });
+  });
 });


### PR DESCRIPTION
# Summary
After all the borders of (A1: B1) are set, read the excel file, and then change the background color of cell A1. The background color of cell B1 will also change.
create test_a.xlsx
```javascript
  const wb = new ExcelJS.Workbook();
  const worksheet = wb.addWorksheet('Sheet1');
  const border = {"left":{"style":"thin"},"right":{"style":"thin"},"top":{"style":"thin"},"bottom":{"style":"thin"}};
  worksheet.getCell('A1').style.border = border;
  worksheet.getCell('A1').value = 'A1';
  worksheet.getCell('B1').style.border = border;
  worksheet.getCell('B1').value = 'B1';
  wb.xlsx.writeFile(path.resolve('./spec/unit/doc/test_a.xlsx'));
```
Then read excel
```javascript
  const wb = new ExcelJS.Workbook();
  const workbook = await wb.xlsx.readFile('./spec/unit/doc/test_a.xlsx');
  workbook.getWorksheet(1).getCell('A1').style.fill = {
    type: 'pattern',
    pattern: 'solid',
    fgColor: { argb: 'FFFF0000' },
    bgColor: { indexed: 64 }
  };
  console.log(workbook.getWorksheet(1).getCell('A1').style.fill === workbook.getWorksheet(1).getCell('B1').style.fill);
  // **true**

  console.log(workbook.getWorksheet(1).getCell('B1').style.fill);
  console.log(workbook.getWorksheet(1).getCell('A1').style.fill);
  workbook.xlsx.writeFile(path.resolve('./spec/unit/doc/test_a0000.xlsx'));
```
fill A1 with red solid but A2 also red solid

Test plan spec\unit\utils
A simple test is included in spec/unit/utils/utils.spec.js