### PR TITLE
fix: Fix xlsx.writeFile() not catching error when error occurs

### DIFF
--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -675,6 +675,8 @@ class XLSX {
 
       this.write(stream, options).then(() => {
         stream.end();
+      }).catch((err)=>{
+        reject(err);
       });
     });
   }

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -675,7 +675,7 @@ class XLSX {
 
       this.write(stream, options).then(() => {
         stream.end();
-      }).catch((err)=>{
+      }).catch(err=>{
         reject(err);
       });
     });

--- a/spec/integration/pr/test-pr-2244.spec.js
+++ b/spec/integration/pr/test-pr-2244.spec.js
@@ -1,0 +1,24 @@
+const ExcelJS = verquire('exceljs');
+
+describe('github 2244', () => {
+  it('pull request 2244', async () => {
+    async function test() {
+      const workbook = new ExcelJS.Workbook();
+      const worksheet = workbook.addWorksheet('sheet');
+      const imageId1 = workbook.addImage({
+        filename: 'path/to/image.jpg',
+        extension: 'jpeg',
+      });
+      worksheet.addImage(imageId1, 'B2:D6');
+      await workbook.xlsx.writeFile('test.xlsx');
+    }
+    let error;
+    try {
+      await test();
+    } catch (err) {
+      error = err;
+    }
+    expect(error).to.be.an('error');
+    //   expect(test).to.throw(Error);
+  });
+});

--- a/spec/integration/pr/test-pr-2244.spec.js
+++ b/spec/integration/pr/test-pr-2244.spec.js
@@ -1,12 +1,12 @@
 const ExcelJS = verquire('exceljs');
 
-describe('github 2244', () => {
-  it('pull request 2244', async () => {
+describe('pull request  2244', () => {
+  it('pull request 2244- Fix xlsx.writeFile() not catching error when error occurs', async () => {
     async function test() {
       const workbook = new ExcelJS.Workbook();
       const worksheet = workbook.addWorksheet('sheet');
       const imageId1 = workbook.addImage({
-        filename: 'path/to/image.jpg',
+        filename: 'path/to/image.jpg', // Non-existent file
         extension: 'jpeg',
       });
       worksheet.addImage(imageId1, 'B2:D6');
@@ -19,6 +19,5 @@ describe('github 2244', () => {
       error = err;
     }
     expect(error).to.be.an('error');
-    //   expect(test).to.throw(Error);
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
When `await workbook.xlsx.writeFile(filename).`
was reported, but the error was not caught by try catch, after modifying the source code, it can now be caught

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
```
try {
    const imageId2 = workbook.addImage({
        buffer: fs.readFileSync('path/to.image.png'),
        extension: 'png',
      });
    await workbook.xlsx.writeFile(filename);
} catch (error) {
    console.log(error)
}
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
