### PR TITLE
Release large values early for GC to be able to do its job

### DIFF
--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -247,11 +247,13 @@ class XLSX {
     if (!stream[Symbol.asyncIterator] && stream.pipe) {
       stream = stream.pipe(new PassThrough());
     }
-    const chunks = [];
+    let chunks = [];
     for await (const chunk of stream) {
       chunks.push(chunk);
     }
-    return this.load(Buffer.concat(chunks), options);
+    const buffer = Buffer.concat(chunks);
+    chunks = null;
+    return this.load(buffer, options);
   }
 
   async load(data, options) {
@@ -276,7 +278,8 @@ class XLSX {
       vmlDrawings: {},
     };
 
-    const zip = await JSZip.loadAsync(buffer);
+    let zip = await JSZip.loadAsync(buffer);
+    buffer = null;
     for (const entry of Object.values(zip.files)) {
       /* eslint-disable no-await-in-loop */
       if (!entry.dir) {
@@ -405,6 +408,7 @@ class XLSX {
         }
       }
     }
+    zip = null
 
     this.reconcile(model, options);
 

--- a/spec/integration/workbook-xlsx-reader.spec.js
+++ b/spec/integration/workbook-xlsx-reader.spec.js
@@ -131,6 +131,30 @@ describe('WorkbookReader', () => {
         );
       });
     });
+
+    describe('Big file support', () => {
+      it('should read large file correctly', function(done) {
+        this.timeout(20000);
+        const workbook = new ExcelJS.Workbook();
+        workbook.xlsx
+            .read(fs.createReadStream('./spec/integration/data/extra-large.xlsx') )
+            .then(
+                result => {
+                  expect(result._worksheets[1]._rows.length).to.equal(512781);
+                  expect(result._worksheets[1]._rows[500000]._cells[4]._value.value).to.equal(11);
+                  done();
+                }
+            );
+      });
+
+      it('should parse fine if the limit is not exceeded', () => {
+        const workbook = new ExcelJS.Workbook();
+        return workbook.xlsx.read(
+            fs.createReadStream('./spec/integration/data/fibonacci.xlsx'),
+            {maxRows: 20}
+        );
+      });
+    });
   });
 
   describe('edit styles in existing file', () => {


### PR DESCRIPTION
## Summary

Currently we are observing that when importing 19 MB large file, CI eats 2 GB of memory and dies. This is not ideal.

## Test plan

There is a test, showing that loading 19 MB large file does not fail GA CI.