### PR TITLE
Added External Data Validations

### DIFF
--- a/lib/xlsx/xform/sheet/data-validations-xform.js
+++ b/lib/xlsx/xform/sheet/data-validations-xform.js
@@ -2,6 +2,7 @@ const _ = require('../../../utils/under-dash');
 const utils = require('../../../utils/utils');
 const colCache = require('../../../utils/col-cache');
 const BaseXform = require('../base-xform');
+const DataValidationExtXform = require('./dv-ext/data-validation-ext-xform');
 const Range = require('../../../doc/range');
 
 function assign(definedName, attributes, name, defaultValue) {
@@ -29,7 +30,11 @@ function optimiseDataValidations(model) {
     address,
     dataValidation,
     marked: false,
-  })).sort((a, b) => _.strcmp(a.address, b.address));
+  }))
+    .filter(dv => {
+      return !DataValidationExtXform.isExt(dv.dataValidation) && dv.address !== 'hasExtContent';
+    })
+    .sort((a, b) => _.strcmp(a.address, b.address));
   const dvMap = _.keyBy(dvList, 'address');
   const matchCol = (addr, height, col) => {
     for (let i = 0; i < height; i++) {

--- a/lib/xlsx/xform/sheet/dv-ext/data-validation-ext-xform.js
+++ b/lib/xlsx/xform/sheet/dv-ext/data-validation-ext-xform.js
@@ -1,0 +1,141 @@
+const CompositeXform = require('../../composite-xform');
+
+const FormulaExtXform = require('./formula-ext-xform');
+const SqRefExtXform = require('../cf-ext/sqref-ext-xform');
+
+function assign(definedName, attributes, name, defaultValue) {
+  const value = attributes[name];
+  if (value !== undefined) {
+    definedName[name] = value;
+  } else if (defaultValue !== undefined) {
+    definedName[name] = defaultValue;
+  }
+}
+function parseBool(value) {
+  switch (value) {
+    case '1':
+    case 'true':
+      return true;
+    default:
+      return false;
+  }
+}
+function assignBool(definedName, attributes, name, defaultValue) {
+  const value = attributes[name];
+  if (value !== undefined) {
+    definedName[name] = parseBool(value);
+  } else if (defaultValue !== undefined) {
+    definedName[name] = defaultValue;
+  }
+}
+
+class DataValidationExtXform extends CompositeXform {
+  // Inspired from the data-validation-xform file
+  // Normally there should only be lists types,
+  // with a formula and a sqRef (as a node, contrary to normal data validations)
+
+  constructor() {
+    super();
+
+    this.map = {
+      'xm:sqref': (this.sqRef = new SqRefExtXform()),
+      'x14:formula1': (this.formula = new FormulaExtXform()),
+    };
+  }
+
+  get tag() {
+    return 'x14:dataValidation';
+  }
+
+  static isExt(dataValidation) {
+    if (
+      dataValidation.formulae &&
+      dataValidation.formulae.length === 1 &&
+      typeof dataValidation.formulae[0] === 'string'
+    ) {
+      const worksheetNameRegex = new RegExp(
+        [
+          /(('[^/\\?*[\]]{1,31}'|[A-Za-z0-9_]{1,31})!)/,
+          /((\$?[A-Za-z]{1,3})(\$?[0-9]{1,6}))(:((\$?[A-Za-z]{1,3})(\$?[0-9]{1,6})))?/,
+        ]
+          .map(reg => reg.source)
+          .join('')
+      );
+      const match = worksheetNameRegex.test(dataValidation.formulae[0]);
+      return dataValidation.type === 'list' && match;
+    }
+    return false;
+  }
+
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag);
+
+    // We keep the same logic as with normal data validations,
+    // although there should be only the type "list" for external data validations
+    if (model.type !== 'any') {
+      xmlStream.addAttribute('type', model.type);
+
+      if (model.allowBlank) {
+        xmlStream.addAttribute('allowBlank', '1');
+      }
+    }
+    if (model.showInputMessage) {
+      xmlStream.addAttribute('showInputMessage', '1');
+    }
+    if (model.promptTitle) {
+      xmlStream.addAttribute('promptTitle', model.promptTitle);
+    }
+    if (model.prompt) {
+      xmlStream.addAttribute('prompt', model.prompt);
+    }
+    if (model.showErrorMessage) {
+      xmlStream.addAttribute('showErrorMessage', '1');
+    }
+    if (model.errorStyle) {
+      xmlStream.addAttribute('errorStyle', model.errorStyle);
+    }
+    if (model.errorTitle) {
+      xmlStream.addAttribute('errorTitle', model.errorTitle);
+    }
+    if (model.error) {
+      xmlStream.addAttribute('error', model.error);
+    }
+
+    // First the formula then the sqref
+    this.formula.render(xmlStream, model.formulae);
+    this.sqRef.render(xmlStream, model.sqref);
+
+    xmlStream.closeNode();
+  }
+
+  createNewModel(node) {
+    const dataValidation = {type: node.attributes.type || 'list'};
+
+    if (node.attributes.type) {
+      assignBool(dataValidation, node.attributes, 'allowBlank');
+    }
+    assignBool(dataValidation, node.attributes, 'showInputMessage');
+    assignBool(dataValidation, node.attributes, 'showErrorMessage');
+    assign(dataValidation, node.attributes, 'promptTitle');
+    assign(dataValidation, node.attributes, 'prompt');
+    assign(dataValidation, node.attributes, 'errorStyle');
+    assign(dataValidation, node.attributes, 'errorTitle');
+    assign(dataValidation, node.attributes, 'error');
+
+    return dataValidation;
+  }
+
+  onParserClose(name, parser) {
+    switch (name) {
+      case 'xm:sqref':
+        this.model._address = parser.model;
+        break;
+
+      case 'x14:formula1':
+        this.model.formulae = [parser.model['xm:f']];
+        break;
+    }
+  }
+}
+
+module.exports = DataValidationExtXform;

