### PR TITLE
Exclude replacement character between chunks

### DIFF
--- a/lib/utils/iterate-stream.js
+++ b/lib/utils/iterate-stream.js
@@ -1,5 +1,7 @@
+const {bufferToString} = require('./browser-buffer-decode');
+
 module.exports = async function* iterateStream(stream) {
-  const contents = [];
+  let contents = [];
   stream.on('data', data => contents.push(data));
 
   let resolveStreamEndedPromise;
@@ -23,8 +25,21 @@ module.exports = async function* iterateStream(stream) {
       // eslint-disable-next-line no-await-in-loop
       await Promise.race([once(stream, 'data'), streamEndedPromise]);
     } else {
+      const isBuffer = Buffer.isBuffer(contents[0]);
+      while (isBuffer) {
+        const string = bufferToString(Buffer.concat(contents));
+        if (string[string.length - 1] !== '�' || ended) break;
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.race([once(stream, 'data'), streamEndedPromise]);
+      }
       stream.pause();
-      const data = contents.shift();
+      let data;
+      if (isBuffer) {
+        data = Buffer.concat(contents);
+        contents = [];
+      } else {
+        data = contents.shift();
+      }
       yield data;
     }
     if (error) throw error;


### PR DESCRIPTION
## Summary

Chunks of stream can break a character, which causes a replacement character to appear on start and end of two chunks

