### PR TITLE
PivotTable: Support multiple values

### DIFF
--- a/lib/doc/pivot-table.js
+++ b/lib/doc/pivot-table.js
@@ -73,12 +73,14 @@ function validate(worksheet, model) {
     throw new Error('No pivot table rows specified.');
   }
 
-  if (!model.columns.length) {
-    throw new Error('No pivot table columns specified.');
+  if (model.values.length < 1) {
+    throw new Error('Must have at least one value.');
   }
 
-  if (model.values.length !== 1) {
-    throw new Error('Exactly 1 value needs to be specified at this time.');
+  if (model.values.length > 1 && model.columns.length > 0) {
+    throw new Error(
+      'It is currently not possible to have multiple values when columns are specified. Please either supply an empty array for columns or a single value.'
+    );
   }
 }
 

--- a/lib/xlsx/xform/pivot-table/pivot-table-xform.js
+++ b/lib/xlsx/xform/pivot-table/pivot-table-xform.js
@@ -73,19 +73,18 @@ class PivotTableXform extends BaseXform {
       <rowItems count="1">
         <i t="grand"><x /></i>
       </rowItems>
-      <colFields count="${columns.length}">
-        ${columns.map(columnIndex => `<field x="${columnIndex}" />`).join('\n    ')}
+      <colFields count="${columns.length === 0 ? 1 : columns.length}">
+        ${
+          columns.length === 0
+            ? '<field x="-2" />'
+            : columns.map(columnIndex => `<field x="${columnIndex}" />`).join('\n    ')
+        }
       </colFields>
       <colItems count="1">
         <i t="grand"><x /></i>
       </colItems>
       <dataFields count="${values.length}">
-        <dataField
-          name="Sum of ${cacheFields[values[0]].name}"
-          fld="${values[0]}"
-          baseField="0"
-          baseItem="0"
-        />
+        ${buildDataFields(cacheFields, values)}
       </dataFields>
       <pivotTableStyleInfo
         name="PivotStyleLight16"
@@ -138,6 +137,20 @@ class PivotTableXform extends BaseXform {
 }
 
 // Helpers
+function buildDataFields(cacheFields, values) {
+  let i = 0;
+  let datafields = '';
+  while (i < values.length) {
+    datafields += `<dataField
+      name="Sum of ${cacheFields[values[i]].name}"
+      fld="${values[i]}"
+      baseField="0"
+      baseItem="0"
+    />`;
+    i++;
+  }
+  return datafields;
+}
 
 function renderPivotFields(pivotTable) {
   /* eslint-disable no-nested-ternary */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This adds support for multiple values in pivot tables.
It also allows not supplying any columns. This mimics the built-in Excel functionality where it populates the columns field with "Values".

**Limitation:** It is not currently possible to provide multiple values AND any columns.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

With the first implementation checked in yesterday it is not possible to use multiple values. This PR removes that limitation (as long as custom columns are not used)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I created a PivotTable with multiple values and no columns without problems.
I crated a PivotTable with one value and multiple columns without problems