### PR TITLE
fix：Fix the problem of displaying more than 255 characters in formula…

### DIFF
--- a/lib/xlsx/xform/sheet/data-validations-xform.js
+++ b/lib/xlsx/xform/sheet/data-validations-xform.js
@@ -143,6 +143,14 @@ class DataValidationsXform extends BaseXform {
           if (value.type === 'date') {
             xmlStream.writeText(utils.dateToExcel(new Date(formula)));
           } else {
+            if (value.type === 'list') {
+              const pattern = /^".*"$/; // Match "XX, XXX1"
+              if (pattern.test(formula) && formula.length - '""'.length > 255) {
+                throw new Error(
+                  'The input cannot be larger than 255 characters. Please check the value of dataValidation.formulae'
+                );
+              }
+            }
             xmlStream.writeText(formula);
           }
           xmlStream.closeNode();

--- a/spec/integration/issues/issues-2256-data-validation-length.spec.js
+++ b/spec/integration/issues/issues-2256-data-validation-length.spec.js
@@ -1,0 +1,70 @@
+const ExcelJS = verquire('exceljs');
+
+describe('github issues', () => {
+  describe('issue 2256 - (dataValidation) The exported table inserts a drop-down menu for the cell. The cell cannot display drop-down options', () => {
+    it('issue 2256 - (dataValidation) Input content is 266 characters, more than 255 characters, throw error', async () => {
+      async function test() {
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet('sheet');
+        const columns = [
+          {
+            header: 'Test1',
+            key: 'test1',
+            width: 25,
+          },
+        ];
+        worksheet.columns = columns;
+        const cell = worksheet.getCell('A2');
+        const value =
+          '"1234 Main St, Anytown 56789,5678 Elm Ave, Smallville 23456,9012 Oak Rd, Big City 34567,3456 Pine Dr, Tinytown 67890,7890 Maple Ln, Mediumtown 12345,2345 Hickory St, Suburbia 45678,6789 Cedar Cir, Urbanville 89012,0123 Birch Blvd, Countryside 23456,4567 Wal"';
+        cell.dataValidation = {
+          type: 'list',
+          allowBlank: true,
+          formulae: [value],
+        };
+        await workbook.xlsx.writeFile(
+          './spec/integration/data/test-issue-2256-1.xlsx'
+        );
+      }
+      let error;
+      try {
+        await test();
+      } catch (err) {
+        error = err;
+      }
+      expect(error)
+        .to.be.an('error')
+        .with.property(
+          'message',
+          'The input cannot be larger than 255 characters. Please check the value of dataValidation.formulae'
+        );
+    });
+
+    it('issue 2256 - (dataValidation) Input content is 255 characters, normal display', async () => {
+      async function test() {
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet('sheet');
+        const columns = [
+          {
+            header: 'Test1',
+            key: 'test1',
+            width: 25,
+          },
+        ];
+        worksheet.columns = columns;
+        const cell = worksheet.getCell('A2');
+        const value =
+          '"1234 Main St, Anytown 56789,5678 Elm Ave, Smallville 23456,9012 Oak Rd, Big City 34567,3456 Pine Dr, Tinytown 67890,7890 Maple Ln, Mediumtown 12345,2345 Hickory St, Suburbia 45678,6789 Cedar Cir, Urbanville 89012,0123 Birch Blvd, Countryside 23456,4567 Wa"';
+        cell.dataValidation = {
+          type: 'list',
+          allowBlank: true,
+          formulae: [value],
+        };
+        await workbook.xlsx.writeFile(
+          './spec/integration/data/test-issue-2256-2.xlsx'
+        );
+      }
+      await test();
+    });
+  });
+});


### PR DESCRIPTION
 (#2256) #1736
Fix the problem that the exported excel dataValidation drop-down list cannot be displayed normally when the content of formulae exceeds 255 characters when dataValidation type=list

When dataValidation formulae exceed 255 characters，
```
throw new Error('The input cannot be larger than 255 characters. Please check the value of dataValidation.formulae');
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
