### PR TITLE
fix issue #894

### DIFF
--- a/lib/doc/anchor.js
+++ b/lib/doc/anchor.js
@@ -4,6 +4,7 @@ const colCache = require('../utils/col-cache');
 
 class Anchor {
   constructor(worksheet, address, offset = 0) {
+    this.worksheet = worksheet;
     if (!address) {
       this.nativeCol = 0;
       this.nativeColOff = 0;
@@ -29,8 +30,6 @@ class Anchor {
       this.nativeRow = 0;
       this.nativeRowOff = 0;
     }
-
-    this.worksheet = worksheet;
   }
 
   static asInstance(model) {
@@ -56,18 +55,20 @@ class Anchor {
   }
 
   get colWidth() {
+    let width = this.worksheet.properties.defaultColWidth != undefined ? this.worksheet.properties.defaultColWidth : 9.14285714285714;
     return this.worksheet &&
       this.worksheet.getColumn(this.nativeCol + 1) &&
       this.worksheet.getColumn(this.nativeCol + 1).isCustomWidth
-      ? Math.floor(this.worksheet.getColumn(this.nativeCol + 1).width * 10000)
+      ? Math.floor(this.worksheet.getColumn(this.nativeCol + 1).width/width * 640000)
       : 640000;
   }
 
   get rowHeight() {
+    let height = this.worksheet.properties.defaultRowHeight != undefined ? this.worksheet.properties.defaultRowHeight : 15;
     return this.worksheet &&
       this.worksheet.getRow(this.nativeRow + 1) &&
       this.worksheet.getRow(this.nativeRow + 1).height
-      ? Math.floor(this.worksheet.getRow(this.nativeRow + 1).height * 10000)
+      ? Math.floor(this.worksheet.getRow(this.nativeRow + 1).height/height * 180000)
       : 180000;
   }
 


### PR DESCRIPTION
## Summary
When I use this lib for excel exporting, I found that the issue with image exporting.
When add image with none integer coordinates, I get the wrong position in result file. I found others also facing this problem in issues like #894.

I make some test and lookup the data affter unziping the drawing.xml file. I found that the error is caused by the wrong colwidth and rowheight. The tl and br are set to float number, if the col and row are not resized, the result is ok. But when width or height of the cell, in which tl or br defined, were resized, the result were still calculated with the standard cell width and row. So we got the wrong result.

## Test plan
I read the code related with this problem. Finally, I found the reason occured in anchor.js. There is my fix below.

Put the following code in the first line in constructor function. After this we can get the real column width and row height in worksheet.
this.worksheet = worksheet;

Then, modify the colWidth and rowHeight getters methods to get the correct number. As the default height or width can be undefined in worksheet properties, so we can add some protection code for below sample. We can check if the default heigth or width defined, if not, use constant value instead. (for example, height is 15, width is 9.14XXXXXX.)
Math.floor(this.worksheet.getRow(this.nativeRow + 1).height/this.worksheet.properties.defaultRowHeight * 180000) Math.floor(this.worksheet.getColumn(this.nativeCol + 1).width/this.worksheet.properties.defaultColWidth * 640000)

as the following code we put the image in xlsx with correct positions.
worksheet.addImage(imageId, { tl: {col: 1.1, row: 5.83 }, br: {col: 8.85, row: 10.2 } });
testimage
[https://user-images.githubusercontent.com/12286518/111744731-a64e8d00-88c6-11eb-827f-bff3231177ba.png](url)

