### PR TITLE
chore: upgrade jszip to ^3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "archiver": "^5.0.0",
     "dayjs": "^1.8.34",
     "fast-csv": "^4.3.1",
-    "jszip": "^3.7.1",
+    "jszip": "^3.10.1",
     "readable-stream": "^3.6.0",
     "saxes": "^5.0.1",
     "tmp": "^0.2.0",


### PR DESCRIPTION
## Summary

This patches the zipslip vulnerability in <= 3.7.1 and patched in >= 3.8.0.

No issues found with our usage in https://stuk.github.io/jszip/CHANGES.html, most notable change was 3.9.0 API change, but we are unaffected, due to not using constructor arguments.

## Test plan

Run npm install and npm test after upgrading. All tests passed.
