### PR TITLE
Fix loading of tables with calculated columns.

### DIFF
--- a/lib/xlsx/xform/table/table-column-xform.js
+++ b/lib/xlsx/xform/table/table-column-xform.js
@@ -36,8 +36,8 @@ class TableColumnXform extends BaseXform {
 
   parseText() {}
 
-  parseClose() {
-    return false;
+  parseClose(name) {
+    return name !== this.tag;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Loading a table with calculated columns fails. It stops loading columns after the first calculated one, resulting in a wrong column number.

## Test plan

See the test provided. Columns number should be 3, and it is only 2 because column 2 contains a formula.

## Related to source code (for typings update)

Don't know what that means, be gentle it is my first PR.
