### PR TITLE
fix CSV reading large number

### DIFF
--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -59,7 +59,7 @@ class CSV {
             return null;
           }
           const datumNumber = Number(datum);
-          if (!Number.isNaN(datumNumber) && datumNumber !== Infinity) {
+          if (!Number.isNaN(datumNumber) && datumNumber !== Infinity && String(datumNumber) === String(datum)) {
             return datumNumber;
           }
           const dt = dateFormats.reduce((matchingDate, currentDateFormat) => {


### PR DESCRIPTION
## Summary

When I read in a CSV file with a value in a cell that exceed the Number() limit in JavaScript then it does not fail graciously.  It simply returns a number but it's extremely hard to catch.  I think in these situations it needs to just return a string so that the user can figure out what they want to do with it, whether it's converting to a BigInt (which is a glorified String anyway) or actually storing their value as a String. 

Example:
56343416020533614003

When you try to parse it as a number in csv.js you are doing...
Number(56343416020533614003)

This ends up being 56343416020533620000 in JavaScript

You'd even see that String(Number(56343416020533614003)) == '56343416020533614003' => true because it's coerce the string to a Number with double-equals.  I want a triple-equal check so that we can skip the step in csv.js that's returning the number and instead return a string if it's too big of a number so that the consumer doesn't lose the original value.

## Test plan

Please help me with the standard test plan that you might want to use for this?  I'm not sure since there are so many test vectors in this code base.
