### PR TITLE
ExcelJS/ExcelJS#2237 : Update CI Tests, Drop support for Node v8 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://github.com/actions/setup-node/issues/27
-        node-version: [8.17.0, 10.x, 12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: ExcelJS
+name: Tests
 
 on:
   push:
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/actions/setup-node/issues/27
-        node-version: [8.17.0, 10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [8.17.0, 10.x, 12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
FEAT https://github.com/exceljs/exceljs/issues/2237

In this PR:
* Added node versions 18 and 19 to the tests suite
* Drop node v8 tests
