### PR TITLE
Fix parsing of boolean attributes

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -163,6 +163,10 @@ const utils = {
   toIsoDateString(dt) {
     return dt.toIsoString().subsstr(0, 10);
   },
+
+  parseBoolean(value) {
+    return value === true || value === 'true' || value === 1 || value === '1';
+  },
 };
 
 module.exports = utils;

--- a/lib/xlsx/xform/sheet/col-xform.js
+++ b/lib/xlsx/xform/sheet/col-xform.js
@@ -1,3 +1,4 @@
+const utils = require('../../../utils/utils');
 const BaseXform = require('../base-xform');
 
 class ColXform extends BaseXform {
@@ -51,21 +52,16 @@ class ColXform extends BaseXform {
       if (node.attributes.style) {
         model.styleId = parseInt(node.attributes.style, 10);
       }
-      if (
-        node.attributes.hidden === true ||
-        node.attributes.hidden === 'true' ||
-        node.attributes.hidden === 1 ||
-        node.attributes.hidden === '1'
-      ) {
+      if (utils.parseBoolean(node.attributes.hidden)) {
         model.hidden = true;
       }
-      if (node.attributes.bestFit) {
+      if (utils.parseBoolean(node.attributes.bestFit)) {
         model.bestFit = true;
       }
       if (node.attributes.outlineLevel) {
         model.outlineLevel = parseInt(node.attributes.outlineLevel, 10);
       }
-      if (node.attributes.collapsed) {
+      if (utils.parseBoolean(node.attributes.collapsed)) {
         model.collapsed = true;
       }
       return true;

--- a/lib/xlsx/xform/sheet/data-validations-xform.js
+++ b/lib/xlsx/xform/sheet/data-validations-xform.js
@@ -12,19 +12,11 @@ function assign(definedName, attributes, name, defaultValue) {
     definedName[name] = defaultValue;
   }
 }
-function parseBool(value) {
-  switch (value) {
-    case '1':
-    case 'true':
-      return true;
-    default:
-      return false;
-  }
-}
+
 function assignBool(definedName, attributes, name, defaultValue) {
   const value = attributes[name];
   if (value !== undefined) {
-    definedName[name] = parseBool(value);
+    definedName[name] = utils.parseBoolean(value);
   } else if (defaultValue !== undefined) {
     definedName[name] = defaultValue;
   }

--- a/lib/xlsx/xform/sheet/row-xform.js
+++ b/lib/xlsx/xform/sheet/row-xform.js
@@ -1,4 +1,5 @@
 const BaseXform = require('../base-xform');
+const utils = require('../../../utils/utils');
 
 const CellXform = require('./cell-xform');
 
@@ -79,15 +80,10 @@ class RowXform extends BaseXform {
       if (node.attributes.s) {
         model.styleId = parseInt(node.attributes.s, 10);
       }
-      if (
-        node.attributes.hidden === true ||
-        node.attributes.hidden === 'true' ||
-        node.attributes.hidden === 1 ||
-        node.attributes.hidden === '1'
-      ) {
+      if (utils.parseBoolean(node.attributes.hidden)) {
         model.hidden = true;
       }
-      if (node.attributes.bestFit) {
+      if (utils.parseBoolean(node.attributes.bestFit)) {
         model.bestFit = true;
       }
       if (node.attributes.ht) {
@@ -96,7 +92,7 @@ class RowXform extends BaseXform {
       if (node.attributes.outlineLevel) {
         model.outlineLevel = parseInt(node.attributes.outlineLevel, 10);
       }
-      if (node.attributes.collapsed) {
+      if (utils.parseBoolean(node.attributes.collapsed)) {
         model.collapsed = true;
       }
       return true;

--- a/lib/xlsx/xform/style/alignment-xform.js
+++ b/lib/xlsx/xform/style/alignment-xform.js
@@ -145,8 +145,8 @@ class AlignmentXform extends BaseXform {
       'vertical',
       node.attributes.vertical === 'center' ? 'middle' : node.attributes.vertical
     );
-    add(node.attributes.wrapText, 'wrapText', !!node.attributes.wrapText);
-    add(node.attributes.shrinkToFit, 'shrinkToFit', !!node.attributes.shrinkToFit);
+    add(node.attributes.wrapText, 'wrapText', utils.parseBoolean(node.attributes.wrapText));
+    add(node.attributes.shrinkToFit, 'shrinkToFit', utils.parseBoolean(node.attributes.shrinkToFit));
     add(node.attributes.indent, 'indent', parseInt(node.attributes.indent, 10));
     add(
       node.attributes.textRotation,

--- a/lib/xlsx/xform/style/border-xform.js
+++ b/lib/xlsx/xform/style/border-xform.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 const BaseXform = require('../base-xform');
+const utils = require('../../../utils/utils');
 
 const ColorXform = require('./color-xform');
 
@@ -156,8 +157,8 @@ class BorderXform extends BaseXform {
     switch (node.name) {
       case 'border':
         this.reset();
-        this.diagonalUp = !!node.attributes.diagonalUp;
-        this.diagonalDown = !!node.attributes.diagonalDown;
+        this.diagonalUp = utils.parseBoolean(node.attributes.diagonalUp);
+        this.diagonalDown = utils.parseBoolean(node.attributes.diagonalDown);
         return true;
       default:
         this.parser = this.map[node.name];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Some boolean attributes are incorrectly parsed using `if (node.attribute.name)` or `!!node.attribute.name` which always return true for non-empty strings. Boolean attributes can be strings with the value `"true"` or `"false"`,

## Test plan


## Related to source code (for typings update)
