### PR TITLE
Fix loadin of table rows and ref from xlsx file

### DIFF
--- a/lib/doc/table.js
+++ b/lib/doc/table.js
@@ -69,8 +69,14 @@ class Column {
 class Table {
   constructor(worksheet, table) {
     this.worksheet = worksheet;
-    if (table) {
-      this.table = table;
+    this.table = table;
+    if (table.tableRef && !table.ref) {
+      // The table structure has just been loaded from an xlsx file, load the data
+      this.load(this.worksheet);
+
+      this.validate();
+    } else {
+      // Tab has just been created, store it
       // check things are ok first
       this.validate();
 
@@ -236,39 +242,30 @@ class Table {
   load(worksheet) {
     // where the table will read necessary features from a loaded sheet
     const {table} = this;
-    const {row, col} = table.tl;
-    let count = 0;
-    if (table.headerRow) {
-      const r = worksheet.getRow(row + count++);
-      table.columns.forEach((column, j) => {
-        const cell = r.getCell(col + j);
-        cell.value = column.name;
-      });
-    }
-    table.rows.forEach(data => {
-      const r = worksheet.getRow(row + count++);
-      data.forEach((value, j) => {
-        const cell = r.getCell(col + j);
-        cell.value = value;
-      });
-    });
 
-    if (table.totalsRow) {
-      const r = worksheet.getRow(row + count++);
-      table.columns.forEach((column, j) => {
-        const cell = r.getCell(col + j);
-        if (j === 0) {
-          cell.value = column.totalsRowLabel;
-        } else {
-          const formula = this.getFormula(column);
-          if (formula) {
-            cell.value = {
-              formula: column.totalsRowFormula,
-              result: column.totalsRowResult,
-            };
-          }
-        }
-      });
+    if (table.tableRef && !table.ref) {
+      // The table has just been loaded from an xlsx file, fill missing properties
+      const refs = table.tableRef.split(':');
+      if (refs.length !== 2) {
+        return;
+      }
+      table.ref = refs[0];
+      table.tl = colCache.decodeAddress(table.ref);
+      const end = colCache.decodeAddress(refs[1]);
+      table.rows = new Array(end.row - table.tl.row);
+    }
+
+    const {row, col} = table.tl;
+    const {height} = this;
+
+    let count = 0;
+    for (let r = row + 1; r <= height + row; r++) {
+      const rowData = [];
+      for (let c = col; c < col + table.columns.length; c++) {
+        const strValue = this.worksheet.getCell(r, c).value ? this.worksheet.getCell(r, c).value.toString().trim() : '';
+        rowData.push(strValue);
+      }
+      this.table.rows[count++] = rowData;
     }
   }
 

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -867,8 +867,7 @@ class Worksheet {
     this._media = value.media.map(medium => new Image(this, medium));
     this.sheetProtection = value.sheetProtection;
     this.tables = value.tables.reduce((tables, table) => {
-      const t = new Table();
-      t.model = table;
+      const t = new Table(this, table);
       tables[table.name] = t;
       return tables;
     }, {});

--- a/lib/xlsx/xform/table/table-column-xform.js
+++ b/lib/xlsx/xform/table/table-column-xform.js
@@ -36,8 +36,8 @@ class TableColumnXform extends BaseXform {
 
   parseText() {}
 
-  parseClose() {
-    return false;
+  parseClose(name) {
+    return name !== this.tag;
   }
 }
 

--- a/spec/integration/pr/test-pr-1936.spec.js
+++ b/spec/integration/pr/test-pr-1936.spec.js
@@ -1,11 +1,11 @@
 const ExcelJS = verquire('exceljs');
 
 describe('github issues', () => {
-  describe('pull request 0 - fix load of tables with computed columns', () => {
-    it('Reading test-pr-0.xlsx', () => {
+  describe('pull request 1936 - fix load of tables with computed columns', () => {
+    it('Reading test-pr-1936.xlsx', () => {
       const wb = new ExcelJS.Workbook();
       return wb.xlsx
-        .readFile('./spec/integration/data/test-pr-0.xlsx')
+        .readFile('./spec/integration/data/test-pr-1936.xlsx')
         .then(() => {
           const ws = wb.getWorksheet('Sheet1');
           const table = ws.getTable('Table1');

--- a/spec/integration/pr/test-pr-1936.spec.js
+++ b/spec/integration/pr/test-pr-1936.spec.js
@@ -1,0 +1,16 @@
+const ExcelJS = verquire('exceljs');
+
+describe('github issues', () => {
+  describe('pull request 0 - fix load of tables with computed columns', () => {
+    it('Reading test-pr-0.xlsx', () => {
+      const wb = new ExcelJS.Workbook();
+      return wb.xlsx
+        .readFile('./spec/integration/data/test-pr-0.xlsx')
+        .then(() => {
+          const ws = wb.getWorksheet('Sheet1');
+          const table = ws.getTable('Table1');
+          expect(table.model.columns.length).to.equal(3);
+        });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Only structure (columns) of tables are loaded when reading a xlsx file. The data is missing : rows and ref properties remain undefined.

## Test plan

A test file is commited. It tests that table data is properly loaded.

## Related to source code (for typings update)
