### PR TITLE
Fix Row.values type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -537,7 +537,7 @@ export interface Row extends Style {
 	 * Get a row as a sparse array
 	 */
 	// readonly values: CellValue[];
-	values: CellValue[] | { [key: string]: CellValue };
+	values: CellValue[];
 
 	/**
 	 * Set an outline level for rows


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Considering the source code, the Row.values can only be an array, therefore the current type definition is not correct.

## Test plan

N/A

## Related to source code (for typings update)

https://github.com/exceljs/exceljs/blob/1d5e5ac02d836f02f2d8b6282b3e1e327f0403b6/lib/doc/row.js#L165-L174
