### PR TITLE
fixed spelling error in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ workbook.worksheets[0]; //the first one;
 ```
 
 It's important to know that `workbook.getWorksheet(1) != Workbook.worksheets[0]` and `workbook.getWorksheet(1) != Workbook.worksheets[1]`,
-becouse `workbook.worksheets[0].id` may have any value.
+because `workbook.worksheets[0].id` may have any value.
 
 ## Worksheet State[⬆](#contents)<!-- Link generated with jump2header -->
 


### PR DESCRIPTION
spelling issue: **becouse** changed to **because**

