### PR TITLE
#514: Remove invalid readonly for Column.values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -634,7 +634,7 @@ export interface Column {
 	/**
 	 * The cell values in the column
 	 */
-	values: ReadonlyArray<CellValue>;
+	values: CellValue;
 
 	/**
 	 * Column letter key


### PR DESCRIPTION
## Summary

The `values` field for Column class is actually mutable.
https://github.com/exceljs/exceljs/issues/514#issuecomment-1782927522