--- a/lib/xlsx/xform/sheet/dv-ext/data-validations-ext-xform.js
+++ b/lib/xlsx/xform/sheet/dv-ext/data-validations-ext-xform.js
@@ -1,0 +1,140 @@
+const _ = require('../../../../utils/under-dash');
+const CompositeXform = require('../../composite-xform');
+const Range = require('../../../../doc/range');
+const colCache = require('../../../../utils/col-cache');
+
+const DataValidationExtForm = require('./data-validation-ext-xform');
+const DataValidationExtXform = require('./data-validation-ext-xform');
+
+function optimiseDataValidations(model) {
+  // Squeeze alike data validations together into rectangular ranges
+  // to reduce file size and speed up Excel load time
+  // We do it only for external DVs
+  const dvList = _.map(model, (dataValidation, address) => ({
+    address,
+    dataValidation,
+    marked: false,
+  }))
+    .filter(dv => DataValidationExtXform.isExt(dv.dataValidation))
+    .sort((a, b) => _.strcmp(a.address, b.address));
+  const dvMap = _.keyBy(dvList, 'address');
+  const matchCol = (addr, height, col) => {
+    for (let i = 0; i < height; i++) {
+      const otherAddress = colCache.encodeAddress(addr.row + i, col);
+      if (!model[otherAddress] || !_.isEqual(model[addr.address], model[otherAddress])) {
+        return false;
+      }
+    }
+    return true;
+  };
+  return dvList
+    .map(dv => {
+      if (!dv.marked) {
+        const addr = colCache.decodeEx(dv.address);
+        if (addr.dimensions) {
+          dvMap[addr.dimensions].marked = true;
+          return {
+            ...dv.dataValidation,
+            sqref: dv.address,
+          };
+        }
+
+        // iterate downwards - finding matching cells
+        let height = 1;
+        let otherAddress = colCache.encodeAddress(addr.row + height, addr.col);
+        while (model[otherAddress] && _.isEqual(dv.dataValidation, model[otherAddress])) {
+          height++;
+          otherAddress = colCache.encodeAddress(addr.row + height, addr.col);
+        }
+
+        // iterate rightwards...
+
+        let width = 1;
+        while (matchCol(addr, height, addr.col + width)) {
+          width++;
+        }
+
+        // mark all included addresses
+        for (let i = 0; i < height; i++) {
+          for (let j = 0; j < width; j++) {
+            otherAddress = colCache.encodeAddress(addr.row + i, addr.col + j);
+            dvMap[otherAddress].marked = true;
+          }
+        }
+
+        if (height > 1 || width > 1) {
+          const bottom = addr.row + (height - 1);
+          const right = addr.col + (width - 1);
+          return {
+            ...dv.dataValidation,
+            sqref: `${dv.address}:${colCache.encodeAddress(bottom, right)}`,
+          };
+        }
+        return {
+          ...dv.dataValidation,
+          sqref: dv.address,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+class DataValidationsExtXform extends CompositeXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'x14:dataValidation': (this.dataValidation = new DataValidationExtForm()),
+    };
+  }
+
+  get tag() {
+    return 'x14:dataValidations';
+  }
+
+  render(xmlStream, model) {
+    const optimizedModel = optimiseDataValidations(model);
+    xmlStream.openNode(this.tag, {
+      count: optimizedModel.length,
+      'xmlns:xm': 'http://schemas.microsoft.com/office/excel/2006/main',
+    });
+    optimizedModel.forEach(value => {
+      this.dataValidation.render(xmlStream, value);
+    });
+    xmlStream.closeNode();
+  }
+
+  hasContent(model) {
+    if (!model) {
+      return false;
+    }
+    if (model.hasExtContent === undefined) {
+      model.hasExtContent = _.some(model, dv => DataValidationExtXform.isExt(dv));
+    }
+    return model.hasExtContent;
+  }
+
+  createNewModel() {
+    return {};
+  }
+
+  onParserClose(name, parser) {
+    // Assign the data validation per cell, like regular
+    // data validations
+    const list = parser.model._address.split(/\s+/g) || [];
+    delete parser.model._address;
+    list.forEach(addr => {
+      if (addr.includes(':')) {
+        const range = new Range(addr);
+        range.forEachAddress(address => {
+          this.model[address] = parser.model;
+        });
+      } else {
+        this.model[addr] = parser.model;
+      }
+    });
+  }
+}
+
+module.exports = DataValidationsExtXform;

--- a/lib/xlsx/xform/sheet/dv-ext/formula-ext-xform.js
+++ b/lib/xlsx/xform/sheet/dv-ext/formula-ext-xform.js
@@ -1,0 +1,31 @@
+const CompositeXform = require('../../composite-xform');
+
+const FExtXform = require('../cf-ext/f-ext-xform');
+
+class FormulaExtXform extends CompositeXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'xm:f': (this.fExtXform = new FExtXform()),
+    };
+  }
+
+  get tag() {
+    return 'x14:formula1';
+  }
+
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag, {});
+    if (model !== undefined && model.length === 1) {
+      this.fExtXform.render(xmlStream, model[0]);
+    }
+    xmlStream.closeNode();
+  }
+
+  createNewModel(node) {
+    return {};
+  }
+}
+
+module.exports = FormulaExtXform;

