### PR TITLE
fix hyperlink hash

### DIFF
--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -602,7 +602,7 @@ class HyperlinkValue {
       v.tooltip = this.model.tooltip;
     }
     if (this.model.hash) {
-      v.hash = this.model.hash;
+      v.hyperlink = `${v.hyperlink}#${this.model.hash}`;
     }
     return v;
   }

--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -586,6 +586,7 @@ class HyperlinkValue {
       type: Cell.Types.Hyperlink,
       text: value ? value.text : undefined,
       hyperlink: value ? value.hyperlink : undefined,
+      hash: value ? value.hash : undefined,
     };
     if (value && value.tooltip) {
       this.model.tooltip = value.tooltip;
@@ -599,6 +600,9 @@ class HyperlinkValue {
     };
     if (this.model.tooltip) {
       v.tooltip = this.model.tooltip;
+    }
+    if (this.model.hash) {
+      v.hash = this.model.hash;
     }
     return v;
   }
@@ -862,8 +866,7 @@ class FormulaValue {
     if (!this._translatedFormula && this.model.sharedFormula) {
       const {worksheet} = this.cell;
       const master = worksheet.findCell(this.model.sharedFormula);
-      this._translatedFormula =
-        master && slideFormula(master.formula, master.address, this.model.address);
+      this._translatedFormula = master && slideFormula(master.formula, master.address, this.model.address);
     }
     return this._translatedFormula;
   }

--- a/lib/xlsx/xform/sheet/cell-xform.js
+++ b/lib/xlsx/xform/sheet/cell-xform.js
@@ -107,9 +107,7 @@ class CellXform extends BaseXform {
         } else if (model.sharedFormula) {
           const master = options.formulae[model.sharedFormula];
           if (!master) {
-            throw new Error(
-              `Shared Formula master must exist above and or left of clone for cell ${model.address}`
-            );
+            throw new Error(`Shared Formula master must exist above and or left of clone for cell ${model.address}`);
           }
           if (master.si === undefined) {
             master.shareType = 'shared';
@@ -486,6 +484,9 @@ class CellXform extends BaseXform {
       }
       model.type = Enums.ValueType.Hyperlink;
       model.hyperlink = hyperlink;
+      if (options.hyperlinkHashMap[model.address]) {
+        model.hash = options.hyperlinkHashMap[model.address];
+      }
     }
 
     const comment = options.commentsMap && options.commentsMap[model.address];

--- a/lib/xlsx/xform/sheet/hyperlink-xform.js
+++ b/lib/xlsx/xform/sheet/hyperlink-xform.js
@@ -28,6 +28,7 @@ class HyperlinkXform extends BaseXform {
         address: node.attributes.ref,
         rId: node.attributes['r:id'],
         tooltip: node.attributes.tooltip,
+        hash: node.attributes.location,
       };
 
       // This is an internal link

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -221,9 +221,7 @@ class WorkSheetXform extends BaseXform {
           });
         }
         let rIdImage =
-          this.preImageId === medium.imageId
-            ? drawingRelsHash[medium.imageId]
-            : drawingRelsHash[drawing.rels.length];
+          this.preImageId === medium.imageId ? drawingRelsHash[medium.imageId] : drawingRelsHash[drawing.rels.length];
         if (!rIdImage) {
           rIdImage = nextRid(drawing.rels);
           drawingRelsHash[drawing.rels.length] = rIdImage;
@@ -405,11 +403,7 @@ class WorkSheetXform extends BaseXform {
             false,
           margins: this.map.pageMargins.model,
         };
-        const pageSetup = Object.assign(
-          sheetProperties,
-          this.map.pageSetup.model,
-          this.map.printOptions.model
-        );
+        const pageSetup = Object.assign(sheetProperties, this.map.pageSetup.model, this.map.printOptions.model);
         const conditionalFormattings = mergeConditionalFormattings(
           this.map.conditionalFormatting.model,
           this.map.extLst.model && this.map.extLst.model['x14:conditionalFormattings']
@@ -472,6 +466,12 @@ class WorkSheetXform extends BaseXform {
     options.hyperlinkMap = (model.hyperlinks || []).reduce((h, hyperlink) => {
       if (hyperlink.rId) {
         h[hyperlink.address] = rels[hyperlink.rId].Target;
+      }
+      return h;
+    }, {});
+    options.hyperlinkHashMap = (model.hyperlinks || []).reduce((h, hyperlink) => {
+      if (hyperlink.rId && hyperlink.hash) {
+        h[hyperlink.address] = hyperlink.hash;
       }
       return h;
     }, {});


### PR DESCRIPTION
## Summary

lost hash value in hyperlink

## test 

Example file:
[linkhash.xlsx](https://github.com/exceljs/exceljs/files/8243080/linkhash.xlsx)

A1 is hyperlink with hash

<img width="653" alt="image" src="https://user-images.githubusercontent.com/6889/158135106-bb11eebc-7116-4f12-b5c1-5147ad831a31.png">

test source:

```javascript
const Excel = require('exceljs');

const workbook = new Excel.Workbook();

(async function () {
  await workbook.xlsx.readFile('linkhash.xlsx');
  const worksheet = workbook.getWorksheet('Sheet1');
  const cell = worksheet.getCell('A1');
  console.log(cell.value);
})();
```

Result before this pr 

```js
{ text: 'link', hyperlink: 'http://localhost/' }
```

Result after this pr 

```js
{ text: 'link', hyperlink: 'http://localhost/#myhash' }
```


