### PR TITLE
Increase resilience to generating large workbooks

### DIFF
--- a/lib/utils/xml-stream.js
+++ b/lib/utils/xml-stream.js
@@ -12,19 +12,17 @@ const QUOTE = '"';
 const SPACE = ' ';
 
 function pushAttribute(xml, name, value) {
-  xml.push(SPACE);
-  xml.push(name);
-  xml.push(EQUALS_QUOTE);
-  xml.push(utils.xmlEncode(value.toString()));
-  xml.push(QUOTE);
+  xml.push(` ${name}="${utils.xmlEncode(value.toString())}"`);
 }
 function pushAttributes(xml, attributes) {
   if (attributes) {
+    const tmp = [];
     _.each(attributes, (value, name) => {
       if (value !== undefined) {
-        pushAttribute(xml, name, value);
+        pushAttribute(tmp, name, value);
       }
     });
+    xml.push(tmp.join(""));
   }
 }
 

--- a/lib/utils/xml-stream.js
+++ b/lib/utils/xml-stream.js
@@ -7,9 +7,6 @@ const OPEN_ANGLE = '<';
 const CLOSE_ANGLE = '>';
 const OPEN_ANGLE_SLASH = '</';
 const CLOSE_SLASH_ANGLE = '/>';
-const EQUALS_QUOTE = '="';
-const QUOTE = '"';
-const SPACE = ' ';
 
 function pushAttribute(xml, name, value) {
   xml.push(` ${name}="${utils.xmlEncode(value.toString())}"`);


### PR DESCRIPTION
## Summary

Updates the xml-stream.js to generate a single string instead of multiple strings for each attribute or record of attributes.

Closes: #2303