### PR TITLE
Fixed tabColor example and documented hexadecimal format

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ Use the second parameter of the addWorksheet function to specify options for the
 For Example:
 
 ```javascript
-// create a sheet with red tab colour
-const sheet = workbook.addWorksheet('My Sheet', {properties:{tabColor:{argb:'FFC0000'}}});
+// create a sheet with a red tab colour using the hexadecimal alpha-red-green-blue format
+const sheet = workbook.addWorksheet('My Sheet', {properties:{tabColor:{argb:'FFCC0000'}}});
 
 // create a sheet where the grid lines are hidden
 const sheet = workbook.addWorksheet('My Sheet', {views: [{showGridLines: false}]});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The README had an incorrect example for `tabColor`. I've also specified the alpha-red-green-blue format used (since it's different to the expected rgba used across the web).
