### PR TITLE
FIX assignStyle on Table.store

### DIFF
--- a/lib/doc/table.js
+++ b/lib/doc/table.js
@@ -183,7 +183,7 @@ class Table {
     const assignStyle = (cell, style) => {
       if (style) {
         Object.keys(style).forEach(key => {
-          cell[key] = style[key];
+          cell.style[key] = style[key];
         });
       }
     };


### PR DESCRIPTION
The current implementation sets any style properties directly to the cell instead of merging into the existing cell style.

The result is that if you set a style in a column of a Table model it will break the resulting `xlsx`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

I need to be able to set the `numFmt` style on a Worksheet table. If I do it direct as in this example:
```javascript
  ws.addTable({
    name     : "FlexReport",
    ref      : "A1",
    headerRow: true,
    totalsRow: true,
    style    : {
      theme         : "TableStyleMedium9",
      showRowStripes: true,
    },
    columns  : [{
      key         : "id",
      name        : "ID",
      filterButton: true,
    }, {
      key         : "name",
      name        : "Name",
      filterButton: true,
    }, {
      key         : "value",
      name        : "value",
      filterButton: true,
      style       : {numFmt: "#,#00.00"},
    }],
    rows,
  });
```
the exported `xlsx` file is broke with the following error: 
![image](https://user-images.githubusercontent.com/1793873/142189773-0ec98e05-0300-45e3-8cc1-fe65164b51d8.png)

## Test plan

After reviewing the source code I've tried to do the same export with the following change, which produced the correct format:
```javascript
  ws.addTable({
    name     : "FlexReport",
    ref      : "A1",
    headerRow: true,
    totalsRow: true,
    style    : {
      theme         : "TableStyleMedium9",
      showRowStripes: true,
    },
    columns  : [{
      key         : "id",
      name        : "ID",
      filterButton: true,
    }, {
      key         : "name",
      name        : "Name",
      filterButton: true,
    }, {
      key         : "value",
      name        : "value",
      filterButton: true,
      style       : {style:{numFmt: "#,#00.00"}}, // <-- Note the change which works but will overwrite any existing cell.style
    }],
    rows,
  });
```

## Related to source code (for typings update)

- https://github.com/o100ja/exceljs/blob/5b41d7ac608ceaf8b0f8df389d8c7398ee68fdbd/lib/doc/table.js#L186
