### PR TITLE
Fix addThemes

### DIFF
--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -487,7 +487,12 @@ class XLSX {
   }
 
   async addThemes(zip, model) {
-    const themes = model.themes || {theme1: theme1Xml};
+    let {themes} = model;
+
+    if (!themes || Object.keys(themes).length === 0) {
+      themes = {theme1: theme1Xml};
+    }
+
     Object.keys(themes).forEach(name => {
       const xml = themes[name];
       const path = `xl/theme/${name}.xml`;


### PR DESCRIPTION
## Summary

This function would not insert the default theme if model.themes is an empty object. This causes errors when opening the spreadsheet in Excel.