### PR TITLE
Fix read this.worksheet before assign it

### DIFF
--- a/lib/doc/anchor.js
+++ b/lib/doc/anchor.js
@@ -4,6 +4,8 @@ const colCache = require('../utils/col-cache');
 
 class Anchor {
   constructor(worksheet, address, offset = 0) {
+    this.worksheet = worksheet;
+
     if (!address) {
       this.nativeCol = 0;
       this.nativeColOff = 0;
@@ -29,8 +31,6 @@ class Anchor {
       this.nativeRow = 0;
       this.nativeRowOff = 0;
     }
-
-    this.worksheet = worksheet;
   }
 
   static asInstance(model) {


### PR DESCRIPTION
The anchor.js assign `this.worksheet = worksheet` at end of constructor, but the getter (such as rowHeight) used in constructor will read this.worksheet. so it will cause rowHeight fall back to default value (180000);
 
## Summary
When I want to add a image in a cell over a range, and I adjust the height of this row before. The nativeRowOff will not calculate use the row height.
```javascript
const Excel = require('exceljs');
const fs = require('fs').promises;

(async () => {
    const workbook = new Excel.Workbook();
    await workbook.xlsx.readFile('./test.xlsx');
    const worksheet = workbook.getWorksheet(1);
    const row = worksheet.getRow(1);
    row.height = 400;
    const col = worksheet.getColumn('A');
    col.width = 200
    const image = await fs.readFile('./image.png')
    const imageId = workbook.addImage({
        buffer: image,
        extension: 'png',
    });
    worksheet.addImage(imageId, {
        tl: { col: 0.5, row: 0.5 },
        br: { col: 1, row: 1 }
    });
    await workbook.xlsx.writeFile('./result.xlsx');
})()
```
result is
![图片](https://user-images.githubusercontent.com/13046418/146639198-e4276c98-a99b-4b57-9dfe-c268bf46a935.png)



## Test plan
After I change anchor.js,
```javascript
const Excel = require('exceljs');
const fs = require('fs').promises;

(async () => {
    const workbook = new Excel.Workbook();
    await workbook.xlsx.readFile('./test.xlsx');
    const worksheet = workbook.getWorksheet(1);
    const row = worksheet.getRow(1);
    row.height = 400;
    const col = worksheet.getColumn('A');
    col.width = 200
    const image = await fs.readFile('./image.png')
    const imageId = workbook.addImage({
        buffer: image,
        extension: 'png',
    });
    worksheet.addImage(imageId, {
        tl: { col: 0.5, row: 0.5 },
        br: { col: 1, row: 1 }
    });
    await workbook.xlsx.writeFile('./result.xlsx');
})()
```
the result is
![图片](https://user-images.githubusercontent.com/13046418/146639297-bc18117a-d17b-46a8-86b2-829424afb2a7.png)
The image top-left will start from 0.5*row height
## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
https://github.com/ZyqGitHub1/exceljs/blob/458f372609589e6b3665a5c955998b677df2037e/lib/doc/anchor.js#L7