### PR TITLE
Fix types for getWorksheet()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1743,7 +1743,7 @@ export class Workbook {
 	/**
 	 * fetch sheet by name or id
 	 */
-	getWorksheet(indexOrName: number | string): Worksheet;
+	getWorksheet(indexOrName: number | string): Worksheet | undefined;
 
 	/**
 	 * Iterate over all sheets.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fix types for getWorksheet(). It can return undefined

## Test plan

N/A

## Related to source code (for typings update)

[lib/doc/workbook.js#L143](https://github.com/exceljs/exceljs/blob/master/lib/doc/workbook.js#L143)
