### PR TITLE
Add missing tooltip attribute to CellHyperlinkValue index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -344,6 +344,7 @@ export interface CellRichTextValue {
 export interface CellHyperlinkValue {
 	text: string;
 	hyperlink: string;
+	tooltip?: string;
 }
 
 export interface CellFormulaValue {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Super simple extension of the `CellHyperlinkValue` to include the `tooltip` functionality, which already was implemented (just the typing was missing).
