### PR TITLE
fix: fix opening a worksheet with conditional formatting can cause bo…

### DIFF
--- a/lib/xlsx/xform/simple/boolean-xform.js
+++ b/lib/xlsx/xform/simple/boolean-xform.js
@@ -17,7 +17,11 @@ class BooleanXform extends BaseXform {
 
   parseOpen(node) {
     if (node.name === this.tag) {
-      this.model = true;
+      if (this.attr) {
+        this.model = BaseXform.toBoolValue(node.attributes[this.attr], true);
+      } else {
+        this.model = true;
+      }
     }
   }
 

--- a/spec/unit/xlsx/xform/simple/boolean-xform.spec.js
+++ b/spec/unit/xlsx/xform/simple/boolean-xform.spec.js
@@ -16,13 +16,22 @@ const expectations = [
     tests: ['render', 'renderIn', 'parse'],
   },
   {
-    title: 'false',
+    title: 'zero',
     create() {
       return new BooleanXform({tag: 'boolean', attr: 'val'});
     },
     preparedModel: false,
-    xml: '',
-    tests: ['render', 'renderIn'],
+    xml: '<boolean val="0"/>',
+    tests: ['render', 'renderIn', 'parse'],
+  },
+  {
+    title: 'one',
+    create() {
+      return new BooleanXform({tag: 'boolean', attr: 'val'});
+    },
+    preparedModel: true,
+    xml: '<boolean val="1"/>',
+    tests: ['render', 'renderIn', 'parse'],
   },
   {
     title: 'undefined',


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
When opening a workbook with conditional formatting rules and saving it back font style applied by when the conditional formatting rule is true can change. 

To reproduce the issue create workbook using Excel (latest version) with a conditional formatting rule that enables all font styles (italic, bold, strikethrough, etc). The condition of the rule is not relevant just make sure it applies to some rows in the sheet. Save the workbook, close it and reopen it in Excel. Now disable some of the font styles that are applied through the conditional formatting rule. Save the workbook and close it.

Now open the workbook using exceljs and save it without making any changes.

Expected behavior should be that the conditional formatting is exactly the same, observed behavior is that the cells to which conditional formatting is applied will have **all** font styles (italic, bold, strikethrough, etc) applied.

After analysis I found that the dfxs tag in styles.xml containing conditional styles was not getting parsed properly. Each font style is parsed as Boolean tag. When a font should be **bold** the `b` tag is present with no value or attributes: `<b/>`. When the bold is unchecked a `val` attribute is added and set to 0 making the tag look as follows: `<b val="0"/>`.

Looking at the font xform parser the configuration on first inspection looks correct, i.e:
```js
this.map = {
      b: {prop: 'bold', xform: new BooleanXform({tag: 'b', attr: 'val'})},
      i: {prop: 'italic', xform: new BooleanXform({tag: 'i', attr: 'val'})}
      ...
```

Looking a bit deeper in the `BooleanXform` class the `attr` property is being set but completely ignored during the actual parsing of the tag and always returns true. And that is correct when the value is actually true but incorrect when there is an `val` attribute on the tag. In which case `BooleanXform` should honor the value in `val` instead of just checking if the 

```js
class BooleanXform extends BaseXform {
  constructor(options) {
    super();

    this.tag = options.tag;
    this.attr = options.attr;
  }
  
  ...

  parseOpen(node) {
    if (node.name === this.tag) {
      this.model = true;
    }
  }
```

This also fixes issue #1732

## Test plan
We use exceljs to generate a workbook from a database using an excel file as template that defines which columns to export. The template excel file as conditional formattings that makes certain rows as italic. The formatting is copied from the template sheet to the new sheet. The proposed fix has been tested and is confirmed to work for our application.

The spec file that tests the Boolean parser is also updated to test `val='0'` is parsed as false.

The `BooleanXform`-class which is changed in the PR is only used in `FontXform` therefore I expect this change will not have any side effects. Apart from that these changes are backward compatible and only when there is an attribute will the attribute value be honored instead of just checking if the tag exists.
