### PR TITLE
Update parse-sax.js

### DIFF
--- a/lib/utils/parse-sax.js
+++ b/lib/utils/parse-sax.js
@@ -1,6 +1,7 @@
 const {SaxesParser} = require('saxes');
 const {PassThrough} = require('readable-stream');
 const {bufferToString} = require('./browser-buffer-decode');
+const { StringDecoder } = require('string_decoder');
 
 module.exports = async function* (iterable) {
   // TODO: Remove once node v8 is deprecated
@@ -17,8 +18,11 @@ module.exports = async function* (iterable) {
   saxesParser.on('opentag', value => events.push({eventType: 'opentag', value}));
   saxesParser.on('text', value => events.push({eventType: 'text', value}));
   saxesParser.on('closetag', value => events.push({eventType: 'closetag', value}));
+  const decoder = new StringDecoder('utf8');
   for await (const chunk of iterable) {
-    saxesParser.write(bufferToString(chunk));
+    // chunk may happen be in the middle of a utf8 string
+    const utf8chunk = decoder.write(chunk)
+    saxesParser.write(bufferToString(utf8chunk));
     // saxesParser.write and saxesParser.on() are synchronous,
     // so we can only reach the below line once all events have been emitted
     if (error) throw error;


### PR DESCRIPTION
hello, friends.

this tries to fix chunk in the middle of a utf8 string.

## Summary
when parsing the sharedStrings, sometimes the chunk is not a valid utf8 string, `saxes` could result invalid string. 

## Test plan

```js

const parseSax = require('./lib/utils/parse-sax');
const buffer = Buffer.from(`<root>大家好，才是真的好</root>`)

async function * generate() {
	yield buffer.slice(0, 20)
	yield buffer.slice(20)
}

;(async () => {
	const iterator = generate()
	for await (const event of parseSax(iterator)) {
		console.log(JSON.stringify(event))
	}
})()

// actual
[{"eventType":"text","value":"大家好，��是真的好"}]

// expected
[{"eventType":"text","value":"大家好，才是真的好"}]
```
