### PR TITLE
Improve worksheets' naming validation logic.

### DIFF
--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -53,30 +53,6 @@ class Workbook {
   addWorksheet(name, options) {
     const id = this.nextId;
 
-    if (name && name.length > 31) {
-      // eslint-disable-next-line no-console
-      console.warn(`Worksheet name ${name} exceeds 31 chars. This will be truncated`);
-    }
-
-    // Illegal character in worksheet name: asterisk (*), question mark (?),
-    // colon (:), forward slash (/ \), or bracket ([])
-    if (/[*?:/\\[\]＊？：￥／＼［］]/.test(name)) {
-      throw new Error(
-        `Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ] ＊ ？ ： ￥ ／ ＼ ［ ］`
-      );
-    }
-
-    if (/(^')|('$)/.test(name)) {
-      throw new Error(
-        `The first or last character of worksheet name cannot be a single quotation mark: ${name}`
-      );
-    }
-
-    name = (name || `sheet${id}`).substring(0, 31);
-    if (this._worksheets.find(ws => ws && ws.name.toLowerCase() === name.toLowerCase())) {
-      throw new Error(`Worksheet name already exists: ${name}`);
-    }
-
     // if options is a color, call it tabColor (and signal deprecated message)
     if (options) {
       if (typeof options === 'string') {
@@ -102,10 +78,7 @@ class Workbook {
       }
     }
 
-    const lastOrderNo = this._worksheets.reduce(
-      (acc, ws) => ((ws && ws.orderNo) > acc ? ws.orderNo : acc),
-      0
-    );
+    const lastOrderNo = this._worksheets.reduce((acc, ws) => ((ws && ws.orderNo) > acc ? ws.orderNo : acc), 0);
     const worksheetOptions = Object.assign({}, options, {
       id,
       name,
@@ -235,7 +208,6 @@ class Workbook {
         state,
         workbook: this,
       }));
-
       worksheet.model = worksheetModel;
     });
 

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -20,13 +20,14 @@ const {copyStyle} = require('../utils/copy-style');
 class Worksheet {
   constructor(options) {
     options = options || {};
+    this._workbook = options.workbook;
 
     // in a workbook, each sheet will have a number
     this.id = options.id;
     this.orderNo = options.orderNo;
 
     // and a name
-    this.name = options.name || `Sheet${this.id}`;
+    this.name = options.name || `sheet${this.id}`;
 
     // add a state
     this.state = options.state || 'visible';
@@ -46,8 +47,6 @@ class Worksheet {
 
     // record of all row and column pageBreaks
     this.rowBreaks = [];
-
-    this._workbook = options.workbook;
 
     // for tabColor, default row height, outline levels, etc
     this.properties = Object.assign(
@@ -126,6 +125,39 @@ class Worksheet {
     this.tables = {};
 
     this.conditionalFormattings = [];
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  set name(name) {
+    if (this._name === name) return;
+
+    name = (name || `sheet${this.id}`).substring(0, 31);
+
+    // Illegal character in worksheet name: asterisk (*), question mark (?),
+    // colon (:), forward slash (/ \), or bracket ([])
+    if (/[*?:/\\[\]＊？：￥／＼［］]/.test(name)) {
+      throw new Error(
+        `Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ] ＊ ？ ： ￥ ／ ＼ ［ ］`
+      );
+    }
+
+    if (/(^')|('$)/.test(name)) {
+      throw new Error(`The first or last character of worksheet name cannot be a single quotation mark: ${name}`);
+    }
+
+    if (name && name.length > 31) {
+      // eslint-disable-next-line no-console
+      console.warn(`Worksheet name ${name} exceeds 31 chars. This will be truncated`);
+    }
+
+    if (this._workbook._worksheets.find(ws => ws && ws.name.toLowerCase() === name.toLowerCase())) {
+      throw new Error(`Worksheet name already exists: ${name}`);
+    }
+
+    this._name = name;
   }
 
   get workbook() {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -136,6 +136,10 @@ class Worksheet {
 
     name = (name || `sheet${this.id}`).substring(0, 31);
 
+    if (name === 'History') {
+      throw new Error('The name "History" is protected. Please use a different name.');
+    }
+
     // Illegal character in worksheet name: asterisk (*), question mark (?),
     // colon (:), forward slash (/ \), or bracket ([])
     if (/[*?:/\\[\]]/.test(name)) {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -139,7 +139,7 @@ class Worksheet {
     if (this._name === name) return;
 
     if (typeof name !== 'string') {
-      throw new Error('The name has to be string.');
+      throw new Error('The name has to be a string.');
     }
 
     if (name === '') {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -27,7 +27,7 @@ class Worksheet {
     this.orderNo = options.orderNo;
 
     // and a name
-    this.name = options.name || `sheet${this.id}`;
+    this.name = options.name;
 
     // add a state
     this.state = options.state || 'visible';
@@ -132,9 +132,19 @@ class Worksheet {
   }
 
   set name(name) {
+    if (name === undefined) {
+      name = `sheet${this.id}`;
+    }
+
     if (this._name === name) return;
 
-    name = (name || `sheet${this.id}`).substring(0, 31);
+    if (typeof name !== 'string') {
+      throw new Error('The name has to be string.');
+    }
+
+    if (name === '') {
+      throw new Error('The name can\'t be empty.');
+    }
 
     if (name === 'History') {
       throw new Error('The name "History" is protected. Please use a different name.');
@@ -153,6 +163,7 @@ class Worksheet {
     if (name && name.length > 31) {
       // eslint-disable-next-line no-console
       console.warn(`Worksheet name ${name} exceeds 31 chars. This will be truncated`);
+      name = name.substring(0, 31);
     }
 
     if (this._workbook._worksheets.find(ws => ws && ws.name.toLowerCase() === name.toLowerCase())) {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -138,10 +138,8 @@ class Worksheet {
 
     // Illegal character in worksheet name: asterisk (*), question mark (?),
     // colon (:), forward slash (/ \), or bracket ([])
-    if (/[*?:/\\[\]＊？：￥／＼［］]/.test(name)) {
-      throw new Error(
-        `Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ] ＊ ？ ： ￥ ／ ＼ ［ ］`
-      );
+    if (/[*?:/\\[\]]/.test(name)) {
+      throw new Error(`Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ]`);
     }
 
     if (/(^')|('$)/.test(name)) {

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -689,6 +689,18 @@ describe('Worksheet', () => {
         });
       });
 
+      context('when worksheet name is `History`', () => {
+        it('thrown an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          expect(() => {
+            wb.addWorksheet('History');
+          }).to.throw(
+            'The name "History" is protected. Please use a different name.'
+          );
+        });
+      });
+
       context('when worksheet name is longer than 31', () => {
         it('keep first 31 characters', () => {
           const wb = new ExcelJS.Workbook();
@@ -762,6 +774,19 @@ describe('Worksheet', () => {
           ws = wb.addWorksheet();
           ws.name = 'ThisIsAWorksheetNameWith31Chars';
           expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
+        });
+      });
+
+      context('when worksheet name is `History`', () => {
+        it('thrown an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          expect(() => {
+            const ws = wb.addWorksheet();
+            ws.name = 'History';
+          }).to.throw(
+            'The name "History" is protected. Please use a different name.'
+          );
         });
       });
 

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -677,7 +677,6 @@ describe('Worksheet', () => {
 
       expect(ws.getRows(1, 0)).to.equal(undefined);
     });
-
     context('when worksheet name is less than or equal 31', () => {
       it('save the original name', () => {
         const wb = new ExcelJS.Workbook();
@@ -702,11 +701,11 @@ describe('Worksheet', () => {
       it('throws an error', () => {
         const workbook = new ExcelJS.Workbook();
 
-        const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']', '＊', '？', '：', '￥', '／', '＼', '［', '］'];
+        const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
 
         for (const invalidCharacter of invalidCharacters) {
           expect(() => workbook.addWorksheet(invalidCharacter)).to.throw(
-            `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ] ＊ ？ ： ￥ ／ ＼ ［ ］`
+            `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
           );
         }
       });

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -701,6 +701,23 @@ describe('Worksheet', () => {
         });
       });
 
+      context('name is be not empty string', () => {
+        it('when empty should thrown an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          expect(() => {
+            wb.addWorksheet('');
+          }).to.throw('The name can\'t be empty.');
+        });
+        it('when isn\'t string should thrown an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          expect(() => {
+            wb.addWorksheet(0);
+          }).to.throw('The name has to be string.');
+        });
+      });
+
       context('when worksheet name is longer than 31', () => {
         it('keep first 31 characters', () => {
           const wb = new ExcelJS.Workbook();
@@ -774,6 +791,25 @@ describe('Worksheet', () => {
           ws = wb.addWorksheet();
           ws.name = 'ThisIsAWorksheetNameWith31Chars';
           expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
+        });
+      });
+
+      context('name is be not empty string', () => {
+        it('when empty should thrown an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          expect(() => {
+            const ws = wb.addWorksheet();
+            ws.name = '';
+          }).to.throw('The name can\'t be empty.');
+        });
+        it('when isn\'t string should thrown an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          expect(() => {
+            const ws = wb.addWorksheet();
+            ws.name = 0;
+          }).to.throw('The name has to be string.');
         });
       });
 

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -677,76 +677,173 @@ describe('Worksheet', () => {
 
       expect(ws.getRows(1, 0)).to.equal(undefined);
     });
-    context('when worksheet name is less than or equal 31', () => {
-      it('save the original name', () => {
-        const wb = new ExcelJS.Workbook();
-        let ws = wb.addWorksheet('ThisIsAWorksheetName');
-        expect(ws.name).to.equal('ThisIsAWorksheetName');
+    context('names validation through wb.addWorksheet', () => {
+      context('when worksheet name is less than or equal 31', () => {
+        it('save the original name', () => {
+          const wb = new ExcelJS.Workbook();
+          let ws = wb.addWorksheet('ThisIsAWorksheetName');
+          expect(ws.name).to.equal('ThisIsAWorksheetName');
 
-        ws = wb.addWorksheet('ThisIsAWorksheetNameWith31Chars');
-        expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
+          ws = wb.addWorksheet('ThisIsAWorksheetNameWith31Chars');
+          expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
+        });
+      });
+
+      context('when worksheet name is longer than 31', () => {
+        it('keep first 31 characters', () => {
+          const wb = new ExcelJS.Workbook();
+          const ws = wb.addWorksheet('ThisIsAWorksheetNameThatIsLongerThan31');
+
+          expect(ws.name).to.equal('ThisIsAWorksheetNameThatIsLonge');
+        });
+      });
+
+      context('when the worksheet name contains illegal characters', () => {
+        it('throws an error', () => {
+          const workbook = new ExcelJS.Workbook();
+
+          const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
+
+          for (const invalidCharacter of invalidCharacters) {
+            expect(() => workbook.addWorksheet(invalidCharacter)).to.throw(
+              `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
+            );
+          }
+        });
+
+        it('throws an error', () => {
+          const workbook = new ExcelJS.Workbook();
+
+          const invalidNames = ['\'sheetName', 'sheetName\''];
+
+          for (const invalidName of invalidNames) {
+            expect(() => workbook.addWorksheet(invalidName)).to.throw(
+              `The first or last character of worksheet name cannot be a single quotation mark: ${invalidName}`
+            );
+          }
+        });
+      });
+
+      context('when worksheet name already exists', () => {
+        it('throws an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          const validName = 'thisisaworksheetnameinuppercase';
+          const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
+          const expectedError = `Worksheet name already exists: ${invalideName}`;
+
+          wb.addWorksheet(validName);
+
+          expect(() => wb.addWorksheet(invalideName)).to.throw(expectedError);
+        });
+
+        it('throws an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          const validName = 'ThisIsAWorksheetNameThatIsLonge';
+          const invalideName = 'ThisIsAWorksheetNameThatIsLongerThan31';
+          const expectedError = `Worksheet name already exists: ${validName}`;
+
+          wb.addWorksheet(validName);
+
+          expect(() => wb.addWorksheet(validName)).to.throw(expectedError);
+          expect(() => wb.addWorksheet(invalideName)).to.throw(expectedError);
+        });
       });
     });
+    context('names validation through ws.name setter', () => {
+      context('when worksheet name is less than or equal 31', () => {
+        it('save the original name', () => {
+          const wb = new ExcelJS.Workbook();
+          let ws = wb.addWorksheet();
+          ws.name = 'ThisIsAWorksheetName';
+          expect(ws.name).to.equal('ThisIsAWorksheetName');
 
-    context('when worksheet name is longer than 31', () => {
-      it('keep first 31 characters', () => {
-        const wb = new ExcelJS.Workbook();
-        const ws = wb.addWorksheet('ThisIsAWorksheetNameThatIsLongerThan31');
-
-        expect(ws.name).to.equal('ThisIsAWorksheetNameThatIsLonge');
-      });
-    });
-
-    context('when the worksheet name contains illegal characters', () => {
-      it('throws an error', () => {
-        const workbook = new ExcelJS.Workbook();
-
-        const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
-
-        for (const invalidCharacter of invalidCharacters) {
-          expect(() => workbook.addWorksheet(invalidCharacter)).to.throw(
-            `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
-          );
-        }
+          ws = wb.addWorksheet();
+          ws.name = 'ThisIsAWorksheetNameWith31Chars';
+          expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
+        });
       });
 
-      it('throws an error', () => {
-        const workbook = new ExcelJS.Workbook();
+      context('when worksheet name is longer than 31', () => {
+        it('keep first 31 characters', () => {
+          const wb = new ExcelJS.Workbook();
+          const ws = wb.addWorksheet();
+          ws.name = 'ThisIsAWorksheetNameThatIsLongerThan31';
 
-        const invalidNames = ['\'sheetName', 'sheetName\''];
-
-        for (const invalidName of invalidNames) {
-          expect(() => workbook.addWorksheet(invalidName)).to.throw(
-            `The first or last character of worksheet name cannot be a single quotation mark: ${invalidName}`
-          );
-        }
-      });
-    });
-
-    context('when worksheet name already exists', () => {
-      it('throws an error', () => {
-        const wb = new ExcelJS.Workbook();
-
-        const validName = 'thisisaworksheetnameinuppercase';
-        const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
-        const expectedError = `Worksheet name already exists: ${invalideName}`;
-
-        wb.addWorksheet(validName);
-
-        expect(() => wb.addWorksheet(invalideName)).to.throw(expectedError);
+          expect(ws.name).to.equal('ThisIsAWorksheetNameThatIsLonge');
+        });
       });
 
-      it('throws an error', () => {
-        const wb = new ExcelJS.Workbook();
+      context('when the worksheet name contains illegal characters', () => {
+        it('throws an error', () => {
+          const workbook = new ExcelJS.Workbook();
 
-        const validName = 'ThisIsAWorksheetNameThatIsLonge';
-        const invalideName = 'ThisIsAWorksheetNameThatIsLongerThan31';
-        const expectedError = `Worksheet name already exists: ${validName}`;
+          const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
 
-        wb.addWorksheet(validName);
+          for (const invalidCharacter of invalidCharacters) {
+            expect(() => {
+              const ws = workbook.addWorksheet();
+              ws.name = invalidCharacter;
+            }).to.throw(
+              `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
+            );
+          }
+        });
 
-        expect(() => wb.addWorksheet(validName)).to.throw(expectedError);
-        expect(() => wb.addWorksheet(invalideName)).to.throw(expectedError);
+        it('throws an error', () => {
+          const workbook = new ExcelJS.Workbook();
+
+          const invalidNames = ['\'sheetName', 'sheetName\''];
+
+          for (const invalidName of invalidNames) {
+            expect(() => {
+              const ws = workbook.addWorksheet();
+              ws.name = invalidName;
+            }).to.throw(
+              `The first or last character of worksheet name cannot be a single quotation mark: ${invalidName}`
+            );
+          }
+        });
+      });
+
+      context('when worksheet name already exists', () => {
+        it('throws an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          const validName = 'thisisaworksheetnameinuppercase';
+          const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
+          const expectedError = `Worksheet name already exists: ${invalideName}`;
+
+          const ws = wb.addWorksheet();
+          ws.name = validName;
+
+          expect(() => {
+            const newWs = wb.addWorksheet();
+            newWs.name = invalideName;
+          }).to.throw(expectedError);
+        });
+
+        it('throws an error', () => {
+          const wb = new ExcelJS.Workbook();
+
+          const validName = 'ThisIsAWorksheetNameThatIsLonge';
+          const invalideName = 'ThisIsAWorksheetNameThatIsLongerThan31';
+          const expectedError = `Worksheet name already exists: ${validName}`;
+
+          const ws = wb.addWorksheet();
+          ws.name = validName;
+
+          expect(() => {
+            const newWs = wb.addWorksheet();
+            newWs.name = validName;
+          }).to.throw(expectedError);
+
+          expect(() => {
+            const newWs = wb.addWorksheet();
+            newWs.name = invalideName;
+          }).to.throw(expectedError);
+        });
       });
     });
   });

--- a/spec/integration/worksheet.spec.js
+++ b/spec/integration/worksheet.spec.js
@@ -677,234 +677,129 @@ describe('Worksheet', () => {
 
       expect(ws.getRows(1, 0)).to.equal(undefined);
     });
-    context('names validation through wb.addWorksheet', () => {
-      context('when worksheet name is less than or equal 31', () => {
-        it('save the original name', () => {
-          const wb = new ExcelJS.Workbook();
-          let ws = wb.addWorksheet('ThisIsAWorksheetName');
-          expect(ws.name).to.equal('ThisIsAWorksheetName');
+    context('when worksheet name is less than or equal 31', () => {
+      it('save the original name', () => {
+        const wb = new ExcelJS.Workbook();
+        let ws = wb.addWorksheet();
+        ws.name = 'ThisIsAWorksheetName';
+        expect(ws.name).to.equal('ThisIsAWorksheetName');
 
-          ws = wb.addWorksheet('ThisIsAWorksheetNameWith31Chars');
-          expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
-        });
-      });
-
-      context('when worksheet name is `History`', () => {
-        it('thrown an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          expect(() => {
-            wb.addWorksheet('History');
-          }).to.throw(
-            'The name "History" is protected. Please use a different name.'
-          );
-        });
-      });
-
-      context('name is be not empty string', () => {
-        it('when empty should thrown an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          expect(() => {
-            wb.addWorksheet('');
-          }).to.throw('The name can\'t be empty.');
-        });
-        it('when isn\'t string should thrown an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          expect(() => {
-            wb.addWorksheet(0);
-          }).to.throw('The name has to be string.');
-        });
-      });
-
-      context('when worksheet name is longer than 31', () => {
-        it('keep first 31 characters', () => {
-          const wb = new ExcelJS.Workbook();
-          const ws = wb.addWorksheet('ThisIsAWorksheetNameThatIsLongerThan31');
-
-          expect(ws.name).to.equal('ThisIsAWorksheetNameThatIsLonge');
-        });
-      });
-
-      context('when the worksheet name contains illegal characters', () => {
-        it('throws an error', () => {
-          const workbook = new ExcelJS.Workbook();
-
-          const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
-
-          for (const invalidCharacter of invalidCharacters) {
-            expect(() => workbook.addWorksheet(invalidCharacter)).to.throw(
-              `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
-            );
-          }
-        });
-
-        it('throws an error', () => {
-          const workbook = new ExcelJS.Workbook();
-
-          const invalidNames = ['\'sheetName', 'sheetName\''];
-
-          for (const invalidName of invalidNames) {
-            expect(() => workbook.addWorksheet(invalidName)).to.throw(
-              `The first or last character of worksheet name cannot be a single quotation mark: ${invalidName}`
-            );
-          }
-        });
-      });
-
-      context('when worksheet name already exists', () => {
-        it('throws an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          const validName = 'thisisaworksheetnameinuppercase';
-          const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
-          const expectedError = `Worksheet name already exists: ${invalideName}`;
-
-          wb.addWorksheet(validName);
-
-          expect(() => wb.addWorksheet(invalideName)).to.throw(expectedError);
-        });
-
-        it('throws an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          const validName = 'ThisIsAWorksheetNameThatIsLonge';
-          const invalideName = 'ThisIsAWorksheetNameThatIsLongerThan31';
-          const expectedError = `Worksheet name already exists: ${validName}`;
-
-          wb.addWorksheet(validName);
-
-          expect(() => wb.addWorksheet(validName)).to.throw(expectedError);
-          expect(() => wb.addWorksheet(invalideName)).to.throw(expectedError);
-        });
+        ws = wb.addWorksheet();
+        ws.name = 'ThisIsAWorksheetNameWith31Chars';
+        expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
       });
     });
-    context('names validation through ws.name setter', () => {
-      context('when worksheet name is less than or equal 31', () => {
-        it('save the original name', () => {
-          const wb = new ExcelJS.Workbook();
-          let ws = wb.addWorksheet();
-          ws.name = 'ThisIsAWorksheetName';
-          expect(ws.name).to.equal('ThisIsAWorksheetName');
 
-          ws = wb.addWorksheet();
-          ws.name = 'ThisIsAWorksheetNameWith31Chars';
-          expect(ws.name).to.equal('ThisIsAWorksheetNameWith31Chars');
-        });
+    context('name is be not empty string', () => {
+      it('when empty should thrown an error', () => {
+        const wb = new ExcelJS.Workbook();
+
+        expect(() => {
+          const ws = wb.addWorksheet();
+          ws.name = '';
+        }).to.throw('The name can\'t be empty.');
       });
+      it('when isn\'t string should thrown an error', () => {
+        const wb = new ExcelJS.Workbook();
 
-      context('name is be not empty string', () => {
-        it('when empty should thrown an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          expect(() => {
-            const ws = wb.addWorksheet();
-            ws.name = '';
-          }).to.throw('The name can\'t be empty.');
-        });
-        it('when isn\'t string should thrown an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          expect(() => {
-            const ws = wb.addWorksheet();
-            ws.name = 0;
-          }).to.throw('The name has to be string.');
-        });
+        expect(() => {
+          const ws = wb.addWorksheet();
+          ws.name = 0;
+        }).to.throw('The name has to be a string.');
       });
+    });
 
-      context('when worksheet name is `History`', () => {
-        it('thrown an error', () => {
-          const wb = new ExcelJS.Workbook();
+    context('when worksheet name is `History`', () => {
+      it('thrown an error', () => {
+        const wb = new ExcelJS.Workbook();
 
+        expect(() => {
+          const ws = wb.addWorksheet();
+          ws.name = 'History';
+        }).to.throw(
+          'The name "History" is protected. Please use a different name.'
+        );
+      });
+    });
+
+    context('when worksheet name is longer than 31', () => {
+      it('keep first 31 characters', () => {
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet();
+        ws.name = 'ThisIsAWorksheetNameThatIsLongerThan31';
+
+        expect(ws.name).to.equal('ThisIsAWorksheetNameThatIsLonge');
+      });
+    });
+
+    context('when the worksheet name contains illegal characters', () => {
+      it('throws an error', () => {
+        const workbook = new ExcelJS.Workbook();
+
+        const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
+
+        for (const invalidCharacter of invalidCharacters) {
           expect(() => {
-            const ws = wb.addWorksheet();
-            ws.name = 'History';
+            const ws = workbook.addWorksheet();
+            ws.name = invalidCharacter;
           }).to.throw(
-            'The name "History" is protected. Please use a different name.'
+            `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
           );
-        });
+        }
       });
 
-      context('when worksheet name is longer than 31', () => {
-        it('keep first 31 characters', () => {
-          const wb = new ExcelJS.Workbook();
-          const ws = wb.addWorksheet();
-          ws.name = 'ThisIsAWorksheetNameThatIsLongerThan31';
+      it('throws an error', () => {
+        const workbook = new ExcelJS.Workbook();
 
-          expect(ws.name).to.equal('ThisIsAWorksheetNameThatIsLonge');
-        });
+        const invalidNames = ['\'sheetName', 'sheetName\''];
+
+        for (const invalidName of invalidNames) {
+          expect(() => {
+            const ws = workbook.addWorksheet();
+            ws.name = invalidName;
+          }).to.throw(
+            `The first or last character of worksheet name cannot be a single quotation mark: ${invalidName}`
+          );
+        }
+      });
+    });
+
+    context('when worksheet name already exists', () => {
+      it('throws an error', () => {
+        const wb = new ExcelJS.Workbook();
+
+        const validName = 'thisisaworksheetnameinuppercase';
+        const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
+        const expectedError = `Worksheet name already exists: ${invalideName}`;
+
+        const ws = wb.addWorksheet();
+        ws.name = validName;
+
+        expect(() => {
+          const newWs = wb.addWorksheet();
+          newWs.name = invalideName;
+        }).to.throw(expectedError);
       });
 
-      context('when the worksheet name contains illegal characters', () => {
-        it('throws an error', () => {
-          const workbook = new ExcelJS.Workbook();
+      it('throws an error', () => {
+        const wb = new ExcelJS.Workbook();
 
-          const invalidCharacters = ['*', '?', ':', '/', '\\', '[', ']'];
+        const validName = 'ThisIsAWorksheetNameThatIsLonge';
+        const invalideName = 'ThisIsAWorksheetNameThatIsLongerThan31';
+        const expectedError = `Worksheet name already exists: ${validName}`;
 
-          for (const invalidCharacter of invalidCharacters) {
-            expect(() => {
-              const ws = workbook.addWorksheet();
-              ws.name = invalidCharacter;
-            }).to.throw(
-              `Worksheet name ${invalidCharacter} cannot include any of the following characters: * ? : \\ / [ ]`
-            );
-          }
-        });
+        const ws = wb.addWorksheet();
+        ws.name = validName;
 
-        it('throws an error', () => {
-          const workbook = new ExcelJS.Workbook();
+        expect(() => {
+          const newWs = wb.addWorksheet();
+          newWs.name = validName;
+        }).to.throw(expectedError);
 
-          const invalidNames = ['\'sheetName', 'sheetName\''];
-
-          for (const invalidName of invalidNames) {
-            expect(() => {
-              const ws = workbook.addWorksheet();
-              ws.name = invalidName;
-            }).to.throw(
-              `The first or last character of worksheet name cannot be a single quotation mark: ${invalidName}`
-            );
-          }
-        });
-      });
-
-      context('when worksheet name already exists', () => {
-        it('throws an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          const validName = 'thisisaworksheetnameinuppercase';
-          const invalideName = 'THISISAWORKSHEETNAMEINUPPERCASE';
-          const expectedError = `Worksheet name already exists: ${invalideName}`;
-
-          const ws = wb.addWorksheet();
-          ws.name = validName;
-
-          expect(() => {
-            const newWs = wb.addWorksheet();
-            newWs.name = invalideName;
-          }).to.throw(expectedError);
-        });
-
-        it('throws an error', () => {
-          const wb = new ExcelJS.Workbook();
-
-          const validName = 'ThisIsAWorksheetNameThatIsLonge';
-          const invalideName = 'ThisIsAWorksheetNameThatIsLongerThan31';
-          const expectedError = `Worksheet name already exists: ${validName}`;
-
-          const ws = wb.addWorksheet();
-          ws.name = validName;
-
-          expect(() => {
-            const newWs = wb.addWorksheet();
-            newWs.name = validName;
-          }).to.throw(expectedError);
-
-          expect(() => {
-            const newWs = wb.addWorksheet();
-            newWs.name = invalideName;
-          }).to.throw(expectedError);
-        });
+        expect(() => {
+          const newWs = wb.addWorksheet();
+          newWs.name = invalideName;
+        }).to.throw(expectedError);
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR aims to resolve #2243 issue. 
Additionally, I transferred the responsibility for name validation from `Workbook` to `Worksheet`, which allowed me to tighten the rules for changing the name using: `ws.name`

## Test plan

I completed the missing tests and covers all new assertions.

