### PR TITLE
basic shape support added

### DIFF
--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -1,0 +1,70 @@
+const colCache = require('../utils/col-cache');
+const Anchor = require('./anchor');
+
+class Shape {
+  constructor(worksheet, model) {
+    this.worksheet = worksheet;
+    this.model = model;
+  }
+
+  get model() {
+    switch (this.type) {
+      case 'shape':
+        return {
+          type: this.type,
+          shape: this.shape,
+          rotation: this.rotation,
+          fill: this.fill,
+          stroke: this.stroke,
+          hyperlinks: this.range.hyperlinks,
+          range: {
+            tl: this.range.tl.model,
+            br: this.range.br && this.range.br.model,
+            ext: this.range.ext,
+            editAs: this.range.editAs,
+          },
+        };
+      default:
+        throw new Error('Invalid Shape Type');
+    }
+  }
+
+  set model({type, shape, rotation, fill, stroke, range, hyperlinks}) {
+    this.type = type;
+    this.shape = shape;
+    this.rotation = rotation;
+    this.fill = fill;
+    this.stroke = stroke;
+
+    if (type === 'shape') {
+      if (typeof range === 'string') {
+        const decoded = colCache.decode(range);
+        this.range = {
+          tl: new Anchor(this.worksheet, {col: decoded.left, row: decoded.top}, -1),
+          br: new Anchor(this.worksheet, {col: decoded.right, row: decoded.bottom}, 0),
+          editAs: 'oneCell',
+        };
+      } else {
+        this.range = {
+          tl: new Anchor(this.worksheet, range.tl, 0),
+          br: range.br && new Anchor(this.worksheet, range.br, 0),
+          ext: range.ext,
+          editAs: range.editAs,
+          hyperlinks: hyperlinks || range.hyperlinks,
+        };
+      }
+    }
+  }
+}
+
+Shape.LINE = 'line';
+Shape.RECTANGLE = 'rect';
+Shape.ROUND_RECTANGLE = 'roundRect';
+Shape.ELLIPSE = 'ellipse';
+Shape.TRIANGLE = 'triangle';
+Shape.RIGHT_ARROW = 'rightArrow';
+Shape.DOWN_ARROW = 'downArrow';
+Shape.LEFT_BRACE = 'leftBrace';
+Shape.RIGHT_BRACE = 'rightBrace';
+
+module.exports = Shape;

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -6,6 +6,7 @@ const Row = require('./row');
 const Column = require('./column');
 const Enums = require('./enums');
 const Image = require('./image');
+const Shape = require('./shape');
 const Table = require('./table');
 const DataValidations = require('./data-validations');
 const Encryptor = require('../utils/encryptor');
