### PR TITLE
Fix worksheet reader type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2000,17 +2000,21 @@ export namespace stream {
 		interface WorksheetReaderOptions {
 			workbook: Workbook;
 			id: number;
-			entry: import('stream').Stream;
+			iterator: AsyncIterator<any>;
 			options: WorkbookStreamReaderOptions;
 		}
 
 		class WorksheetReader {
+			readonly id: number;
+			name: string;
+			state: WorksheetState;
+			workbook: WorkbookReader;
 			constructor(options: WorksheetReaderOptions);
-			read(): Promise<void>;
+			readonly dimensions: Range;
+			readonly columns: Column[];
 			[Symbol.asyncIterator](): AsyncGenerator<Row>;
+			read(): Promise<void>;
 			parse(): AsyncIterator<Array<any>>;
-			dimensions(): number;
-			columns(): number;
 			getColumn(c: number): Column;
 		}
 	}


### PR DESCRIPTION
Update to match implementation and allow usage of id, name
and state properties.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Allows accessing the worksheet id name and state when using the stream reading in Typescript

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
N/A

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->

Matches implementation:
https://github.com/exceljs/exceljs/blob/0f6d7657e71f1de3c1fc2a2a75776b7766f0576a/lib/stream/xlsx/worksheet-reader.js#L12-L49

Properties are assigned by workbook reader here:
https://github.com/exceljs/exceljs/blob/0f6d7657e71f1de3c1fc2a2a75776b7766f0576a/lib/stream/xlsx/workbook-reader.js#L292-L314
