### PR TITLE
Downgrade regenerator runtime dependency to be CSP strict-src compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "mocha": "^7.2.0",
     "prettier-eslint": "^11.0.0",
     "prettier-eslint-cli": "^5.0.0",
-    "regenerator-runtime": "^0.13.7",
+    "regenerator-runtime": "^0.13.1",
     "sax": "^1.2.4",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.7"


### PR DESCRIPTION
## Summary
Exceljs is not CSP strict-src compliant. As per discoveries listed in issue - https://github.com/exceljs/exceljs/issues/713
a Function constructor is invoked by regenerator-runtime dependency (primarily used for polyfilling async/promises through generators). 

Exceljs is compiled in strict mode by default, causing the Function constructor call in the regenerator-runtime script. 
A possible solution listed is to simply use the bare version of exceljs and include this regenerator-runtime lib separately (causing it to not be run in strict mode and hence not invoke the Function constructor).


## Test plan

A simple fix is to downgrade to regenrator-runtime to 0.13.1, which doesn't have the forbidden Function constructor call.