--- a/lib/xlsx/xform/sheet/ext-lst-xform.js
+++ b/lib/xlsx/xform/sheet/ext-lst-xform.js
@@ -2,12 +2,14 @@
 const CompositeXform = require('../composite-xform');
 
 const ConditionalFormattingsExt = require('./cf-ext/conditional-formattings-ext-xform');
+const DataValidationsExt = require('./dv-ext/data-validations-ext-xform');
 
 class ExtXform extends CompositeXform {
   constructor() {
     super();
     this.map = {
       'x14:conditionalFormattings': (this.conditionalFormattings = new ConditionalFormattingsExt()),
+      'x14:dataValidations': (this.dataValidations = new DataValidationsExt()),
     };
   }
 
@@ -16,7 +18,10 @@ class ExtXform extends CompositeXform {
   }
 
   hasContent(model) {
-    return this.conditionalFormattings.hasContent(model.conditionalFormattings);
+    return (
+      this.conditionalFormattings.hasContent(model.conditionalFormattings) ||
+      this.dataValidations.hasContent(model.dataValidations)
+    );
   }
 
   prepare(model, options) {
@@ -24,14 +29,26 @@ class ExtXform extends CompositeXform {
   }
 
   render(xmlStream, model) {
-    xmlStream.openNode('ext', {
-      uri: '{78C0D931-6437-407d-A8EE-F0AAD7539E65}',
-      'xmlns:x14': 'http://schemas.microsoft.com/office/spreadsheetml/2009/9/main',
-    });
+    // Each ext has a different uri
+    // See https://docs.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/07d607af-5618-4ca2-b683-6a78dc0d9627
+    if (this.conditionalFormattings.hasContent(model.conditionalFormattings)) {
+      xmlStream.openNode('ext', {
+        uri: '{78C0D931-6437-407d-A8EE-F0AAD7539E65}',
+        'xmlns:x14': 'http://schemas.microsoft.com/office/spreadsheetml/2009/9/main',
+      });
+      this.conditionalFormattings.render(xmlStream, model.conditionalFormattings);
 
-    this.conditionalFormattings.render(xmlStream, model.conditionalFormattings);
+      xmlStream.closeNode();
+    }
+    if (this.dataValidations.hasContent(model.dataValidations)) {
+      xmlStream.openNode('ext', {
+        uri: '{CCE6A557-97BC-4b89-ADB6-D9C93CAAB3DF}',
+        'xmlns:x14': 'http://schemas.microsoft.com/office/spreadsheetml/2009/9/main',
+      });
+      this.dataValidations.render(xmlStream, model.dataValidations);
 
-    xmlStream.closeNode();
+      xmlStream.closeNode();
+    }
   }
 
   createNewModel() {

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -88,6 +88,18 @@ const mergeConditionalFormattings = (model, extModel) => {
   return model;
 };
 
+const mergeDataValidations = (model, extModel) => {
+  // data validations are rendered in worksheet.dataValidations and also in
+  // worksheet.extLst.ext.x14:davaValidations
+  if (!extModel) {
+    return model;
+  }
+  if (!model) {
+    return extModel;
+  }
+  return Object.assign(model, extModel);
+};
+
 class WorkSheetXform extends BaseXform {
   constructor(options) {
     super();
@@ -221,9 +233,7 @@ class WorkSheetXform extends BaseXform {
           });
         }
         let rIdImage =
-          this.preImageId === medium.imageId
-            ? drawingRelsHash[medium.imageId]
-            : drawingRelsHash[drawing.rels.length];
+          this.preImageId === medium.imageId ? drawingRelsHash[medium.imageId] : drawingRelsHash[drawing.rels.length];
         if (!rIdImage) {
           rIdImage = nextRid(drawing.rels);
           drawingRelsHash[drawing.rels.length] = rIdImage;
@@ -405,14 +415,14 @@ class WorkSheetXform extends BaseXform {
             false,
           margins: this.map.pageMargins.model,
         };
-        const pageSetup = Object.assign(
-          sheetProperties,
-          this.map.pageSetup.model,
-          this.map.printOptions.model
-        );
+        const pageSetup = Object.assign(sheetProperties, this.map.pageSetup.model, this.map.printOptions.model);
         const conditionalFormattings = mergeConditionalFormattings(
           this.map.conditionalFormatting.model,
           this.map.extLst.model && this.map.extLst.model['x14:conditionalFormattings']
+        );
+        const dataValidations = mergeDataValidations(
+          this.map.dataValidations.model,
+          this.map.extLst.model && this.map.extLst.model['x14:dataValidations']
         );
         this.model = {
           dimensions: this.map.dimension.model,
@@ -420,7 +430,7 @@ class WorkSheetXform extends BaseXform {
           rows: this.map.sheetData.model,
           mergeCells: this.map.mergeCells.model,
           hyperlinks: this.map.hyperlinks.model,
-          dataValidations: this.map.dataValidations.model,
+          dataValidations,
           properties,
           views: this.map.sheetViews.model,
           pageSetup,

--- a/spec/unit/xlsx/xform/sheet/data/sheet.4.1.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.4.1.json
@@ -1,0 +1,45 @@
+{
+  "dimensions": "A1:C3",
+  "properties": {"defaultRowHeight": 14.4, "dyDescent": 0.55, "outlineLevelRow": 2},
+  "views": [{"state": "normal", "workbookViewId": 0}],
+  "pageSetup": {
+    "margins": {"left": 0.7, "right": 0.7, "top": 0.75, "bottom": 0.75, "header": 0.3, "footer":  0.3 }
+  },
+  "rows": [
+    {
+      "number": 1, "min": 1, "max": 3,
+      "cells": [
+        {"address": "A1", "type": 3, "value": "Tom"},
+        {"address": "B1", "type": 3, "value": "John"},
+        {"address": "C1", "type": 3, "value": "Tom"}
+      ]
+    },
+    {
+      "number": 2, "min": 1, "max": 3, "outlineLevel": 1,
+      "cells": [
+        {"address": "A2", "type": 3, "value": "Dick"},
+        {"address": "B1", "type": 3, "value": "Snow"},
+        {"address": "C2", "type": 3, "value": "Dick"}
+      ]
+    },
+    {
+      "number": 3, "min": 1, "max": 3, "outlineLevel": 2, "collapsed": true,
+      "cells": [
+        {"address": "A3", "type": 3, "value": "Harry"},
+        {"address": "B3", "type": 3, "value": "Bastard"},
+        {"address": "C3", "type": 3, "value": "Harry"}
+      ]
+    }
+  ],
+  "dataValidations": {
+    "A1": { "type": "list", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "formulae": ["$C$1:$C$3"]},
+    "A2": { "type": "list", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "formulae": ["$C$1:$C$3"]},
+    "A3": { "type": "list", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "formulae": ["$C$1:$C$3"]},
+    "B1": { "type": "list", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "formulae": ["ExternalSheet!$A$1:$A$3"]},
+    "B2": { "type": "list", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "formulae": ["ExternalSheet!$A$1:$A$3"]},
+    "B3": { "type": "list", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "formulae": ["ExternalSheet!$A$1:$A$3"]}
+  },
+  "media": [],
+  "tables": [],
+  "conditionalFormattings": []
+}

--- a/spec/unit/xlsx/xform/sheet/dv-ext/data-validations-ext-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/dv-ext/data-validations-ext-xform.spec.js
@@ -1,0 +1,116 @@
+const testXformHelper = require('../../test-xform-helper');
+
+const DataValidationsExtXform = verquire(
+  'xlsx/xform/sheet/dv-ext/data-validations-ext-xform'
+);
+
+const expectations = [
+  {
+    title: 'Single element external list type',
+    create: () => new DataValidationsExtXform(),
+    preparedModel: {
+      E1: {
+        type: 'list',
+        allowBlank: true,
+        showInputMessage: true,
+        showErrorMessage: true,
+        formulae: ['ExternalSheet!$A$1:$A$10'],
+      },
+    },
+    get parsedModel() {
+      return this.preparedModel;
+    },
+    xml: `
+    <x14:dataValidations count="1"
+        xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+        <x14:dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1">
+            <x14:formula1>
+                <xm:f>ExternalSheet!$A$1:$A$10</xm:f>
+            </x14:formula1>
+            <xm:sqref>E1</xm:sqref>
+        </x14:dataValidation>
+    </x14:dataValidations>
+    `,
+    tests: ['render', 'renderIn', 'parse'],
+  },
+  {
+    title: 'Single element validated by single element external list type',
+    create: () => new DataValidationsExtXform(),
+    preparedModel: {
+      E1: {
+        type: 'list',
+        allowBlank: true,
+        showInputMessage: true,
+        showErrorMessage: true,
+        formulae: ['ExternalSheet!$A$1'],
+      },
+    },
+    get parsedModel() {
+      return this.preparedModel;
+    },
+    xml: `
+    <x14:dataValidations count="1"
+        xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+        <x14:dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1">
+            <x14:formula1>
+                <xm:f>ExternalSheet!$A$1</xm:f>
+            </x14:formula1>
+            <xm:sqref>E1</xm:sqref>
+        </x14:dataValidation>
+    </x14:dataValidations>
+    `,
+    tests: ['render', 'renderIn', 'parse'],
+  },
+  {
+    title: 'Multiple element external list type',
+    create: () => new DataValidationsExtXform(),
+    preparedModel: {
+      D1: {
+        type: 'list',
+        allowBlank: true,
+        showInputMessage: true,
+        showErrorMessage: true,
+        formulae: ['ExternalSheet2!$B$1:$B$3'],
+      },
+      E1: {
+        type: 'list',
+        allowBlank: true,
+        showInputMessage: true,
+        showErrorMessage: true,
+        formulae: ['ExternalSheet!$A$1:$A$10'],
+      },
+      E2: {
+        type: 'list',
+        allowBlank: true,
+        showInputMessage: true,
+        showErrorMessage: true,
+        formulae: ['ExternalSheet!$A$1:$A$10'],
+      },
+    },
+    get parsedModel() {
+      return this.preparedModel;
+    },
+    xml: `
+    <x14:dataValidations count="2"
+        xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+        <x14:dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1">
+            <x14:formula1>
+                <xm:f>ExternalSheet2!$B$1:$B$3</xm:f>
+            </x14:formula1>
+            <xm:sqref>D1</xm:sqref>
+        </x14:dataValidation>
+        <x14:dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1">
+            <x14:formula1>
+                <xm:f>ExternalSheet!$A$1:$A$10</xm:f>
+            </x14:formula1>
+            <xm:sqref>E1:E2</xm:sqref>
+        </x14:dataValidation>
+    </x14:dataValidations>
+    `,
+    tests: ['render', 'renderIn', 'parse'],
+  },
+];
+
+describe('DataValidationsExtXform', () => {
+  testXformHelper(expectations);
+});

--- a/spec/unit/xlsx/xform/sheet/dv-ext/formula-ext-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/dv-ext/formula-ext-xform.spec.js
@@ -1,0 +1,26 @@
+const testXformHelper = require('../../test-xform-helper');
+
+const FormulaExtXform = verquire('xlsx/xform/sheet/dv-ext/formula-ext-xform');
+
+const expectations = [
+  {
+    title: 'formula',
+    create() {
+      return new FormulaExtXform();
+    },
+    preparedModel: ['ExternalSheet!$A$1:$A$2'],
+    xml: `
+        <x14:formula1>
+            <xm:f>ExternalSheet!$A$1:$A$2</xm:f>
+        </x14:formula1>
+    `,
+    parsedModel: {
+      'xm:f': 'ExternalSheet!$A$1:$A$2',
+    },
+    tests: ['render', 'parse'],
+  },
+];
+
+describe('FormulaExtXform', () => {
+  testXformHelper(expectations);
+});

--- a/spec/unit/xlsx/xform/sheet/worksheet-xform.spec.js
+++ b/spec/unit/xlsx/xform/sheet/worksheet-xform.spec.js
@@ -188,4 +188,27 @@ describe('WorksheetXform', () => {
     expect(iDataValidations).not.to.equal(-1);
     expect(iConditionalFormatting).to.be.lessThan(iDataValidations);
   });
+  it('dataValidations should be split between internal and external', () => {
+    const xform = new WorksheetXform();
+    const model = require('./data/sheet.4.1.json');
+    const xmlStream = new XmlStream();
+    const options = {
+      styles: new StylesXform(true),
+      hyperlinks: [],
+    };
+    xform.prepare(model, options);
+    xform.render(xmlStream, model);
+
+    const {xml} = xmlStream;
+    const iInternalDataValidations = xml.indexOf('dataValidations');
+    const iExt = xml.indexOf('ext');
+    const iExternalDataValidations = xml.indexOf('x14:dataValidations');
+    const countCounters = (xml.match(/count="1"/g) || []).length;
+    expect(iInternalDataValidations).not.to.equal(-1);
+    expect(iExt).not.to.equal(-1);
+    expect(iExternalDataValidations).not.to.equal(-1);
+    expect(iInternalDataValidations).to.be.lessThan(iExt);
+    expect(iExt).to.be.lessThan(iExternalDataValidations);
+    expect(countCounters).to.be.equal(2);
+  });
 });


### PR DESCRIPTION
## Summary

This commit adds the feature to use external ranges for data validations, aka data validation lists located inside the same workbook, but on different worksheets than the validated data. It works for the xlsx part, but not the stream/xlsx one. The feature is quite similar to external conditional formatting, as it uses the extLst tag.

The resulting data validations are merged with the other local data validations in the model. The deciding factor to mark them as external is if the type is list and the formulae element has the format "<SheetName>!<Range or Cell>". 

## Test plan

New unit tests have been added for each new tag, namely, inside the ExtLst tag:
- x14:dataValidations
- x14:dataValidation
- x14:formula1

The xm:sqref was already used and tested due to external conditonal formatting. There are 3 tests in total and are executable running:
- `npx mocha --require spec/config/setup --require spec/config/setup-unit spec/unit --recursive --grep "FormulaExtXform"`
- `npx mocha --require spec/config/setup --require spec/config/setup-unit spec/unit --recursive --grep "DataValidationsExtXform"`
- `npx mocha --require spec/config/setup --require spec/config/setup-unit spec/unit --recursive --grep "dataValidations should be split between internal and external"`

Or simply running `npm run test`
