### PR TITLE
fix: fix the loss of column attributes due to incorrect column order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ _SpecRunner.html
 
 # Ignore xlsx files generated during testing
 *.xlsx
+enpm-lock.yaml

--- a/lib/doc/column.js
+++ b/lib/doc/column.js
@@ -297,6 +297,13 @@ class Column {
     const columns = [];
     let count = 1;
     let index = 0;
+    /**
+     * sort cols by min
+     * If it is not sorted, the subsequent column configuration will be overwritten
+     * */
+    cols = cols.sort(function(pre, next)  {
+      return pre.min - next.min;
+    });
     while (index < cols.length) {
       const col = cols[index++];
       while (count < col.min) {


### PR DESCRIPTION
When I try to read the excel file and display it on the page, I found that the hidden columns of some files were not parsed correctly.

## Summary

I found that if the order of the column data parsed here is not positive, the subsequent attributes will be overwritten
![image](https://user-images.githubusercontent.com/45730337/222389920-684a7904-9b9f-483e-9d97-3d1c1aa3cc36.png)

![image](https://user-images.githubusercontent.com/45730337/222389824-6f1c06b6-876d-4178-98e6-b8603bfd3da6.png)


## Test plan
Before modification
![image](https://user-images.githubusercontent.com/45730337/222390826-8515397d-a498-4bca-91b2-62cac42cc0ff.png)
After modification
![image](https://user-images.githubusercontent.com/45730337/222391194-bb1fe799-0b29-4396-9b10-0fa44767410f.png)

<!-- List with permalink into source code to prove that changes are true -->
