### PR TITLE
Add duplicate multiple rows feature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1239,7 +1239,12 @@ export interface Worksheet {
 	/**
 	 * Duplicate rows and insert new rows
 	 */
-	duplicateRow(rowNum: number, count: number, insert: boolean): void;
+	duplicateRows({
+		initialRow: number,
+		length = 1,
+		firstRowToPaste = 1,
+		copiesAmount = 1,
+	}): void;
 
 	/**
 	 * Get or create row by 1-based index

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -443,7 +443,7 @@ class Worksheet {
     const inserts = rSrc.map((row) => row.values);
 
     //Loops through the copies amount requested
-    for (i = 0; i <= copiesAmount; i++){
+    for (let i = 0; i <= copiesAmount; i++){
         this.spliceRows(firstRowToPaste + (i * length + 1), 1, ...inserts); //Inserts the row with new values
 
         // Copy the original style to the pasted copy

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -1,15 +1,15 @@
-const _ = require('../utils/under-dash');
+const _ = require("../utils/under-dash");
 
-const colCache = require('../utils/col-cache');
-const Range = require('./range');
-const Row = require('./row');
-const Column = require('./column');
-const Enums = require('./enums');
-const Image = require('./image');
-const Table = require('./table');
-const DataValidations = require('./data-validations');
-const Encryptor = require('../utils/encryptor');
-const {copyStyle} = require('../utils/copy-style');
+const colCache = require("../utils/col-cache");
+const Range = require("./range");
+const Row = require("./row");
+const Column = require("./column");
+const Enums = require("./enums");
+const Image = require("./image");
+const Table = require("./table");
+const DataValidations = require("./data-validations");
+const Encryptor = require("../utils/encryptor");
+const { copyStyle } = require("../utils/copy-style");
 
 // Worksheet requirements
 //  Operate as sheet inside workbook or standalone
@@ -29,7 +29,7 @@ class Worksheet {
     this.name = options.name || `Sheet${this.id}`;
 
     // add a state
-    this.state = options.state || 'visible';
+    this.state = options.state || "visible";
 
     // rows allows access organised by row. Sparse array of arrays indexed by row-1, col
     // Note: _rows is zero based. Must subtract 1 to go from cell.row to index
@@ -65,8 +65,15 @@ class Worksheet {
     this.pageSetup = Object.assign(
       {},
       {
-        margins: {left: 0.7, right: 0.7, top: 0.75, bottom: 0.75, header: 0.3, footer: 0.3},
-        orientation: 'portrait',
+        margins: {
+          left: 0.7,
+          right: 0.7,
+          top: 0.75,
+          bottom: 0.75,
+          header: 0.3,
+          footer: 0.3,
+        },
+        orientation: "portrait",
         horizontalDpi: 4294967295,
         verticalDpi: 4294967295,
         fitToPage: !!(
@@ -74,11 +81,11 @@ class Worksheet {
           (options.pageSetup.fitToWidth || options.pageSetup.fitToHeight) &&
           !options.pageSetup.scale
         ),
-        pageOrder: 'downThenOver',
+        pageOrder: "downThenOver",
         blackAndWhite: false,
         draft: false,
-        cellComments: 'None',
-        errors: 'displayed',
+        cellComments: "None",
+        errors: "displayed",
         scale: 100,
         fitToWidth: 1,
         fitToHeight: 1,
@@ -140,7 +147,7 @@ class Worksheet {
   // Get the bounding range of the cells in this worksheet
   get dimensions() {
     const dimensions = new Range();
-    this._rows.forEach(row => {
+    this._rows.forEach((row) => {
       if (row) {
         const rowDims = row.dimensions;
         if (rowDims) {
@@ -164,14 +171,15 @@ class Worksheet {
   set columns(value) {
     // calculate max header row count
     this._headerRowCount = value.reduce((pv, cv) => {
-      const headerCount = (cv.header && 1) || (cv.headers && cv.headers.length) || 0;
+      const headerCount =
+        (cv.header && 1) || (cv.headers && cv.headers.length) || 0;
       return Math.max(pv, headerCount);
     }, 0);
 
     // construct Column objects
     let count = 1;
     const columns = (this._columns = []);
-    value.forEach(defn => {
+    value.forEach((defn) => {
       const column = new Column(this, count++, false);
       columns.push(column);
       column.defn = defn;
@@ -196,7 +204,7 @@ class Worksheet {
 
   // get a single column by col number. If it doesn't exist, create it and any gaps before it
   getColumn(c) {
-    if (typeof c === 'string') {
+    if (typeof c === "string") {
       // if it matches a key'd column, return that
       const col = this._keys[c];
       if (col) return col;
@@ -224,7 +232,7 @@ class Worksheet {
       for (let i = 0; i < nRows; i++) {
         const rowArguments = [start, count];
         // eslint-disable-next-line no-loop-func
-        inserts.forEach(insert => {
+        inserts.forEach((insert) => {
           rowArguments.push(insert[i] || null);
         });
         const row = this.getRow(i + 1);
@@ -233,7 +241,7 @@ class Worksheet {
       }
     } else {
       // nothing to insert, so just splice all rows
-      this._rows.forEach(r => {
+      this._rows.forEach((r) => {
         if (r) {
           r.splice(start, count);
         }
@@ -258,7 +266,12 @@ class Worksheet {
     }
 
     // account for defined names
-    this.workbook.definedNames.spliceColumns(this.name, start, count, inserts.length);
+    this.workbook.definedNames.spliceColumns(
+      this.name,
+      start,
+      count,
+      inserts.length
+    );
   }
 
   get lastColumn() {
@@ -267,7 +280,7 @@ class Worksheet {
 
   get columnCount() {
     let maxCount = 0;
-    this.eachRow(row => {
+    this.eachRow((row) => {
       maxCount = Math.max(maxCount, row.cellCount);
     });
     return maxCount;
@@ -277,8 +290,8 @@ class Worksheet {
     // performance nightmare - for each row, counts all the columns used
     const counts = [];
     let count = 0;
-    this.eachRow(row => {
-      row.eachCell(({col}) => {
+    this.eachRow((row) => {
+      row.eachCell(({ col }) => {
         if (!counts[col]) {
           counts[col] = true;
           count++;
@@ -358,37 +371,40 @@ class Worksheet {
     return rows;
   }
 
-  addRow(value, style = 'n') {
+  addRow(value, style = "n") {
     const rowNo = this._nextRow;
     const row = this.getRow(rowNo);
     row.values = value;
-    this._setStyleOption(rowNo, style[0] === 'i' ? style : 'n');
+    this._setStyleOption(rowNo, style[0] === "i" ? style : "n");
     return row;
   }
 
-  addRows(value, style = 'n') {
+  addRows(value, style = "n") {
     const rows = [];
-    value.forEach(row => {
+    value.forEach((row) => {
       rows.push(this.addRow(row, style));
     });
     return rows;
   }
 
-  insertRow(pos, value, style = 'n') {
+  insertRow(pos, value, style = "n") {
     this.spliceRows(pos, 0, value);
     this._setStyleOption(pos, style);
     return this.getRow(pos);
   }
 
-  insertRows(pos, values, style = 'n') {
+  insertRows(pos, values, style = "n") {
     this.spliceRows(pos, 0, ...values);
-    if (style !== 'n') {
+    if (style !== "n") {
       // copy over the styles
       for (let i = 0; i < values.length; i++) {
-        if (style[0] === 'o' && this.findRow(values.length + pos + i) !== undefined) {
-          this._copyStyle(values.length + pos + i, pos + i, style[1] === '+');
-        } else if (style[0] === 'i' && this.findRow(pos - 1) !== undefined) {
-          this._copyStyle(pos - 1, pos + i, style[1] === '+');
+        if (
+          style[0] === "o" &&
+          this.findRow(values.length + pos + i) !== undefined
+        ) {
+          this._copyStyle(values.length + pos + i, pos + i, style[1] === "+");
+        } else if (style[0] === "i" && this.findRow(pos - 1) !== undefined) {
+          this._copyStyle(pos - 1, pos + i, style[1] === "+");
         }
       }
     }
@@ -396,11 +412,11 @@ class Worksheet {
   }
 
   // set row at position to same style as of either pervious row (option 'i') or next row (option 'o')
-  _setStyleOption(pos, style = 'n') {
-    if (style[0] === 'o' && this.findRow(pos + 1) !== undefined) {
-      this._copyStyle(pos + 1, pos, style[1] === '+');
-    } else if (style[0] === 'i' && this.findRow(pos - 1) !== undefined) {
-      this._copyStyle(pos - 1, pos, style[1] === '+');
+  _setStyleOption(pos, style = "n") {
+    if (style[0] === "o" && this.findRow(pos + 1) !== undefined) {
+      this._copyStyle(pos + 1, pos, style[1] === "+");
+    } else if (style[0] === "i" && this.findRow(pos - 1) !== undefined) {
+      this._copyStyle(pos - 1, pos, style[1] === "+");
     }
   }
 
@@ -409,30 +425,38 @@ class Worksheet {
     const rDst = this.getRow(dest);
     rDst.style = copyStyle(rSrc.style);
     // eslint-disable-next-line no-loop-func
-    rSrc.eachCell({includeEmpty: styleEmpty}, (cell, colNumber) => {
+    rSrc.eachCell({ includeEmpty: styleEmpty }, (cell, colNumber) => {
       rDst.getCell(colNumber).style = copyStyle(cell.style);
     });
     rDst.height = rSrc.height;
   }
 
-  duplicateRow(rowNum, count, insert = false) {
-    // create count duplicates of rowNum
-    // either inserting new or overwriting existing rows
+  duplicateRows({
+    initialRow,
+    length = 1,
+    firstRowToPaste = initialRow,
+    copiesAmount = 1,
+  }) {
+    //Get requested rows
+    const rSrc = this.getRows(initialRow, length);
+    //Get their values for later pasting
+    const inserts = rSrc.map((row) => row.values);
 
-    const rSrc = this._rows[rowNum - 1];
-    const inserts = new Array(count).fill(rSrc.values);
-    this.spliceRows(rowNum + 1, insert ? 0 : count, ...inserts);
+    //Loops through the copies amount requested
+    for (i = 0; i <= copiesAmount; i++){
+        this.spliceRows(firstRowToPaste + (i * length + 1), 1, ...inserts); //Inserts the row with new values
 
-    // now copy styles...
-    for (let i = 0; i < count; i++) {
-      const rDst = this._rows[rowNum + i];
-      rDst.style = rSrc.style;
-      rDst.height = rSrc.height;
-      // eslint-disable-next-line no-loop-func
-      rSrc.eachCell({includeEmpty: true}, (cell, colNumber) => {
-        rDst.getCell(colNumber).style = cell.style;
-      });
-    }
+        // Copy the original style to the pasted copy
+        rSrc.forEach((row, index) => {
+          this
+            .getRow(firstRowToPaste + (i * length + 1) + index)
+            .eachCell({ includeEmpty: true }, (cell, col) => {
+              cell.style = row.findCell(col)?.style;
+              cell.height = row.findCell(col)?.height;
+              cell.width = row.findCell(col)?.width;
+            });
+        });
+      };
   }
 
   spliceRows(start, count, ...inserts) {
@@ -453,7 +477,7 @@ class Worksheet {
           rDst.style = rSrc.style;
           rDst.height = rSrc.height;
           // eslint-disable-next-line no-loop-func
-          rSrc.eachCell({includeEmpty: true}, (cell, colNumber) => {
+          rSrc.eachCell({ includeEmpty: true }, (cell, colNumber) => {
             rDst.getCell(colNumber).style = cell.style;
           });
           this._rows[i - 1] = undefined;
@@ -471,14 +495,18 @@ class Worksheet {
           rDst.style = rSrc.style;
           rDst.height = rSrc.height;
           // eslint-disable-next-line no-loop-func
-          rSrc.eachCell({includeEmpty: true}, (cell, colNumber) => {
+          rSrc.eachCell({ includeEmpty: true }, (cell, colNumber) => {
             rDst.getCell(colNumber).style = cell.style;
 
             // remerge cells accounting for insert offset
-            if (cell._value.constructor.name === 'MergeValue') {
-              const cellToBeMerged = this.getRow(cell._row._number + nInserts).getCell(colNumber);
+            if (cell._value.constructor.name === "MergeValue") {
+              const cellToBeMerged = this.getRow(
+                cell._row._number + nInserts
+              ).getCell(colNumber);
               const prevMaster = cell._value._master;
-              const newMaster = this.getRow(prevMaster._row._number + nInserts).getCell(prevMaster._column._number);
+              const newMaster = this.getRow(
+                prevMaster._row._number + nInserts
+              ).getCell(prevMaster._column._number);
               cellToBeMerged.merge(newMaster);
             }
           });
@@ -511,7 +539,7 @@ class Worksheet {
         iteratee(this.getRow(i), i);
       }
     } else {
-      this._rows.forEach(row => {
+      this._rows.forEach((row) => {
         if (row && row.hasValues) {
           iteratee(row, row.number);
         }
@@ -522,7 +550,7 @@ class Worksheet {
   // return all rows as sparse array
   getSheetValues() {
     const rows = [];
-    this._rows.forEach(row => {
+    this._rows.forEach((row) => {
       if (row) {
         rows[row.number] = row.values;
       }
@@ -563,9 +591,9 @@ class Worksheet {
 
   _mergeCellsInternal(dimensions, ignoreStyle) {
     // check cells aren't already merged
-    _.each(this._merges, merge => {
+    _.each(this._merges, (merge) => {
       if (merge.intersects(dimensions)) {
-        throw new Error('Cannot merge already merged cells');
+        throw new Error("Cannot merge already merged cells");
       }
     });
 
@@ -627,17 +655,17 @@ class Worksheet {
 
   // ===========================================================================
   // Shared/Array Formula
-  fillFormula(range, formula, results, shareType = 'shared') {
+  fillFormula(range, formula, results, shareType = "shared") {
     // Define formula for top-left cell and share to rest
     const decoded = colCache.decode(range);
-    const {top, left, bottom, right} = decoded;
+    const { top, left, bottom, right } = decoded;
     const width = right - left + 1;
     const masterAddress = colCache.encodeAddress(top, left);
-    const isShared = shareType === 'shared';
+    const isShared = shareType === "shared";
 
     // work out result accessor
     let getResult;
-    if (typeof results === 'function') {
+    if (typeof results === "function") {
       getResult = results;
     } else if (Array.isArray(results)) {
       if (Array.isArray(results[0])) {
@@ -676,7 +704,7 @@ class Worksheet {
   // Images
   addImage(imageId, range) {
     const model = {
-      type: 'image',
+      type: "image",
       imageId,
       range,
     };
@@ -684,19 +712,19 @@ class Worksheet {
   }
 
   getImages() {
-    return this._media.filter(m => m.type === 'image');
+    return this._media.filter((m) => m.type === "image");
   }
 
   addBackgroundImage(imageId) {
     const model = {
-      type: 'background',
+      type: "background",
       imageId,
     };
     this._media.push(new Image(this, model));
   }
 
   getBackgroundImageId() {
-    const image = this._media.find(m => m.type === 'background');
+    const image = this._media.find((m) => m.type === "background");
     return image && image.imageId;
   }
 
@@ -705,28 +733,32 @@ class Worksheet {
   protect(password, options) {
     // TODO: make this function truly async
     // perhaps marshal to worker thread or something
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       this.sheetProtection = {
         sheet: true,
       };
-      if (options && 'spinCount' in options) {
+      if (options && "spinCount" in options) {
         // force spinCount to be integer >= 0
-        options.spinCount = Number.isFinite(options.spinCount) ? Math.round(Math.max(0, options.spinCount)) : 100000;
+        options.spinCount = Number.isFinite(options.spinCount)
+          ? Math.round(Math.max(0, options.spinCount))
+          : 100000;
       }
       if (password) {
-        this.sheetProtection.algorithmName = 'SHA-512';
-        this.sheetProtection.saltValue = Encryptor.randomBytes(16).toString('base64');
-        this.sheetProtection.spinCount = options && 'spinCount' in options ? options.spinCount : 100000; // allow user specified spinCount
+        this.sheetProtection.algorithmName = "SHA-512";
+        this.sheetProtection.saltValue =
+          Encryptor.randomBytes(16).toString("base64");
+        this.sheetProtection.spinCount =
+          options && "spinCount" in options ? options.spinCount : 100000; // allow user specified spinCount
         this.sheetProtection.hashValue = Encryptor.convertPasswordToHash(
           password,
-          'SHA512',
+          "SHA512",
           this.sheetProtection.saltValue,
           this.sheetProtection.spinCount
         );
       }
       if (options) {
         this.sheetProtection = Object.assign(this.sheetProtection, options);
-        if (!password && 'spinCount' in options) {
+        if (!password && "spinCount" in options) {
           delete this.sheetProtection.spinCount;
         }
       }
@@ -765,7 +797,7 @@ class Worksheet {
   }
 
   removeConditionalFormatting(filter) {
-    if (typeof filter === 'number') {
+    if (typeof filter === "number") {
       this.conditionalFormattings.splice(filter, 1);
     } else if (filter instanceof Function) {
       this.conditionalFormattings = this.conditionalFormattings.filter(filter);
@@ -778,13 +810,17 @@ class Worksheet {
   // Deprecated
   get tabColor() {
     // eslint-disable-next-line no-console
-    console.trace('worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor');
+    console.trace(
+      "worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor"
+    );
     return this.properties.tabColor;
   }
 
   set tabColor(value) {
     // eslint-disable-next-line no-console
-    console.trace('worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor');
+    console.trace(
+      "worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor"
+    );
     this.properties.tabColor = value;
   }
 
@@ -803,9 +839,9 @@ class Worksheet {
       rowBreaks: this.rowBreaks,
       views: this.views,
       autoFilter: this.autoFilter,
-      media: this._media.map(medium => medium.model),
+      media: this._media.map((medium) => medium.model),
       sheetProtection: this.sheetProtection,
-      tables: Object.values(this.tables).map(table => table.model),
+      tables: Object.values(this.tables).map((table) => table.model),
       conditionalFormattings: this.conditionalFormattings,
     };
 
@@ -817,10 +853,15 @@ class Worksheet {
     // Rows
     const rows = (model.rows = []);
     const dimensions = (model.dimensions = new Range());
-    this._rows.forEach(row => {
+    this._rows.forEach((row) => {
       const rowModel = row && row.model;
       if (rowModel) {
-        dimensions.expand(rowModel.number, rowModel.min, rowModel.number, rowModel.max);
+        dimensions.expand(
+          rowModel.number,
+          rowModel.min,
+          rowModel.number,
+          rowModel.max
+        );
         rows.push(rowModel);
       }
     });
@@ -828,7 +869,7 @@ class Worksheet {
     // ==========================================================
     // Merges
     model.merges = [];
-    _.each(this._merges, merge => {
+    _.each(this._merges, (merge) => {
       model.merges.push(merge.range);
     });
 
@@ -837,7 +878,7 @@ class Worksheet {
 
   _parseRows(model) {
     this._rows = [];
-    model.rows.forEach(rowModel => {
+    model.rows.forEach((rowModel) => {
       const row = new Row(this, rowModel.number);
       this._rows[row.number - 1] = row;
       row.model = rowModel;
@@ -845,7 +886,7 @@ class Worksheet {
   }
 
   _parseMergeCells(model) {
-    _.each(model.mergeCells, merge => {
+    _.each(model.mergeCells, (merge) => {
       // Do not merge styles when importing an Excel file
       // since each cell may have different styles intentionally.
       this.mergeCellsWithoutStyle(merge);
@@ -864,7 +905,7 @@ class Worksheet {
     this.headerFooter = value.headerFooter;
     this.views = value.views;
     this.autoFilter = value.autoFilter;
-    this._media = value.media.map(medium => new Image(this, medium));
+    this._media = value.media.map((medium) => new Image(this, medium));
     this.sheetProtection = value.sheetProtection;
     this.tables = value.tables.reduce((tables, table) => {
       const t = new Table();

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -449,7 +449,7 @@ class Worksheet {
         // Copy the original style to the pasted copy
         rSrc.forEach((row, index) => {
           this
-            .getRow(firstRowToPaste + (i * length + 1) + index)
+            ._rows[firstRowToPaste + (i * length + 1) + index]
             .eachCell({ includeEmpty: true }, (cell, col) => {
               cell.style = row.findCell(col)?.style;
               cell.height = row.findCell(col)?.height;

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -449,7 +449,7 @@ class Worksheet {
         // Copy the original style to the pasted copy
         rSrc.forEach((row, index) => {
           this
-            ._rows[firstRowToPaste + (i * length + 1) + index]
+            .getRow(firstRowToPaste + (i * length + 1) + index)
             .eachCell({ includeEmpty: true }, (cell, col) => {
               cell.style = row.findCell(col)?.style;
               cell.height = row.findCell(col)?.height;

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -443,7 +443,7 @@ class Worksheet {
     const inserts = rSrc.map((row) => row.values);
 
     //Loops through the copies amount requested
-    for (let i = 0; i <= copiesAmount; i++){
+    for (let i = 0; i < copiesAmount; i++){
         this.spliceRows(firstRowToPaste + (i * length + 1), 1, ...inserts); //Inserts the row with new values
 
         // Copy the original style to the pasted copy


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The current duplicateRow functions does not work with multiple rows as it's supposed, it seems too functionally specific and allows little flexibility towards where to paste the duplicates.

This new implementation can duplicate single rows just like before, but it also allows to duplicate multiple rows as a group, and the new/generic parameters gives it more usage flexibility.

The user will be able to control which rows to duplicate, how much duplicates will be generated and where to paste them, the copies will be pasted in sequence, but the function could also be used multiple times pasting duplicates in different locations.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Initial Template:
![image](https://user-images.githubusercontent.com/74212278/185643916-a79e99be-489f-402a-b5a1-4acc256bb690.png)

Usage example:
`sheet.duplicateRows(
            {
                initialRow: 14,
                length: 4,
                firstRowToPaste: 17,
                copiesAmount: 2,
            },
        );`

Result:

![image](https://user-images.githubusercontent.com/74212278/185644281-cba546ff-b0f6-4fad-866d-922b4e66fcca.png)


## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
