### PR TITLE
Fix Unable to specify a note in a cell within a table

### DIFF
--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -338,10 +338,6 @@ class WorkSheetXform extends BaseXform {
     this.map.headerFooter.render(xmlStream, model.headerFooter);
     this.map.rowBreaks.render(xmlStream, model.rowBreaks);
     this.map.drawing.render(xmlStream, model.drawing); // Note: must be after rowBreaks
-    this.map.picture.render(xmlStream, model.background); // Note: must be after drawing
-    this.map.tableParts.render(xmlStream, model.tables);
-
-    this.map.extLst.render(xmlStream, model);
 
     if (model.rels) {
       // add a <legacyDrawing /> node for each comment
@@ -351,6 +347,11 @@ class WorkSheetXform extends BaseXform {
         }
       });
     }
+
+    this.map.picture.render(xmlStream, model.background); // Note: must be after legacyDrawing
+    this.map.tableParts.render(xmlStream, model.tables); // Note: must be after picture
+
+    this.map.extLst.render(xmlStream, model); // Note: must be after tableParts
 
     xmlStream.closeNode();
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes #1369 

Moved legacyDrawing to be directly after drawing to match the order specified in https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.worksheet?view=openxml-2.8.1

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Make spreadsheet with a note in a cell within a table. Note that the spreadsheet is valid and properly opens with table and note in tact.

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
