### PR TITLE
return destination stream when piping in StreamBuf

### DIFF
--- a/lib/utils/stream-buf.js
+++ b/lib/utils/stream-buf.js
@@ -345,6 +345,7 @@ utils.inherits(StreamBuf, Stream.Duplex, {
     if (!this.paused && this.buffers.length) {
       this.end();
     }
+    return destination;
   },
   unpipe(destination) {
     // remove destination from pipe list

--- a/spec/unit/utils/stream-buf.spec.js
+++ b/spec/unit/utils/stream-buf.spec.js
@@ -59,4 +59,9 @@ describe('StreamBuf', () => {
       );
     }
   });
+  it('returns stream when piping', async () => {
+    const stream1 = new StreamBuf();
+    const stream2 = new StreamBuf();
+    expect(stream1.pipe(stream2)).to.equal(stream2);
+  });
 });


### PR DESCRIPTION
Fixes StreamBuf pipe method, returning the destination stream. Fixes #1595

## Summary

Fixes usages of StreamBuf in [stream.pipeline](https://nodejs.org/api/stream.html#stream_stream_pipeline_source_transforms_destination_callback) and calls such as:
```javascript
worbook.stream.pipe(fs.createWritableStream('/tmp/sheet.xlsx'))
    .on('finish', ()=>console.log('Sheet has been written!'));
```

## Test plan

Added a unit test related to this change.
