### PR TITLE
Upgrade jszip to its latest version to date. This version does not have any vulnerability found by Snyk so far

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "archiver": "^5.0.0",
     "dayjs": "^1.8.34",
     "fast-csv": "^4.3.1",
-    "jszip": "^3.5.0",
+    "jszip": "^3.7.1",
     "readable-stream": "^3.6.0",
     "saxes": "^5.0.1",
     "tmp": "^0.2.0",


### PR DESCRIPTION
Snyk found a Denial of Service vulnerability in jszip: https://security.snyk.io/vuln/SNYK-JS-JSZIP-1251497

There is no version of exceljs so far upgrading to a safe version of jszip. This pull request is meant to solve that.

## Test plan

Run `npm install` and `npm test` after upgrading. All tests passed.