### PR TITLE
Added Node v16 to the test suite

### DIFF
--- a/.github/workflows/exceljs.yml
+++ b/.github/workflows/exceljs.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/actions/setup-node/issues/27
-        node-version: [8.17.0, 10.x, 12.x, 14.x]
+        node-version: [8.17.0, 10.x, 12.x, 14.x, 16.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary

v16 is a new major version of Node.js, let's make sure to add test case of this.

Related to (at least) issue #1594
