### PR TITLE
FIXES #713 Remove 'use strict' strings brute force to enable module packaging

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -3,6 +3,7 @@
 module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-babel');
   grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-string-replace');
   grunt.loadNpmTasks('grunt-terser');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-contrib-copy');
@@ -27,14 +28,17 @@ module.exports = function(grunt) {
     browserify: {
       options: {
         transform: [
-          ['babelify', {
-            // enable babel transpile for node_modules
-            global: true,
-            presets: ['@babel/preset-env'],
-            // core-js should not be transpiled
-            // See https://github.com/zloirock/core-js/issues/514
-            ignore: [/node_modules[\\/]core-js/],
-          }],
+          [
+            'babelify',
+            {
+              // enable babel transpile for node_modules
+              global: true,
+              presets: ['@babel/preset-env'],
+              // core-js should not be transpiled
+              // See https://github.com/zloirock/core-js/issues/514
+              ignore: [/node_modules[\\/]core-js/],
+            },
+          ],
         ],
         browserifyOptions: {
           // enable source map for browserify
@@ -50,7 +54,7 @@ module.exports = function(grunt) {
       bundle: {
         // keep the original source for source maps
         src: ['./lib/exceljs.browser.js'],
-        dest: './dist/exceljs.js',
+        dest: './build/web/exceljs.browserify.js',
       },
       spec: {
         options: {
@@ -59,6 +63,21 @@ module.exports = function(grunt) {
         },
         src: ['./build/spec/browser/exceljs.spec.js'],
         dest: './build/web/exceljs.spec.js',
+      },
+    },
+
+    'string-replace': {
+      dist: {
+        options: {
+          replacements: [
+            {
+              pattern: /("use strict")|('use strict')/g,
+              replacement: '\'\'',
+            },
+          ],
+        },
+        src: ['./build/web/exceljs.browserify.js'],
+        dest: './dist/exceljs.js',
       },
     },
 
@@ -128,6 +147,6 @@ module.exports = function(grunt) {
     },
   });
 
-  grunt.registerTask('build', ['babel:dist', 'browserify', 'terser', 'exorcise', 'copy']);
+  grunt.registerTask('build', ['babel:dist', 'browserify', 'string-replace', 'terser', 'exorcise', 'copy']);
   grunt.registerTask('ug', ['terser']);
 };

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "grunt-contrib-jasmine": "^2.2.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-exorcise": "^2.1.1",
+    "grunt-string-replace": "^1.3.1",
     "grunt-terser": "^1.0.0",
     "husky": "^4.3.0",
     "lint-staged": "^10.2.13",


### PR DESCRIPTION
## Summary

The current ExcelJS fails with CSP unsafe code evaluation when exceljs is bundled with recent WebPack versions. It appears that the root cause is regenerator-runtime resorting to 'eval':ing the source code whenever it encounters "use strict". This is probably because "use strict" shouldn't be necessary with ES modules (they are strict by default).

I tried various workarounds, such as replacing all "use strict" clauses when babelifying code, having similar replacements with browserify etc. I am almost sure the root cause relates to browserify, e.g. it somehow ends up adding the "use strict" clauses. In absence of a better solution, I thought that brute force removal of "use strict" strings was the only option left, so I added a Grunt task for that. I tried the more popular "grunt-replace" module for this, but unfortunately it failed to process some of the libraries included (because of @@ character somewhere within the code).

I think the long term solution would be to replace the current build system with some other than browserify that would supply the needed polyfills, but I believe such an architectural change would be much bigger undertaking.

## Test plan

Steps to repeat:
1) Include the module in a Webpack build, insert `new CspHtmlWebpackPlugin(cspConfigPolicy, cspOptions)` into plugins array
2) `npm link` the exceljs module into your project
3) Build and load the web page

## Related to source code (for typings update)

N/A