### PR TITLE
Fixed issue 1351 - "worksheet.properties.outlineProperties does not exist"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1416,6 +1416,13 @@ export interface WorksheetProperties {
 	 */
 	dyDescent: number;
 	showGridLines: boolean;
+	/**
+	 * The worksheet outline properties (default: summaryBelow: true, summaryRight: true)
+	 */
+	outlineProperties: {
+		summaryBelow: boolean,
+		summaryRight: boolean
+	}
 }
 
 export interface AddWorksheetOptions {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -57,6 +57,10 @@ class Worksheet {
         dyDescent: 55,
         outlineLevelCol: 0,
         outlineLevelRow: 0,
+        outlineProperties: {
+          summaryBelow: true,
+          summaryRight: true,
+        }
       },
       options.properties
     );

--- a/lib/stream/xlsx/worksheet-writer.js
+++ b/lib/stream/xlsx/worksheet-writer.js
@@ -116,6 +116,10 @@ class WorksheetWriter {
         dyDescent: 55,
         outlineLevelCol: 0,
         outlineLevelRow: 0,
+        outlineProperties: {
+          summaryBelow: true,
+          summaryRight: true,
+        }
       },
       options.properties
     );
@@ -549,6 +553,7 @@ class WorksheetWriter {
           dyDescent: properties.dyDescent,
           outlineLevelCol: properties.outlineLevelCol,
           outlineLevelRow: properties.outlineLevelRow,
+          outlineProperties: properties.outlineProperties,
         }
       : undefined;
     if (properties.defaultColWidth) {


### PR DESCRIPTION
## Summary

I was using exceljs and wanted to group rows using outline level. I noticed that the elements were grouped with a summary below but I wanted it to be summary above. In the readME it states that I could use worksheet.properties.outlineProperties to set summaryBelow to false but whenever I tried to do this I received an error that outlineProperties did not exist on type worksheet.properties. After doing some research I noticed that there was a bug reported (issue 1351) with the same problem. My pull request addes the outlineProperties to worksheet properties so that summary below and summary right can be set.