### PR TITLE
add characters cannot be used for worksheet name

### DIFF
--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -60,9 +60,9 @@ class Workbook {
 
     // Illegal character in worksheet name: asterisk (*), question mark (?),
     // colon (:), forward slash (/ \), or bracket ([])
-    if (/[*?:/\\[\]]/.test(name)) {
+    if (/[*?:/\\[\]＊？：￥／＼［］]/.test(name)) {
       throw new Error(
-        `Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ]`
+        `Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ] ＊ ？ ： ￥ ／ ＼ ［ ］`
       );
     }
 

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -702,11 +702,11 @@ describe('Worksheet', () => {
       it('throws an error', () => {
         const workbook = new ExcelJS.Workbook();
 
-        const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
+        const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']', '＊', '？', '：', '￥', '／', '＼', '［', '］'];
 
         for (const invalidCharacter of invalidCharacters) {
           expect(() => workbook.addWorksheet(invalidCharacter)).to.throw(
-            `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
+            `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ] ＊ ？ ： ￥ ／ ＼ ［ ］`
           );
         }
       });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

As for worksheet name, it raises error if worksheet name contains followings characters now

```js
'*', '?', ':', '/', '\\', '[', ']'
```

I expect this implementation prevents worksheet from breaking
But, if these characters are full-width characters, the worksheet is broken


https://user-images.githubusercontent.com/3395349/187575650-5528a378-755e-46ae-a3fa-d12925aee154.mov

So, I fixed the issue

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Code example is below

```js
import ExcelJS from 'exceljs';

const workbook = new ExcelJS.Workbook()
workbook.addWorksheet('？')
```

If error raises, the test is success

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
