### PR TITLE
fix: fix type definitions about last column, formula values and protection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -289,6 +289,7 @@ export interface Alignment {
 
 export interface Protection {
 	locked: boolean;
+	hidden: boolean;
 }
 
 export interface Style {
@@ -348,15 +349,15 @@ export interface CellHyperlinkValue {
 
 export interface CellFormulaValue {
 	formula: string;
-	result?: number | string | Date | { error: CellErrorValue };
-	date1904: boolean;
+	result?: number | string | Date | CellErrorValue;
+	date1904?: boolean;
 }
 
 export interface CellSharedFormulaValue {
 	sharedFormula: string;
 	readonly formula?: string;
-	result?: number | string | Date | { error: CellErrorValue };
-	date1904: boolean;
+	result?: number | string | Date | CellErrorValue;
+	date1904?: boolean;
 }
 
 export declare enum ValueType {
@@ -1139,7 +1140,7 @@ export interface Worksheet {
 	/**
 	 * Get the last column in a worksheet
 	 */
-	readonly lastColumn: Column;
+	readonly lastColumn: Column | undefined;
 
 	/**
 	 * A count of the number of columns that have values.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Several type definition has been fixed. Details:

- `Worksheet.lastColumn` can be `undefined` for an empty worksheet, as `Worksheet.lastRow` can be `undefined`.
- `date1904` should be an optional property for both `CellFormulaValue` and `CellSharedFormulaValue`.
- `CellFormulaValue.result` and `CellSharedFormulaValue.result` should include `CellErrorValue`, not `{ error: CellErrorValue }`, because `CellErrorValue` itself is already an interface with `error` as its property.
- `Protection` should have a `hidden` property, as is recorded in the documentation.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->

- https://github.com/exceljs/exceljs/blob/ec92cb3b898bdf7f806ff9d7b8370c955ee8ba20/index.d.ts#L1191
- https://github.com/exceljs/exceljs/blob/ec92cb3b898bdf7f806ff9d7b8370c955ee8ba20/lib/xlsx/xform/sheet/cell-xform.js#L98
- https://github.com/exceljs/exceljs/blob/ec92cb3b898bdf7f806ff9d7b8370c955ee8ba20/lib/xlsx/xform/sheet/cell-xform.js#L357
- https://github.com/exceljs/exceljs/blob/ec92cb3b898bdf7f806ff9d7b8370c955ee8ba20/lib/xlsx/xform/style/protection-xform.js#L44