### PR TITLE
Feature/comment auto shape

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -403,6 +403,7 @@ export type CellValue =
 		margins?: Partial<CommentMargins>;
 		protection?: Partial<CommentProtection>;
 		editAs?: CommentEditAs;
+		autoShape: boolean;
 	}
 
 export interface CellModel {

--- a/lib/xlsx/xform/comment/vml-textbox-xform.js
+++ b/lib/xlsx/xform/comment/vml-textbox-xform.js
@@ -16,9 +16,8 @@ class VmlTextboxXform extends BaseXform {
   }
 
   render(xmlStream, model) {
-    const attributes = {
-      style: 'mso-direction-alt:auto',
-    };
+    const styleList = ['mso-direction-alt:auto'];
+    const attributes = {};
     if (model && model.note) {
       let {inset} = model.note && model.note.margins;
       if (Array.isArray(inset)) {
@@ -31,7 +30,11 @@ class VmlTextboxXform extends BaseXform {
       if (inset) {
         attributes.inset = inset;
       }
+      if (model.note.autoShape) {
+        styleList.push('mso-fit-shape-to-text:t');
+      }
     }
+    attributes.style = styleList.join(';');
     xmlStream.openNode('v:textbox', attributes);
     xmlStream.leafNode('div', {style: 'text-align:left'});
     xmlStream.closeNode();

--- a/test/test-comments.js
+++ b/test/test-comments.js
@@ -1,4 +1,4 @@
-const Excel = require('../lib/exceljs.nodejs.js');
+const Excel = require('../lib/exceljs.nodejs');
 
 const wb = new Excel.Workbook();
 wb.xlsx
@@ -89,6 +89,11 @@ wb.xlsx
             text: 'format',
           },
         ],
+      };
+
+      sheet.getCell('C3').comment = {
+        texts: ['This\nIs\nA\nComment\nThat\nNeed\nA\nLargeBox'],
+        autoShape: true,
       };
 
       // sheet.getCell('D2').value = 'Zoo';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Add a feature to solve issue #981 (#1493 ).

Comments in Excel has a property
This PR add a option for comment. With that option the comment can be set `Automatic Size` property.
usage:

```js
sheet.getCell('C3').comment = {
    texts: ['This\nIs\nA\nComment\nThat\nNeed\nA\nLarge\nBox'],
    autoShape: true,  // with this option the size of comment box will be adjusted automatically
 };
```

The corresponding setting in excel is in the screenshot below:

<img width="355" alt="image" src="https://user-images.githubusercontent.com/16380986/146628424-f1327c40-7f9c-438c-923a-d7b69df72c08.png">


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`npm i && npm run test:all`

All test cases has passed.

## Questions

Should I update `README.MD` at the same time?
