### PR TITLE
Add type definition for lastColumn property (fixes #1453)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1137,6 +1137,11 @@ export interface Worksheet {
 	readonly columnCount: number;
 
 	/**
+	 * Get the last column in a worksheet
+	 */
+	readonly lastColumn: Column;
+
+	/**
 	 * A count of the number of columns that have values.
 	 */
 	readonly actualColumnCount: number;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

As detected as missing in #1453, the lastColumn property has its type defined in this PR.