### PR TITLE
repair all 'c2fo.io' links ('c2fo.github.io')

### DIFF
--- a/README.md
+++ b/README.md
@@ -2199,7 +2199,7 @@ Options supported when reading CSV files.
 | dateFormats      |     N       |  Array      | Specify the date encoding format of dayjs. |
 | map              |     N       |  Function   | Custom Array.prototype.map() callback function for processing data. |
 | sheetName        |     N       |  String     | Specify worksheet name. |
-| parserOptions    |     N       |  Object     | [parseOptions options](https://c2fo.io/fast-csv/docs/parsing/options)  @fast-csv/format module to write csv data. |
+| parserOptions    |     N       |  Object     | [parseOptions options](https://c2fo.github.io/fast-csv/docs/parsing/options)  @fast-csv/format module to write csv data. |
 
 ```javascript
 // read from a file
@@ -2242,7 +2242,7 @@ const options = {
         return parseFloat(value);
     }
   },
-  // https://c2fo.io/fast-csv/docs/parsing/options
+  // https://c2fo.github.io/fast-csv/docs/parsing/options
   parserOptions: {
     delimiter: '\t',
     quote: false,
@@ -2278,7 +2278,7 @@ Options supported when writing to a CSV file.
 | map              |     N       |  Function   | Custom Array.prototype.map() callback function for processing row values. |
 | sheetName        |     N       |  String     | Specify worksheet name. |
 | sheetId          |     N       |  Number     | Specify worksheet ID. |
-| formatterOptions |     N       |  Object     | [formatterOptions options](https://c2fo.io/fast-csv/docs/formatting/options/) @fast-csv/format module to write csv data. |
+| formatterOptions |     N       |  Object     | [formatterOptions options](https://c2fo.github.io/fast-csv/docs/formatting/options/) @fast-csv/format module to write csv data. |
 
 ```javascript
 
@@ -2319,7 +2319,7 @@ const options = {
         return value;
     }
   },
-  // https://c2fo.io/fast-csv/docs/formatting/options
+  // https://c2fo.github.io/fast-csv/docs/formatting/options
   formatterOptions: {
     delimiter: '\t',
     quote: false,

--- a/README_zh.md
+++ b/README_zh.md
@@ -2089,7 +2089,7 @@ const buffer = await workbook.xlsx.writeBuffer();
 | dateFormats      |     N       |  Array      | 指定 dayjs 的日期编码格式。 |
 | map              |     N       |  Function   | 自定义`Array.prototype.map()` 回调函数，用于处理数据。 |
 | sheetName        |     N       |  String     | 指定工作表名称。 |
-| parserOptions    |     N       |  Object     | [parseOptions 选项](https://c2fo.io/fast-csv/docs/parsing/options)  @fast-csv/format 模块以写入 csv 数据。 |
+| parserOptions    |     N       |  Object     | [parseOptions 选项](https://c2fo.github.io/fast-csv/docs/parsing/options)  @fast-csv/format 模块以写入 csv 数据。 |
 
 ```javascript
 // 从文件读取
@@ -2132,7 +2132,7 @@ const options = {
         return parseFloat(value);
     }
   },
-  // https://c2fo.io/fast-csv/docs/parsing/options
+  // https://c2fo.github.io/fast-csv/docs/parsing/options
   parserOptions: {
     delimiter: '\t',
     quote: false,
@@ -2165,7 +2165,7 @@ CSV 解析器使用 [fast-csv](https://www.npmjs.com/package/fast-csv) 读取CSV
 | map              |     N       |  Function   | 自定义`Array.prototype.map()` 回调函数，用于处理行值。 |
 | sheetName        |     N       |  String     | 指定工作表名称。 |
 | sheetId          |     N       |  Number     | 指定工作表 ID。 |
-| formatterOptions |     N       |  Object     | [formatterOptions 选项](https://c2fo.io/fast-csv/docs/formatting/options/) @fast-csv/format 模块写入csv 数据。 |
+| formatterOptions |     N       |  Object     | [formatterOptions 选项](https://c2fo.github.io/fast-csv/docs/formatting/options/) @fast-csv/format 模块写入csv 数据。 |
 
 ```javascript
 
@@ -2205,7 +2205,7 @@ const options = {
         return value;
     }
   },
-  // https://c2fo.io/fast-csv/docs/formatting/options
+  // https://c2fo.github.io/fast-csv/docs/formatting/options
   formatterOptions: {
     delimiter: '\t',
     quote: false,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1487,7 +1487,7 @@ export interface Xlsx {
 	write(stream: import('stream').Stream, options?: Partial<XlsxWriteOptions>): Promise<void>;
 }
 
-// https://c2fo.io/fast-csv/docs/parsing/options
+// https://c2fo.github.io/fast-csv/docs/parsing/options
 
 type HeaderArray = (string | undefined | null)[];
 type HeaderTransformFunction = (headers: HeaderArray) => HeaderArray;
@@ -1528,7 +1528,7 @@ interface RowTransformFunction {
 	(row: Rows): Rows;
 }
 
-// https://c2fo.io/fast-csv/docs/formatting/options/
+// https://c2fo.github.io/fast-csv/docs/formatting/options/
 export interface FastCsvFormatterOptionsArgs {
 	objectMode: boolean;
 	delimiter: string;


### PR DESCRIPTION
## Summary

All `c2fo.io` links were broken. It should instead be `c2fo.github.io`

## Test plan

N/A

## Related to source code (for typings update)

N/A