### PR TITLE
Fixed error in FastCsvParserOptionsArgs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1494,7 +1494,7 @@ type HeaderTransformFunction = (headers: HeaderArray) => HeaderArray;
 export interface FastCsvParserOptionsArgs {
 	objectMode: boolean;
 	delimiter: string;
-	quote: string | null;
+	quote: string | null | boolean;
 	escape: string;
 	headers: boolean | HeaderTransformFunction | HeaderArray;
 	renameHeaders: boolean;


### PR DESCRIPTION
following the instructions on the ReadMe.md using typescript returns typeError when trying to instatiate options to read csv. I fixed the issue.
![image](https://user-images.githubusercontent.com/44606697/187611961-f310a417-40f8-4013-80a2-139bc6f0e8b6.png)
