### PR TITLE
Fix shared strings and richText

### DIFF
--- a/lib/utils/shared-strings.js
+++ b/lib/utils/shared-strings.js
@@ -22,13 +22,25 @@ class SharedStrings {
   }
 
   add(value) {
-    let index = this._hash[value];
+    const key = this.getKeyFromValue(value);
+    let index = this._hash[key];
+
     if (index === undefined) {
-      index = this._hash[value] = this._values.length;
+      index = this._hash[key] = this._values.length;
       this._values.push(value);
     }
+
     this._totalRefs++;
     return index;
+  }
+
+  getKeyFromValue(value) {
+    if (typeof value !== 'object' || value === null) {
+      return value;
+    }
+
+    // Convert richText value to string
+    return JSON.stringify(value);
   }
 }
 

--- a/spec/unit/utils/shared-strings.spec.js
+++ b/spec/unit/utils/shared-strings.spec.js
@@ -25,4 +25,14 @@ describe('SharedStrings', () => {
     expect(ss.getString(iXml)).to.equal('<tag>value</tag>');
     expect(ss.getString(iAmpersand)).to.equal('&');
   });
+
+  it('Distinguishes richText', () => {
+    // that's the job of the xml utils
+    const ss = new SharedStrings();
+
+    ss.add({richText: [{text: 'value 1'}]});
+    ss.add({richText: [{text: 'value 2'}]});
+
+    expect(ss.count).to.equal(2);
+  });
 });


### PR DESCRIPTION
## Summary

Corrects the behavior of richText in SharedStrings

See https://github.com/exceljs/exceljs/issues/2267

## Test plan

Create a workbook with multiple richText values and enabled useSharedStrings.