### PR TITLE
ci: add tests run in Node 18.x

### DIFF
--- a/.github/workflows/exceljs.yml
+++ b/.github/workflows/exceljs.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/actions/setup-node/issues/27
-        node-version: [8.17.0, 10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [8.17.0, 10.x, 12.x, 14.x, 16.x, 17.x, 18.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary
We want to be able to know if the library is not breaking in the newer versions of Node
