### PR TITLE
Added a polyfill of promise.finally to support lower versions of Firefox.

### DIFF
--- a/lib/exceljs.browser.js
+++ b/lib/exceljs.browser.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies,node/no-unpublished-require */
 require('core-js/modules/es.promise');
+require('core-js/modules/es.promise.finally');
 require('core-js/modules/es.object.assign');
 require('core-js/modules/es.object.keys');
 require('core-js/modules/es.object.values');


### PR DESCRIPTION
## Summary

Added a polyfill of promise.finally to support lower version firefox.

## Test plan

When i use exceljs on firefox of v61.0.1 , the promise.finally api will be undefined.
![image](https://user-images.githubusercontent.com/37802689/154438442-47bc0858-7082-442e-90c5-adefb59d01fc.png)
Original promise api on firefox of v61.0.1：
![image](https://user-images.githubusercontent.com/37802689/154438907-37e1a241-b829-4d15-b6ea-9a64423f321b.png)

