### PR TITLE
improved media properties

### DIFF
--- a/lib/doc/image.js
+++ b/lib/doc/image.js
@@ -12,35 +12,48 @@ class Image {
       case 'background':
         return {
           type: this.type,
-          imageId: this.imageId,
+            imageId: this.imageId,
         };
       case 'image':
         return {
           type: this.type,
-          imageId: this.imageId,
-          hyperlinks: this.range.hyperlinks,
-          range: {
-            tl: this.range.tl.model,
-            br: this.range.br && this.range.br.model,
-            ext: this.range.ext,
-            editAs: this.range.editAs,
-          },
+            imageId: this.imageId,
+            hyperlinks: this.range.hyperlinks,
+            rotation: this.rotation,
+            range: {
+              tl: this.range.tl.model,
+              br: this.range.br && this.range.br.model,
+              ext: this.range.ext,
+              editAs: this.range.editAs,
+            },
         };
       default:
         throw new Error('Invalid Image Type');
     }
   }
 
-  set model({type, imageId, range, hyperlinks}) {
+  set model({
+    type,
+    rotation,
+    imageId,
+    range,
+    hyperlinks
+  }) {
     this.type = type;
     this.imageId = imageId;
-
+    this.rotation = rotation;
     if (type === 'image') {
       if (typeof range === 'string') {
         const decoded = colCache.decode(range);
         this.range = {
-          tl: new Anchor(this.worksheet, {col: decoded.left, row: decoded.top}, -1),
-          br: new Anchor(this.worksheet, {col: decoded.right, row: decoded.bottom}, 0),
+          tl: new Anchor(this.worksheet, {
+            col: decoded.left,
+            row: decoded.top
+          }, 0),
+          br: new Anchor(this.worksheet, {
+            col: decoded.right,
+            row: decoded.bottom
+          }, 0),
           editAs: 'oneCell',
         };
       } else {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -9,7 +9,6 @@ const Image = require('./image');
 const Table = require('./table');
 const DataValidations = require('./data-validations');
 const Encryptor = require('../utils/encryptor');
-const {copyStyle} = require('../utils/copy-style');
 
 // Worksheet requirements
 //  Operate as sheet inside workbook or standalone
@@ -407,10 +406,10 @@ class Worksheet {
   _copyStyle(src, dest, styleEmpty = false) {
     const rSrc = this.getRow(src);
     const rDst = this.getRow(dest);
-    rDst.style = copyStyle(rSrc.style);
+    rDst.style = Object.freeze({...rSrc.style});
     // eslint-disable-next-line no-loop-func
     rSrc.eachCell({includeEmpty: styleEmpty}, (cell, colNumber) => {
-      rDst.getCell(colNumber).style = copyStyle(cell.style);
+      rDst.getCell(colNumber).style = Object.freeze({...cell.style});
     });
     rDst.height = rSrc.height;
   }
@@ -674,11 +673,12 @@ class Worksheet {
 
   // =========================================================================
   // Images
-  addImage(imageId, range) {
+  addImage(imageId, range,rotation) {
     const model = {
       type: 'image',
       imageId,
       range,
+      rotation
     };
     this._media.push(new Image(this, model));
   }

--- a/lib/xlsx/xform/drawing/ext.js
+++ b/lib/xlsx/xform/drawing/ext.js
@@ -1,0 +1,43 @@
+const BaseXform = require('exceljs/lib/xlsx/xform/base-xform');
+
+class ExtXform extends BaseXform {
+  get tag() {
+    return 'a:ext';
+  }
+
+  render(xmlStream, model) {
+
+    model.ext&&xmlStream.leafNode(this.tag, {
+      'cx': model.ext.extentX,
+      'cy': model.ext.extentY
+    });
+  }
+
+  parseOpen(node) {
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          extentX: node.attributes['cx'],
+          extentY: node.attributes['cy'],
+
+        };
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        // unprocessed internal nodes
+        return true;
+    }
+  }
+}
+
+module.exports = ExtXform;

--- a/lib/xlsx/xform/drawing/off.js
+++ b/lib/xlsx/xform/drawing/off.js
@@ -1,0 +1,36 @@
+const BaseXform = require('exceljs/lib/xlsx/xform/base-xform');
+
+class OffXform extends BaseXform {
+  get tag() {
+    return 'a:off';
+  }
+
+  render(xmlStream, model) {
+
+    model.off&&xmlStream.leafNode(this.tag, {
+      'x': model.off.offsetX,
+      'y': model.off.offsetY
+    });
+  }
+
+  parseOpen(node) {
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          offsetX: node.attributes['x'],
+          offsetY: node.attributes['y'],
+        };
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+    return false;
+  }
+}
+
+module.exports = OffXform;

--- a/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
@@ -12,7 +12,7 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
     this.map = {
       'xdr:from': new CellPositionXform({tag: 'xdr:from'}),
       'xdr:ext': new ExtXform({tag: 'xdr:ext'}),
-      'xdr:pic': new PicXform(),
+      'xdr:pic': new StaticXform(PicXform),
       'xdr:clientData': new StaticXform({tag: 'xdr:clientData'}),
     };
   }

--- a/lib/xlsx/xform/drawing/pic-xform.js
+++ b/lib/xlsx/xform/drawing/pic-xform.js
@@ -13,7 +13,7 @@ class PicXform extends BaseXform {
     this.map = {
       'xdr:nvPicPr': new NvPicPrXform(),
       'xdr:blipFill': new BlipFillXform(),
-      'xdr:spPr': new StaticXform(spPrJSON),
+      'xdr:spPr': new spPrJSON(),
     };
   }
 

--- a/lib/xlsx/xform/drawing/sp-pr.js
+++ b/lib/xlsx/xform/drawing/sp-pr.js
@@ -1,17 +1,68 @@
-module.exports = {
-  tag: 'xdr:spPr',
-  c: [
-    {
-      tag: 'a:xfrm',
-      c: [
-        {tag: 'a:off', $: {x: '0', y: '0'}},
-        {tag: 'a:ext', $: {cx: '0', cy: '0'}},
-      ],
-    },
-    {
-      tag: 'a:prstGeom',
-      $: {prst: 'rect'},
-      c: [{tag: 'a:avLst'}],
-    },
-  ],
-};
+
+const BaseXform = require('../base-xform');
+const Xfrmform = require('./xfrm-xform');
+
+class SpPr extends BaseXform {
+    constructor() {
+      super();
+
+      this.map = {
+        'a:xfrm': new Xfrmform(),
+      };
+    }
+  get tag() {
+    return 'xdr:spPr';
+  }
+
+  render(xmlStream, model) {
+
+     xmlStream.openNode(this.tag);
+     this.map['a:xfrm'].render(xmlStream, model);
+     xmlStream.closeNode();
+
+  }
+
+  parseOpen(node) {
+        if (this.parser) {
+          this.parser.parseOpen(node);
+          return true;
+        }
+
+        switch (node.name) {
+          case this.tag:
+            this.reset();
+            break;
+
+          default:
+            this.parser = this.map[node.name];
+            if (this.parser) {
+              this.parser.parseOpen(node);
+            }
+            break;
+        }
+        return true;
+  }
+
+  parseText() {
+
+  }
+
+  parseClose(name) {
+        if (this.parser) {
+          if (!this.parser.parseClose(name)) {
+            this.parser = undefined;
+          }
+          return true;
+        }
+        switch (name) {
+          case this.tag:
+            this.model = this.map['a:xfrm'].model;
+            return false;
+
+          default:
+            return true;
+        }
+  }
+}
+
+module.exports = SpPr;

--- a/lib/xlsx/xform/drawing/xfrm-xform.js
+++ b/lib/xlsx/xform/drawing/xfrm-xform.js
@@ -1,0 +1,70 @@
+
+const BaseXform = require('exceljs/lib/xlsx/xform/base-xform');
+const OffXform = require('./off');
+const ExtXform = require('./ext');
+class XFrm extends BaseXform {
+   constructor() {
+     super();
+
+     this.map = {
+       'a:ext': new ExtXform(),
+       'a:off': new OffXform(),
+     };
+   }
+  get tag() {
+    return 'a:xfrm';
+  }
+
+  render(xmlStream, model) {
+    
+    xmlStream.openNode(this.tag, model.rotation && {
+      'rot': (model.rotation * 60000),
+    });
+    this.map['a:ext'].render(xmlStream, model);
+    this.map['a:off'].render(xmlStream, model);
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+    switch (node.name) {
+      case this.tag:
+        this.reset();
+        this.model = {
+          rot: parseInt(node.attributes['rot']) / 60000,
+        };
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+       if (this.parser) {
+         if (!this.parser.parseClose(name)) {
+           this.parser = undefined;
+         }
+         return true;
+       }
+       switch (name) {
+         case this.tag:
+          //  this.model.ext = this.map['a:ext'].model;
+          //  this.model.off = this.map['a:off'].model;
+           return false;
+         default:
+           return true;
+       }
+       }
+}
+
+module.exports = XFrm;

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -58,7 +58,9 @@ const mergeConditionalFormattings = (model, extModel) => {
   model.forEach(cf => {
     cfMap[cf.ref] = cf;
     cf.rules.forEach(rule => {
-      const {x14Id} = rule;
+      const {
+        x14Id
+      } = rule;
       if (x14Id) {
         ruleMap[x14Id] = rule;
       }
@@ -92,7 +94,10 @@ class WorkSheetXform extends BaseXform {
   constructor(options) {
     super();
 
-    const {maxRows, maxCols} = options || {};
+    const {
+      maxRows,
+      maxCols
+    } = options || {};
     this.map = {
       sheetPr: new SheetPropertiesXform(),
       dimension: new DimensionXform(),
@@ -102,16 +107,26 @@ class WorkSheetXform extends BaseXform {
         childXform: new SheetViewXform(),
       }),
       sheetFormatPr: new SheetFormatPropertiesXform(),
-      cols: new ListXform({tag: 'cols', count: false, childXform: new ColXform()}),
+      cols: new ListXform({
+        tag: 'cols',
+        count: false,
+        childXform: new ColXform()
+      }),
       sheetData: new ListXform({
         tag: 'sheetData',
         count: false,
         empty: true,
-        childXform: new RowXform({maxItems: maxCols}),
+        childXform: new RowXform({
+          maxItems: maxCols
+        }),
         maxItems: maxRows,
       }),
       autoFilter: new AutoFilterXform(),
-      mergeCells: new ListXform({tag: 'mergeCells', count: true, childXform: new MergeCellXform()}),
+      mergeCells: new ListXform({
+        tag: 'mergeCells',
+        count: true,
+        childXform: new MergeCellXform()
+      }),
       rowBreaks: new RowBreaksXform(),
       hyperlinks: new ListXform({
         tag: 'hyperlinks',
@@ -126,7 +141,11 @@ class WorkSheetXform extends BaseXform {
       picture: new PictureXform(),
       drawing: new DrawingXform(),
       sheetProtection: new SheetProtectionXform(),
-      tableParts: new ListXform({tag: 'tableParts', count: true, childXform: new TablePartXform()}),
+      tableParts: new ListXform({
+        tag: 'tableParts',
+        count: true,
+        childXform: new TablePartXform()
+      }),
       conditionalFormatting: new ConditionalFormattingsXform(),
       extLst: new ExtListXform(),
     };
@@ -204,11 +223,14 @@ class WorkSheetXform extends BaseXform {
         };
         model.image = options.media[medium.imageId];
       } else if (medium.type === 'image') {
-        let {drawing} = model;
+        let {
+          drawing
+        } = model;
         bookImage = options.media[medium.imageId];
         if (!drawing) {
           drawing = model.drawing = {
             rId: nextRid(rels),
+            rotation: 0,
             name: `drawing${++options.drawingsCount}`,
             anchors: [],
             rels: [],
@@ -221,9 +243,9 @@ class WorkSheetXform extends BaseXform {
           });
         }
         let rIdImage =
-          this.preImageId === medium.imageId
-            ? drawingRelsHash[medium.imageId]
-            : drawingRelsHash[drawing.rels.length];
+          this.preImageId === medium.imageId ?
+          drawingRelsHash[medium.imageId] :
+          drawingRelsHash[drawing.rels.length];
         if (!rIdImage) {
           rIdImage = nextRid(drawing.rels);
           drawingRelsHash[drawing.rels.length] = rIdImage;
@@ -237,6 +259,7 @@ class WorkSheetXform extends BaseXform {
         const anchor = {
           picture: {
             rId: rIdImage,
+            rotation: medium.rotation,
           },
           range: medium.range,
         };
@@ -272,7 +295,9 @@ class WorkSheetXform extends BaseXform {
 
       // dynamic styles
       table.columns.forEach(column => {
-        const {style} = column;
+        const {
+          style
+        } = column;
         if (style) {
           column.dxfId = options.styles.addDxfStyle(style);
         }
@@ -287,26 +312,25 @@ class WorkSheetXform extends BaseXform {
     xmlStream.openXml(XmlStream.StdDocAttributes);
     xmlStream.openNode('worksheet', WorkSheetXform.WORKSHEET_ATTRIBUTES);
 
-    const sheetFormatPropertiesModel = model.properties
-      ? {
-          defaultRowHeight: model.properties.defaultRowHeight,
-          dyDescent: model.properties.dyDescent,
-          outlineLevelCol: model.properties.outlineLevelCol,
-          outlineLevelRow: model.properties.outlineLevelRow,
-        }
-      : undefined;
+    const sheetFormatPropertiesModel = model.properties ?
+      {
+        defaultRowHeight: model.properties.defaultRowHeight,
+        dyDescent: model.properties.dyDescent,
+        outlineLevelCol: model.properties.outlineLevelCol,
+        outlineLevelRow: model.properties.outlineLevelRow,
+      } :
+      undefined;
     if (model.properties && model.properties.defaultColWidth) {
       sheetFormatPropertiesModel.defaultColWidth = model.properties.defaultColWidth;
     }
     const sheetPropertiesModel = {
       outlineProperties: model.properties && model.properties.outlineProperties,
       tabColor: model.properties && model.properties.tabColor,
-      pageSetup:
-        model.pageSetup && model.pageSetup.fitToPage
-          ? {
-              fitToPage: model.pageSetup.fitToPage,
-            }
-          : undefined,
+      pageSetup: model.pageSetup && model.pageSetup.fitToPage ?
+        {
+          fitToPage: model.pageSetup.fitToPage,
+        } :
+        undefined,
     };
     const pageMarginsModel = model.pageSetup && model.pageSetup.margins;
     const printOptionsModel = {
@@ -347,7 +371,9 @@ class WorkSheetXform extends BaseXform {
       // add a <legacyDrawing /> node for each comment
       model.rels.forEach(rel => {
         if (rel.Type === RelType.VmlDrawing) {
-          xmlStream.leafNode('legacyDrawing', {'r:id': rel.Id});
+          xmlStream.leafNode('legacyDrawing', {
+            'r:id': rel.Id
+          });
         }
       });
     }
@@ -398,8 +424,7 @@ class WorkSheetXform extends BaseXform {
           properties.outlineProperties = this.map.sheetPr.model.outlineProperties;
         }
         const sheetProperties = {
-          fitToPage:
-            (this.map.sheetPr.model &&
+          fitToPage: (this.map.sheetPr.model &&
               this.map.sheetPr.model.pageSetup &&
               this.map.sheetPr.model.pageSetup.fitToPage) ||
             false,
@@ -501,6 +526,7 @@ class WorkSheetXform extends BaseXform {
               imageId: anchor.medium.index,
               range: anchor.range,
               hyperlinks: anchor.picture.hyperlinks,
+              rotation: anchor.picture.rot
             };
             model.media.push(image);
           }

--- a/lib/xlsx/xform/sheet/xfrm-xform.js
+++ b/lib/xlsx/xform/sheet/xfrm-xform.js
@@ -1,0 +1,70 @@
+
+const BaseXform = require('exceljs/lib/xlsx/xform/base-xform');
+const OffXform = require('./off');
+const ExtXform = require('./ext');
+class XFrm extends BaseXform {
+   constructor() {
+     super();
+
+     this.map = {
+       'a:ext': new ExtXform(),
+       'a:off': new OffXform(),
+     };
+   }
+  get tag() {
+    return 'a:xfrm';
+  }
+
+  render(xmlStream, model) {
+    
+    xmlStream.openNode(this.tag, model.rotation && {
+      'rot': (model.rotation * 60000),
+    });
+    this.map['a:ext'].render(xmlStream, model);
+    this.map['a:off'].render(xmlStream, model);
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+    switch (node.name) {
+      case this.tag:
+        this.reset();
+        this.model = {
+          rot: parseInt(node.attributes['rot']) / 60000,
+        };
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+       if (this.parser) {
+         if (!this.parser.parseClose(name)) {
+           this.parser = undefined;
+         }
+         return true;
+       }
+       switch (name) {
+         case this.tag:
+           this.model.ext = this.map['a:ext'].model;
+           this.model.off = this.map['a:off'].model;
+           return false;
+         default:
+           return true;
+       }
+       }
+}
+
+module.exports = XFrm;


### PR DESCRIPTION
add media rotation, extent, offset property

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

add more properties for media object, such as rotation. 
now can define image rotation in addImage()

## Test plan
Sheet with images to duplicate (test location and rotation, etc..)
![Screenshot 2022-04-30 224542](https://user-images.githubusercontent.com/19159941/166110310-26a4592c-095d-4fb3-b92b-ca66c2400322.jpeg)
duplicated sheet, (using addImage(), not duplicate model directly)
![Screenshot 2022-04-30 224555](https://user-images.githubusercontent.com/19159941/166110333-ecbf4530-5c76-4bea-8edf-735cf50a78a8.jpeg)
Now the media can be exactly the same as provided properties

## Related to source code (for typings update)
xfrm-xform.js:

  parseOpen(node) {
    if (this.parser) {
      this.parser.parseOpen(node);
      return true;
    }
    switch (node.name) {
      case this.tag:
        this.reset();
        this.model = {
          rot: parseInt(node.attributes['rot']) / 60000,
        };
        break;
      default:
        this.parser = this.map[node.name];
        if (this.parser) {
          this.parser.parseOpen(node);
        }
        break;
    }
    return true;
  }

<!-- List with permalink into source code to prove that changes are true -->
https://github.com/GitSamson/FFE_Database_Builder