### PR TITLE
Prevent column overflow in data validations

### DIFF
--- a/lib/xlsx/xform/sheet/data-validations-xform.js
+++ b/lib/xlsx/xform/sheet/data-validations-xform.js
@@ -63,7 +63,7 @@ function optimiseDataValidations(model) {
         // iterate rightwards...
 
         let width = 1;
-        while (matchCol(addr, height, addr.col + width)) {
+        while (addr.col+width <= 16384 && matchCol(addr, height, addr.col + width)) {
           width++;
         }
 


### PR DESCRIPTION
If data validation goes all the way to the rightmost column, address encoding will cause a crash.
A simple sanity check will prevent us from iterating past the end of the document.


## Summary
I have a sheet that goes to column XFD and uses data validation. 
There are many thousands of these legacy sheets, so updating the sheets before processing in excel-js isn't a good option.

When attempting to save this sheet, the optimization routine for data validation causes a crash by accessing column XFE.
## Test plan

I can provide screenshots of before/after this change is made on a sheet.
I could also provide a test case with data validation in  cell XFD1.


## Related to source code (for typings update)

Unsure what is wanted here.