@@ -698,6 +699,24 @@ class Worksheet {
   getBackgroundImageId() {
     const image = this._media.find(m => m.type === 'background');
     return image && image.imageId;
+  }
+
+  // =========================================================================
+  // Shapes
+  addShape({shape, fill, stroke, rotation}, range) {
+    const model = {
+      type: 'shape',
+      shape: shape || 'rect',
+      rotation: rotation || 0,
+      fill: fill || {color: '000000', opacity: 0},
+      stroke: stroke || {color: '000000', opacity: 0, weight: 1},
+      range,
+    };
+    this._media.push(new Shape(this, model));
+  }
+
+  getShapes() {
+    return this._media.filter(m => m.type === 'shape');
   }
 
   // =========================================================================

--- a/lib/xlsx/xform/drawing/fill-ref-xform.js
+++ b/lib/xlsx/xform/drawing/fill-ref-xform.js
@@ -1,28 +1,23 @@
 const BaseXform = require('../base-xform');
-const HlickClickXform = require('./hlink-click-xform');
-const ExtLstXform = require('./ext-lst-xform');
 
-class CNvPrXform extends BaseXform {
+const SchemeClrXform = require('./scheme-clr-xform');
+
+class FillRefXform extends BaseXform {
   constructor() {
     super();
-
+    this.model = null;
     this.map = {
-      'a:hlinkClick': new HlickClickXform(),
-      'a:extLst': new ExtLstXform(),
+      'a:schemeClr': new SchemeClrXform(),
     };
   }
 
   get tag() {
-    return 'xdr:cNvPr';
+    return 'a:fillRef';
   }
 
   render(xmlStream, model) {
-    xmlStream.openNode(this.tag, {
-      id: model.index,
-      name: `${model.rId ? 'Picture' : 'Shape'} ${model.index}`,
-    });
-    this.map['a:hlinkClick'].render(xmlStream, model);
-    this.map['a:extLst'].render(xmlStream, model);
+    xmlStream.openNode(this.tag, {idx: 1});
+    this.map['a:schemeClr'].render(xmlStream, {schemeColor: 'accent1', shade: 0, opacity: 1});
     xmlStream.closeNode();
   }
 
@@ -31,7 +26,6 @@ class CNvPrXform extends BaseXform {
       this.parser.parseOpen(node);
       return true;
     }
-
     switch (node.name) {
       case this.tag:
         this.reset();
@@ -46,8 +40,6 @@ class CNvPrXform extends BaseXform {
     return true;
   }
 
-  parseText() {}
-
   parseClose(name) {
     if (this.parser) {
       if (!this.parser.parseClose(name)) {
@@ -55,9 +47,10 @@ class CNvPrXform extends BaseXform {
       }
       return true;
     }
+
     switch (name) {
       case this.tag:
-        this.model = this.map['a:hlinkClick'].model;
+        this.model = this.map['a:schemeClr'].model;
         return false;
       default:
         return true;
@@ -65,4 +58,4 @@ class CNvPrXform extends BaseXform {
   }
 }
 
-module.exports = CNvPrXform;
+module.exports = FillRefXform;

--- a/lib/xlsx/xform/drawing/ln-ref-xform.js
+++ b/lib/xlsx/xform/drawing/ln-ref-xform.js
@@ -1,28 +1,23 @@
 const BaseXform = require('../base-xform');
-const HlickClickXform = require('./hlink-click-xform');
-const ExtLstXform = require('./ext-lst-xform');
 
-class CNvPrXform extends BaseXform {
+const SchemeClrXform = require('./scheme-clr-xform');
+
+class LnRefXform extends BaseXform {
   constructor() {
     super();
-
+    this.model = null;
     this.map = {
-      'a:hlinkClick': new HlickClickXform(),
-      'a:extLst': new ExtLstXform(),
+      'a:schemeClr': new SchemeClrXform(),
     };
   }
 
   get tag() {
-    return 'xdr:cNvPr';
+    return 'a:lnRef';
   }
 
   render(xmlStream, model) {
-    xmlStream.openNode(this.tag, {
-      id: model.index,
-      name: `${model.rId ? 'Picture' : 'Shape'} ${model.index}`,
-    });
-    this.map['a:hlinkClick'].render(xmlStream, model);
-    this.map['a:extLst'].render(xmlStream, model);
+    xmlStream.openNode(this.tag, {idx: 2});
+    this.map['a:schemeClr'].render(xmlStream, {schemeColor: 'accent1', shade: 0.5, opacity: 1});
     xmlStream.closeNode();
   }
 
@@ -31,7 +26,6 @@ class CNvPrXform extends BaseXform {
       this.parser.parseOpen(node);
       return true;
     }
-
     switch (node.name) {
       case this.tag:
         this.reset();
@@ -46,8 +40,6 @@ class CNvPrXform extends BaseXform {
     return true;
   }
 
-  parseText() {}
-
   parseClose(name) {
     if (this.parser) {
       if (!this.parser.parseClose(name)) {
@@ -55,9 +47,10 @@ class CNvPrXform extends BaseXform {
       }
       return true;
     }
+
     switch (name) {
       case this.tag:
-        this.model = this.map['a:hlinkClick'].model;
+        this.model = this.map['a:schemeClr'].model;
         return false;
       default:
         return true;
@@ -65,4 +58,4 @@ class CNvPrXform extends BaseXform {
   }
 }
 
-module.exports = CNvPrXform;
+module.exports = LnRefXform;

--- a/lib/xlsx/xform/drawing/ln-xform.js
+++ b/lib/xlsx/xform/drawing/ln-xform.js
@@ -1,0 +1,71 @@
+const BaseXform = require('../base-xform');
+const SolidFillXform = require('./solid-fill-xform');
+const NoFillXform = require('./no-fill-xform');
+
+class LnXform extends BaseXform {
+
+  constructor() {
+    super();
+    this.model = null;
+    this.map = {
+      'a:solidFill': new SolidFillXform(),
+      'a:noFill': new NoFillXform(),
+    };
+  }
+
+  get tag() {
+    return 'a:ln';
+  }
+
+  render(xmlStream, model) {
+    const m = (typeof model !== 'object' || model === null) ? {weight: 1, opacity: 0} : model;
+
+    xmlStream.openNode(this.tag, {w: (m.weight || 1) * 12700});
+    if(m.opacity === 0) {
+      this.map['a:noFill'].render(xmlStream, model);
+    } else {
+      this.map['a:solidFill'].render(xmlStream, model);
+    }
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          weight: parseInt(node.attributes.w || '12700', 10) / 12700
+        };
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        const model = Object.assign({}, this.map['a:solidFill'].model, this.map['a:noFill'].model)
+        this.model = Object.keys(model).length ? Object.assign(this.model, model) : null;
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = LnXform;

--- a/lib/xlsx/xform/drawing/no-fill-xform.js
+++ b/lib/xlsx/xform/drawing/no-fill-xform.js
@@ -1,0 +1,40 @@
+const BaseXform = require('../base-xform');
+
+class NoFillXform extends BaseXform {
+  constructor() {
+    super();
+    this.model = null;
+  }
+
+  get tag() {
+    return 'a:noFill';
+  }
+
+  render(xmlStream, model) {
+    xmlStream.leafNode(this.tag);
+  }
+
+  parseOpen(node) {
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          color: '000000',
+          opacity: 0,
+        };
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  parseClose(name) {
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = NoFillXform;

--- a/lib/xlsx/xform/drawing/nv-sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/nv-sp-pr-xform.js
@@ -1,28 +1,23 @@
 const BaseXform = require('../base-xform');
-const HlickClickXform = require('./hlink-click-xform');
-const ExtLstXform = require('./ext-lst-xform');
+const CNvPrXform = require('./c-nv-pr-xform');
 
-class CNvPrXform extends BaseXform {
+class NvSpPrXform extends BaseXform {
   constructor() {
     super();
 
     this.map = {
-      'a:hlinkClick': new HlickClickXform(),
-      'a:extLst': new ExtLstXform(),
+      'xdr:cNvPr': new CNvPrXform(),
     };
   }
 
   get tag() {
-    return 'xdr:cNvPr';
+    return 'xdr:nvSpPr';
   }
 
   render(xmlStream, model) {
-    xmlStream.openNode(this.tag, {
-      id: model.index,
-      name: `${model.rId ? 'Picture' : 'Shape'} ${model.index}`,
-    });
-    this.map['a:hlinkClick'].render(xmlStream, model);
-    this.map['a:extLst'].render(xmlStream, model);
+    xmlStream.openNode(this.tag);
+    this.map['xdr:cNvPr'].render(xmlStream, model);
+    xmlStream.leafNode('xdr:cNvSpPr')
     xmlStream.closeNode();
   }
 
@@ -57,7 +52,7 @@ class CNvPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.model = this.map['a:hlinkClick'].model;
+        this.model = this.map['xdr:cNvPr'].model;
         return false;
       default:
         return true;
@@ -65,4 +60,4 @@ class CNvPrXform extends BaseXform {
   }
 }
 
-module.exports = CNvPrXform;
+module.exports = NvSpPrXform;

--- a/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
@@ -4,6 +4,7 @@ const StaticXform = require('../static-xform');
 const CellPositionXform = require('./cell-position-xform');
 const ExtXform = require('./ext-xform');
 const PicXform = require('./pic-xform');
+const SpXform = require('./sp-xform');
 
 class OneCellAnchorXform extends BaseCellAnchorXform {
   constructor() {
@@ -13,6 +14,7 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
       'xdr:from': new CellPositionXform({tag: 'xdr:from'}),
       'xdr:ext': new ExtXform({tag: 'xdr:ext'}),
       'xdr:pic': new PicXform(),
+      'xdr:sp': new SpXform(),
       'xdr:clientData': new StaticXform({tag: 'xdr:clientData'}),
     };
   }
@@ -22,7 +24,8 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
   }
 
   prepare(model, options) {
-    this.map['xdr:pic'].prepare(model.picture, options);
+    model.picture && this.map['xdr:pic'].prepare(model.picture, options);
+    model.shape && this.map['xdr:sp'].prepare(model.shape, options);
   }
 
   render(xmlStream, model) {
@@ -30,7 +33,8 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
 
     this.map['xdr:from'].render(xmlStream, model.range.tl);
     this.map['xdr:ext'].render(xmlStream, model.range.ext);
-    this.map['xdr:pic'].render(xmlStream, model.picture);
+    model.picture && this.map['xdr:pic'].render(xmlStream, model.picture);
+    model.shape && this.map['xdr:sp'].render(xmlStream, model.shape);
     this.map['xdr:clientData'].render(xmlStream, {});
 
     xmlStream.closeNode();
@@ -48,6 +52,7 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
         this.model.range.tl = this.map['xdr:from'].model;
         this.model.range.ext = this.map['xdr:ext'].model;
         this.model.picture = this.map['xdr:pic'].model;
+        this.model.shape = this.map['xdr:sp'].model;
         return false;
       default:
         // could be some unrecognised tags

--- a/lib/xlsx/xform/drawing/prst-geom-xform.js
+++ b/lib/xlsx/xform/drawing/prst-geom-xform.js
@@ -1,0 +1,38 @@
+const BaseXform = require('../base-xform');
+
+class PrstGeomXform extends BaseXform {
+  get tag() {
+    return 'a:prstGeom';
+  }
+
+  prepare(model, options) {}
+
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag, {prst: model.shape});
+    xmlStream.leafNode('a:avLst', {});
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          shape: node.attributes.prst
+        };
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  parseClose(name) {
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = PrstGeomXform;

--- a/lib/xlsx/xform/drawing/scheme-clr-xform.js
+++ b/lib/xlsx/xform/drawing/scheme-clr-xform.js
@@ -1,0 +1,56 @@
+const BaseXform = require('../base-xform');
+
+class SchemeClrXform extends BaseXform {
+  constructor() {
+    super();
+    this.model = null;
+  }
+
+  get tag() {
+    return 'a:schemeClr';
+  }
+
+  render(xmlStream, model) {
+    if(model.schemeColor) {
+      xmlStream.openNode(this.tag, {val: model.schemeColor});
+      if (model.shade !== 0) {
+        xmlStream.leafNode('a:shade', {val: model.shade * 100000});
+      }
+      if (model.opacity < 1) {
+        xmlStream.leafNode('a:alpha', {val: model.opacity * 100000});
+      }
+      xmlStream.closeNode();
+    }
+  }
+
+  parseOpen(node) {
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          schemeColor: node.attributes.val,
+          shade: 0,
+          opacity: 1,
+        };
+        return true;
+      case 'a:alpha':
+        this.model.opacity = parseInt(node.attributes.val || '100000', 10) / 100000;
+        return true;
+      case 'a:shade':
+        this.model.shade = parseInt(node.attributes.val || '0', 10) / 100000;
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  parseClose(name) {
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = SchemeClrXform;

--- a/lib/xlsx/xform/drawing/solid-fill-xform.js
+++ b/lib/xlsx/xform/drawing/solid-fill-xform.js
@@ -1,28 +1,29 @@
 const BaseXform = require('../base-xform');
-const HlickClickXform = require('./hlink-click-xform');
-const ExtLstXform = require('./ext-lst-xform');
 
-class CNvPrXform extends BaseXform {
+const SchemeClrXform = require('./scheme-clr-xform');
+const SrgbClrXform = require('./srgb-clr-xform');
+
+class SolidFillXform extends BaseXform {
   constructor() {
     super();
-
+    this.model = null;
     this.map = {
-      'a:hlinkClick': new HlickClickXform(),
-      'a:extLst': new ExtLstXform(),
+      'a:srgbClr': new SrgbClrXform(),
+      'a:schemeClr': new SchemeClrXform(),
     };
   }
 
   get tag() {
-    return 'xdr:cNvPr';
+    return 'a:solidFill';
   }
 
   render(xmlStream, model) {
-    xmlStream.openNode(this.tag, {
-      id: model.index,
-      name: `${model.rId ? 'Picture' : 'Shape'} ${model.index}`,
-    });
-    this.map['a:hlinkClick'].render(xmlStream, model);
-    this.map['a:extLst'].render(xmlStream, model);
+    xmlStream.openNode(this.tag);
+    if(model.color) {
+      this.map['a:srgbClr'].render(xmlStream, model);
+    } else {
+      this.map['a:schemeClr'].render(xmlStream, model);
+    }
     xmlStream.closeNode();
   }
 
@@ -31,7 +32,6 @@ class CNvPrXform extends BaseXform {
       this.parser.parseOpen(node);
       return true;
     }
-
     switch (node.name) {
       case this.tag:
         this.reset();
@@ -46,8 +46,6 @@ class CNvPrXform extends BaseXform {
     return true;
   }
 
-  parseText() {}
-
   parseClose(name) {
     if (this.parser) {
       if (!this.parser.parseClose(name)) {
@@ -55,9 +53,17 @@ class CNvPrXform extends BaseXform {
       }
       return true;
     }
+
     switch (name) {
       case this.tag:
-        this.model = this.map['a:hlinkClick'].model;
+        this.model = Object.assign(
+          {},
+          this.map['a:schemeClr'].model,
+          this.map['a:srgbClr'].model,
+        );
+        if(!Object.keys(this.model).length) {
+          this.model = null;
+        }
         return false;
       default:
         return true;
@@ -65,4 +71,4 @@ class CNvPrXform extends BaseXform {
   }
 }
 
-module.exports = CNvPrXform;
+module.exports = SolidFillXform;

--- a/lib/xlsx/xform/drawing/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/sp-pr-xform.js
@@ -1,0 +1,88 @@
+const BaseXform = require('../base-xform')
+const XfrmXform = require('./xfrm-xform')
+const PrstGeomXform = require('./prst-geom-xform')
+const SolidFillXform = require('./solid-fill-xform')
+const NoFillXform = require('./no-fill-xform')
+const LnXform = require('./ln-xform')
+
+class SpPrXform extends BaseXform {
+  constructor () {
+    super();
+
+    this.map = {
+      'a:xfrm': new XfrmXform(),
+      'a:prstGeom': new PrstGeomXform(),
+      'a:solidFill': new SolidFillXform(),
+      'a:noFill': new NoFillXform(),
+      'a:ln': new LnXform(),
+    };
+  }
+
+  get tag () {
+    return 'xdr:spPr';
+  }
+
+  render (xmlStream, model) {
+    xmlStream.openNode(this.tag);
+
+    this.map['a:xfrm'].render(xmlStream, model);
+    this.map['a:prstGeom'].render(xmlStream, model);
+    if(typeof model.fill !== 'object' || model.fill === null || model.fill.opacity === 0) {
+      this.map['a:noFill'].render(xmlStream, model.fill);
+    } else {
+      this.map['a:solidFill'].render(xmlStream, model.fill);
+    }
+    this.map['a:ln'].render(xmlStream, model.stroke);
+
+    xmlStream.closeNode();
+  }
+
+  parseOpen (node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          shape: 'rect',
+          rotation: 0,
+          fill: null,
+          stroke: null
+        };
+        break
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break
+    }
+    return true
+  }
+
+  parseClose (name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true
+    }
+    switch (name) {
+      case this.tag:
+        Object.assign(
+          this.model,
+          this.map['a:xfrm'].model ? this.map['a:xfrm'].model : null,
+          this.map['a:prstGeom'].model ? this.map['a:prstGeom'].model : null,
+          this.map['a:solidFill'].model ? {fill: this.map['a:solidFill'].model} : null,
+          this.map['a:noFill'].model ? {fill: this.map['a:noFill'].model} : null,
+          this.map['a:ln'].model ? {stroke: this.map['a:ln'].model} : null,
+        );
+        return false
+      default:
+        return true
+    }
+  }
+}
+
+module.exports = SpPrXform

--- a/lib/xlsx/xform/drawing/sp-xform.js
+++ b/lib/xlsx/xform/drawing/sp-xform.js
@@ -1,0 +1,88 @@
+const BaseXform = require('../base-xform');
+const StaticXform = require('../static-xform');
+const NvSpPrXform = require('./nv-sp-pr-xform');
+const SpPrXform = require('./sp-pr-xform');
+const StyleXform = require('./style-xform');
+
+const txBodyJSON = require('./tx-body');
+
+class SpXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'xdr:nvSpPr': new NvSpPrXform(),
+      'xdr:spPr': new SpPrXform(),
+      'xdr:style': new StyleXform(),
+      'xdr:txBody': new StaticXform(txBodyJSON),
+    };
+  }
+
+  get tag() {
+    return 'xdr:sp';
+  }
+
+  prepare(model, options) {
+    model.index = options.index + 1;
+  }
+
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag);
+
+    this.map['xdr:nvSpPr'].render(xmlStream, model);
+    this.map['xdr:spPr'].render(xmlStream, model);
+    this.map['xdr:style'].render(xmlStream, model);
+    this.map['xdr:txBody'].render(xmlStream, model);
+
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+    switch (node.name) {
+      case this.tag:
+        this.reset();
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        const
+          fill = Object.assign({}, this.map['xdr:style'].model.fill, this.map['xdr:spPr'].model.fill),
+          stroke = Object.assign({}, this.map['xdr:style'].model.stroke, this.map['xdr:spPr'].model.stroke)
+
+        this.model = Object.assign(
+          {},
+          this.map['xdr:spPr'].model,
+          Object.keys(fill).length ? {fill} : null,
+          Object.keys(stroke).length ? {stroke} : null,
+          this.map['xdr:nvSpPr'].model,
+        );
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = SpXform;

--- a/lib/xlsx/xform/drawing/srgb-clr-xform.js
+++ b/lib/xlsx/xform/drawing/srgb-clr-xform.js
@@ -1,0 +1,49 @@
+const BaseXform = require('../base-xform');
+
+class SrgbClrXform extends BaseXform {
+  constructor() {
+    super();
+    this.model = null;
+  }
+
+  get tag() {
+    return 'a:srgbClr';
+  }
+
+  render(xmlStream, model) {
+    if(model.color) {
+      xmlStream.openNode(this.tag, {val: model.color});
+      if (model.opacity < 1) {
+        xmlStream.leafNode('a:alpha', {val: model.opacity * 100000});
+      }
+      xmlStream.closeNode();
+    }
+  }
+
+  parseOpen(node) {
+    switch (node.name) {
+      case this.tag:
+        this.model = {
+          color: node.attributes.val,
+          opacity: 1,
+        };
+        return true;
+      case 'a:alpha':
+        this.model.opacity = parseInt(node.attributes.val || '100000', 10) / 100000;
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  parseClose(name) {
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = SrgbClrXform;

--- a/lib/xlsx/xform/drawing/style-xform.js
+++ b/lib/xlsx/xform/drawing/style-xform.js
@@ -1,28 +1,32 @@
 const BaseXform = require('../base-xform');
-const HlickClickXform = require('./hlink-click-xform');
-const ExtLstXform = require('./ext-lst-xform');
 
-class CNvPrXform extends BaseXform {
+const LnRefXform = require('./ln-ref-xform');
+const FillRefXform = require('./fill-ref-xform');
+
+class StyleXform extends BaseXform {
   constructor() {
     super();
-
+    this.model = null;
     this.map = {
-      'a:hlinkClick': new HlickClickXform(),
-      'a:extLst': new ExtLstXform(),
+      'a:lnRef': new LnRefXform(),
+      'a:fillRef': new FillRefXform(),
     };
   }
 
   get tag() {
-    return 'xdr:cNvPr';
+    return 'xdr:style';
   }
 
   render(xmlStream, model) {
-    xmlStream.openNode(this.tag, {
-      id: model.index,
-      name: `${model.rId ? 'Picture' : 'Shape'} ${model.index}`,
-    });
-    this.map['a:hlinkClick'].render(xmlStream, model);
-    this.map['a:extLst'].render(xmlStream, model);
+    xmlStream.openNode(this.tag);
+    this.map['a:lnRef'].render(xmlStream, model);
+    this.map['a:fillRef'].render(xmlStream, model);
+    xmlStream.openNode('a:effectRef', {idx: 0});
+    xmlStream.leafNode('a:schemeClr', {val: 'accent1'});
+    xmlStream.closeNode();
+    xmlStream.openNode('a:fontRef', {idx: 'minor'});
+    xmlStream.leafNode('a:schemeClr', {val: 'lt1'});
+    xmlStream.closeNode();
     xmlStream.closeNode();
   }
 
@@ -31,7 +35,6 @@ class CNvPrXform extends BaseXform {
       this.parser.parseOpen(node);
       return true;
     }
-
     switch (node.name) {
       case this.tag:
         this.reset();
@@ -46,8 +49,6 @@ class CNvPrXform extends BaseXform {
     return true;
   }
 
-  parseText() {}
-
   parseClose(name) {
     if (this.parser) {
       if (!this.parser.parseClose(name)) {
@@ -55,9 +56,13 @@ class CNvPrXform extends BaseXform {
       }
       return true;
     }
+
     switch (name) {
       case this.tag:
-        this.model = this.map['a:hlinkClick'].model;
+        this.model = {
+          stroke: this.map['a:lnRef'].model,
+          fill: this.map['a:fillRef'].model,
+        };
         return false;
       default:
         return true;
@@ -65,4 +70,4 @@ class CNvPrXform extends BaseXform {
   }
 }
 
-module.exports = CNvPrXform;
+module.exports = StyleXform;

--- a/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
@@ -3,6 +3,7 @@ const StaticXform = require('../static-xform');
 
 const CellPositionXform = require('./cell-position-xform');
 const PicXform = require('./pic-xform');
+const SpXform = require('./sp-xform');
 
 class TwoCellAnchorXform extends BaseCellAnchorXform {
   constructor() {
@@ -12,6 +13,7 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
       'xdr:from': new CellPositionXform({tag: 'xdr:from'}),
       'xdr:to': new CellPositionXform({tag: 'xdr:to'}),
       'xdr:pic': new PicXform(),
+      'xdr:sp': new SpXform(),
       'xdr:clientData': new StaticXform({tag: 'xdr:clientData'}),
     };
   }
@@ -21,7 +23,8 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
   }
 
   prepare(model, options) {
-    this.map['xdr:pic'].prepare(model.picture, options);
+    model.picture && this.map['xdr:pic'].prepare(model.picture, options);
+    model.shape && this.map['xdr:sp'].prepare(model.shape, options);
   }
 
   render(xmlStream, model) {
@@ -29,7 +32,8 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
 
     this.map['xdr:from'].render(xmlStream, model.range.tl);
     this.map['xdr:to'].render(xmlStream, model.range.br);
-    this.map['xdr:pic'].render(xmlStream, model.picture);
+    model.picture && this.map['xdr:pic'].render(xmlStream, model.picture);
+    model.shape && this.map['xdr:sp'].render(xmlStream, model.shape);
     this.map['xdr:clientData'].render(xmlStream, {});
 
     xmlStream.closeNode();
@@ -47,6 +51,7 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
         this.model.range.tl = this.map['xdr:from'].model;
         this.model.range.br = this.map['xdr:to'].model;
         this.model.picture = this.map['xdr:pic'].model;
+        this.model.shape = this.map['xdr:sp'].model;
         return false;
       default:
         // could be some unrecognised tags

--- a/lib/xlsx/xform/drawing/tx-body.js
+++ b/lib/xlsx/xform/drawing/tx-body.js
@@ -1,0 +1,35 @@
+module.exports = {
+  tag: 'xdr:txBody',
+  c: [
+    {
+      tag: 'a:bodyPr',
+      $: {
+        vertOverflow: 'clip',
+        horzOverflow: 'clip',
+        rtlCol: '0',
+        anchor: 't',
+      },
+    },
+    {
+      tag: 'a:lstStyle',
+    },
+    {
+      tag: 'a:p',
+      c: [
+        {
+          tag: 'a:pPr',
+          $: {
+            algn: 'l',
+          },
+        },
+        {
+          tag: 'a:endParaRPr',
+          $: {
+            lang: 'en-US',
+            sz: '1100',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/lib/xlsx/xform/drawing/xfrm-xform.js
+++ b/lib/xlsx/xform/drawing/xfrm-xform.js
@@ -1,0 +1,37 @@
+const BaseXform = require('../base-xform');
+
+class XfrmXform extends BaseXform {
+  get tag() {
+    return 'a:xfrm';
+  }
+
+  prepare(model, options) {}
+
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag, {rot: model.rotation * 60000});
+    xmlStream.leafNode('a:off', {x: 0, y: 0});
+    xmlStream.leafNode('a:ext', {cx: 0, cy: 0});
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    switch (node.name) {
+      case this.tag:
+        this.model = {rotation: (node.attributes.rot || 0) / 60000};
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  parseClose(name) {
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = XfrmXform;

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -203,7 +203,7 @@ class WorkSheetXform extends BaseXform {
           rId,
         };
         model.image = options.media[medium.imageId];
-      } else if (medium.type === 'image') {
+      } else if (medium.type === 'image' || medium.type === 'shape') {
         let {drawing} = model;
         bookImage = options.media[medium.imageId];
         if (!drawing) {
@@ -220,42 +220,57 @@ class WorkSheetXform extends BaseXform {
             Target: `../drawings/${drawing.name}.xml`,
           });
         }
-        let rIdImage =
-          this.preImageId === medium.imageId
-            ? drawingRelsHash[medium.imageId]
-            : drawingRelsHash[drawing.rels.length];
-        if (!rIdImage) {
-          rIdImage = nextRid(drawing.rels);
-          drawingRelsHash[drawing.rels.length] = rIdImage;
-          drawing.rels.push({
-            Id: rIdImage,
-            Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
-            Target: `../media/${bookImage.name}.${bookImage.extension}`,
-          });
-        }
 
-        const anchor = {
-          picture: {
-            rId: rIdImage,
-          },
-          range: medium.range,
-        };
-        if (medium.hyperlinks && medium.hyperlinks.hyperlink) {
-          const rIdHyperLink = nextRid(drawing.rels);
-          drawingRelsHash[drawing.rels.length] = rIdHyperLink;
-          anchor.picture.hyperlinks = {
-            tooltip: medium.hyperlinks.tooltip,
-            rId: rIdHyperLink,
+        if (medium.type === 'image') {
+          let rIdImage =
+            this.preImageId === medium.imageId
+              ? drawingRelsHash[medium.imageId]
+              : drawingRelsHash[drawing.rels.length];
+          if (!rIdImage) {
+            rIdImage = nextRid(drawing.rels);
+            drawingRelsHash[drawing.rels.length] = rIdImage;
+            drawing.rels.push({
+              Id: rIdImage,
+              Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
+              Target: `../media/${bookImage.name}.${bookImage.extension}`,
+            });
+          }
+
+          const anchor = {
+            picture: {
+              rId: rIdImage,
+            },
+            range: medium.range,
           };
-          drawing.rels.push({
-            Id: rIdHyperLink,
-            Type: RelType.Hyperlink,
-            Target: medium.hyperlinks.hyperlink,
-            TargetMode: 'External',
-          });
+          if (medium.hyperlinks && medium.hyperlinks.hyperlink) {
+            const rIdHyperLink = nextRid(drawing.rels);
+            drawingRelsHash[drawing.rels.length] = rIdHyperLink;
+            anchor.picture.hyperlinks = {
+              tooltip: medium.hyperlinks.tooltip,
+              rId: rIdHyperLink,
+            };
+            drawing.rels.push({
+              Id: rIdHyperLink,
+              Type: RelType.Hyperlink,
+              Target: medium.hyperlinks.hyperlink,
+              TargetMode: 'External',
+            });
+          }
+          this.preImageId = medium.imageId;
+          drawing.anchors.push(anchor);
+        } else if (medium.type === 'shape') {
+          const anchor = {
+            shape: {
+              type: medium.type,
+              shape: medium.shape,
+              rotation: medium.rotation,
+              fill: medium.fill,
+              stroke: medium.stroke,
+            },
+            range: medium.range,
+          };
+          drawing.anchors.push(anchor);
         }
-        this.preImageId = medium.imageId;
-        drawing.anchors.push(anchor);
       }
     });
 
@@ -503,6 +518,17 @@ class WorkSheetXform extends BaseXform {
               hyperlinks: anchor.picture.hyperlinks,
             };
             model.media.push(image);
+          } else if (anchor.shape) {
+            const shape = {
+              type: 'shape',
+              shape: anchor.shape.shape,
+              rotation: anchor.shape.rotation,
+              fill: anchor.shape.fill,
+              stroke: anchor.shape.stroke,
+              range: anchor.range,
+              hyperlinks: anchor.shape.hyperlinks,
+            };
+            model.media.push(shape);
           }
         });
       }


### PR DESCRIPTION
## Summary

This PR add basic support for shape. 

- Parsing id in existing file
- Methods in worsheet for list existing shapes and adding new one
- Save it in an xlsx file.

## Test plan

### Adding a new shape in file

```javascript
      ws.addShape(
          {
            shape: Shape.DOWN_ARROW,
            rotation: 45,
            fill : {color: '4499FF', opacity: 0.6},
            stroke: {color: '88AAFF', opacity: 1, weight: 2}
          },
          {
            tl: {col: 19, row: 31},
            ext: {width: 120, height: 50}
          }
        )
```

will result to : 

![arrow_down](https://user-images.githubusercontent.com/4188774/173587684-a2cbaf6a-828d-47ba-9885-a8d77eab7a67.png)

There is a list of tested shapes : 

```javascript
Shape.LINE = 'line';
Shape.RECTANGLE = 'rect';
Shape.ROUND_RECTANGLE = 'roundRect';
Shape.ELLIPSE = 'ellipse';
Shape.TRIANGLE = 'triangle';
Shape.RIGHT_ARROW = 'rightArrow';
Shape.DOWN_ARROW = 'downArrow';
Shape.LEFT_BRACE = 'leftBrace';
Shape.RIGHT_BRACE = 'rightBrace';
```