### PR TITLE
Fix types of Row and Column values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -538,8 +538,7 @@ export interface Row extends Style {
 	/**
 	 * Get a row as a sparse array
 	 */
-	// readonly values: CellValue[];
-	values: CellValue[] | { [key: string]: CellValue };
+	values: CellValue[];
 
 	/**
 	 * Set an outline level for rows
@@ -634,7 +633,7 @@ export interface Column {
 	/**
 	 * The cell values in the column
 	 */
-	values: CellValue;
+	values: CellValue[];
 
 	/**
 	 * Column letter key


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- https://github.com/exceljs/exceljs/commit/2225238343151f0c81035aa4a99895a5425d47a2 was supposed to only remove the readonly modifier on `values` of `Column` but accidently defined it as `string` while it actually remains is an `Array`
- Afaik `values` of `Row` will alway be an array – thus the obsolete union type was also removed