### PR TITLE
Add removeNote method exceljs#1153

### DIFF
--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -229,6 +229,10 @@ class Cell {
     this._comment = new Note(note);
   }
 
+  removeNote() {
+    delete this._comment;
+  }
+
   get text() {
     return this._value.toString();
   }
@@ -331,6 +335,8 @@ class Cell {
     model.style = this.style;
     if (this._comment) {
       model.comment = this._comment.model;
+    } else {
+      delete model.comment;
     }
     return model;
   }
@@ -862,8 +868,7 @@ class FormulaValue {
     if (!this._translatedFormula && this.model.sharedFormula) {
       const {worksheet} = this.cell;
       const master = worksheet.findCell(this.model.sharedFormula);
-      this._translatedFormula =
-        master && slideFormula(master.formula, master.address, this.model.address);
+      this._translatedFormula = master && slideFormula(master.formula, master.address, this.model.address);
     }
     return this._translatedFormula;
   }

--- a/spec/unit/doc/cell.spec.js
+++ b/spec/unit/doc/cell.spec.js
@@ -369,6 +369,28 @@ describe('Cell', () => {
     expect(a1.model.comment.note).to.deep.equal(comment);
   });
 
+  it('can remove comment', () => {
+    const a1 = sheetMock.getCell('A1');
+
+    expect(a1.note).to.be.undefined();
+
+    a1.note = 'Some note';
+    expect(a1.model.comment.note.texts[0].text).to.be.eq('Some note');
+
+    a1.removeNote();
+    expect(a1.model.comment).to.be.undefined();
+  });
+
+  it('fails to remove comment by assigning empty object', () => {
+    const a1 = sheetMock.getCell('A1');
+    a1.note = 'Some note';
+
+    expect(a1.model.comment.note.texts[0].text).to.be.eq('Some note');
+
+    a1.note = {};
+    expect(a1.model.comment).to.exist();
+  });
+
   it('Cell comments supports setting margins, protection, and position properties', () => {
     const a1 = sheetMock.getCell('A1');
 
@@ -399,10 +421,7 @@ describe('Cell', () => {
     expect(a1.model.comment.note.protection).to.deep.equal(comment.protection);
     expect(a1.model.comment.note.margins.insetmode).to.equal('auto');
     expect(a1.model.comment.note.margins.inset).to.deep.equal([
-      0.13,
-      0.13,
-      0.25,
-      0.25,
+      0.13, 0.13, 0.25, 0.25,
     ]);
     expect(a1.model.comment.note.editAs).to.equal('absolute');
   });

--- a/test/test-comments-remove.js
+++ b/test/test-comments-remove.js
@@ -1,0 +1,14 @@
+const Excel = require('../lib/exceljs.nodejs');
+
+const wb = new Excel.Workbook();
+wb.xlsx
+  .readFile(require.resolve('./data/comments.xlsx'))
+  .then(() => {
+    wb.worksheets.forEach(sheet => {
+      sheet.getCell('A1').removeNote();
+      sheet.getCell('B1').removeNote();
+    });
+
+    return wb.xlsx.writeFile(`${__dirname}/data/test.xlsx`);
+  })
+  .catch(console.error);


### PR DESCRIPTION
## Summary
There is no way to remove a note currently. I found related question: https://github.com/exceljs/exceljs/issues/1153 

According to @Siemienik's comment
```
ws.getCell('A1').note = {};
```
should work. But it just sets the empty comment and not removing it, which can be seen in excel.

<img width="260" alt="Screenshot 2021-06-12 at 20 26 55" src="https://user-images.githubusercontent.com/664335/121775887-a5bf4d00-cbbc-11eb-887a-d2e788d21c91.png">


## Test plan

I've added some unit tests to test that `_comment` property is removed from the Cell class.
I've added a `test-comment-remove.js` script that gets `comments.xlsx` file with comments and generates `test.xlsx` file without comments to check that it's working properly.

<img width="214" alt="Screenshot 2021-06-12 at 20 29 10" src="https://user-images.githubusercontent.com/664335/121775985-23835880-cbbd-11eb-842d-47ec9ad4c113.png">
