### PR TITLE
Fix splicecolumn mergedcells

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "printWidth": 100,
   "trailingComma": "all",
   "arrowParens": "avoid",
-  "singleQuote": true,
+  "singleQuote": true
 }

--- a/lib/doc/row.js
+++ b/lib/doc/row.js
@@ -89,6 +89,18 @@ class Row {
         cSrc = this._cells[i - nExpand - 1];
         if (cSrc) {
           cDst = this.getCell(i);
+          if (cDst.isMerged) {
+            const getMaster = cDst.master.address;
+            const getMergeRange = this.worksheet._merges[getMaster].model;
+            const letfCol = this.worksheet.getColumn(getMergeRange.left).letter;
+            const rightCol = this.worksheet.getColumn(getMergeRange.right).letter;
+            const rightDesCol = this.worksheet.getColumn(getMergeRange.right - 1).letter;
+            const srcRange = `${letfCol}${getMergeRange.top}:${rightCol}${getMergeRange.bottom}`;
+            const destRange = `${letfCol}${getMergeRange.top}:${rightDesCol}${getMergeRange.bottom}`;
+            this.worksheet.unMergeCells(srcRange);
+            this.worksheet.mergeCells(destRange);
+            return;
+          }
           cDst.value = cSrc.value;
           cDst.style = cSrc.style;
           // eslint-disable-next-line no-underscore-dangle
@@ -324,9 +336,7 @@ class Row {
   }
 
   get collapsed() {
-    return !!(
-      this._outlineLevel && this._outlineLevel >= this._worksheet.properties.outlineLevelRow
-    );
+    return !!(this._outlineLevel && this._outlineLevel >= this._worksheet.properties.outlineLevelRow);
   }
 
   // =========================================================================

--- a/lib/doc/row.js
+++ b/lib/doc/row.js
@@ -81,24 +81,33 @@ class Row {
     let i;
     let cSrc;
     let cDst;
+    // get a list of merged cells affected by this change. Merge cells that are in the start or after the start range.
+    const mergeItems = this.worksheet._merges.filter(
+      merge => merge.model.left > start || (merge.model.left < start && merge.model.right > start)
+    );
 
     if (nExpand < 0) {
+      // Iterate through mergeItems and move the merge to one column left
+      mergeItems.forEach(mergeItem => {
+        const {model} = mergeItem;
+        const leftCol = model.left < start ? model.left : model.left - 1;
+        const rightCol = model.right - 1;
+        const topRow = model.top;
+        const bottomRow = model.bottom;
+        const newMergeRange = `${this.worksheet.getColumn(leftCol).letter}${topRow}:${
+          this.worksheet.getColumn(rightCol).letter
+        }${bottomRow}`;
+        this.worksheet.unMergeCells(mergeItem.range);
+        this.worksheet.mergeCells(newMergeRange);
+      });
       // remove cells
       for (i = start + inserts.length; i <= nEnd; i++) {
         cDst = this._cells[i - 1];
         cSrc = this._cells[i - nExpand - 1];
         if (cSrc) {
           cDst = this.getCell(i);
+          // ignore cells that are part of a merge
           if (cDst.isMerged) {
-            const getMaster = cDst.master.address;
-            const getMergeRange = this.worksheet._merges[getMaster].model;
-            const letfCol = this.worksheet.getColumn(getMergeRange.left).letter;
-            const rightCol = this.worksheet.getColumn(getMergeRange.right).letter;
-            const rightDesCol = this.worksheet.getColumn(getMergeRange.right - 1).letter;
-            const srcRange = `${letfCol}${getMergeRange.top}:${rightCol}${getMergeRange.bottom}`;
-            const destRange = `${letfCol}${getMergeRange.top}:${rightDesCol}${getMergeRange.bottom}`;
-            this.worksheet.unMergeCells(srcRange);
-            this.worksheet.mergeCells(destRange);
             return;
           }
           cDst.value = cSrc.value;
@@ -336,7 +345,9 @@ class Row {
   }
 
   get collapsed() {
-    return !!(this._outlineLevel && this._outlineLevel >= this._worksheet.properties.outlineLevelRow);
+    return !!(
+      this._outlineLevel && this._outlineLevel >= this._worksheet.properties.outlineLevelRow
+    );
   }
 
   // =========================================================================

--- a/lib/doc/row.js
+++ b/lib/doc/row.js
@@ -81,25 +81,8 @@ class Row {
     let i;
     let cSrc;
     let cDst;
-    // get a list of merged cells affected by this change. Merge cells that are in the start or after the start range.
-    const mergeItems = this.worksheet._merges.filter(
-      merge => merge.model.left > start || (merge.model.left < start && merge.model.right > start)
-    );
 
     if (nExpand < 0) {
-      // Iterate through mergeItems and move the merge to one column left
-      mergeItems.forEach(mergeItem => {
-        const {model} = mergeItem;
-        const leftCol = model.left < start ? model.left : model.left - 1;
-        const rightCol = model.right - 1;
-        const topRow = model.top;
-        const bottomRow = model.bottom;
-        const newMergeRange = `${this.worksheet.getColumn(leftCol).letter}${topRow}:${
-          this.worksheet.getColumn(rightCol).letter
-        }${bottomRow}`;
-        this.worksheet.unMergeCells(mergeItem.range);
-        this.worksheet.mergeCells(newMergeRange);
-      });
       // remove cells
       for (i = start + inserts.length; i <= nEnd; i++) {
         cDst = this._cells[i - 1];

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -156,11 +156,15 @@ class Worksheet {
     // Illegal character in worksheet name: asterisk (*), question mark (?),
     // colon (:), forward slash (/ \), or bracket ([])
     if (/[*?:/\\[\]]/.test(name)) {
-      throw new Error(`Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ]`);
+      throw new Error(
+        `Worksheet name ${name} cannot include any of the following characters: * ? : \\ / [ ]`
+      );
     }
 
     if (/(^')|('$)/.test(name)) {
-      throw new Error(`The first or last character of worksheet name cannot be a single quotation mark: ${name}`);
+      throw new Error(
+        `The first or last character of worksheet name cannot be a single quotation mark: ${name}`
+      );
     }
 
     if (name && name.length > 31) {
@@ -267,6 +271,10 @@ class Worksheet {
   spliceColumns(start, count, ...inserts) {
     const rows = this._rows;
     const nRows = rows.length;
+    // get a list of merged cells affected by this change. Merge cells that are in the start or after the start range.
+    const mergeItems = Object.values(this._merges).filter(
+      merge => merge.model.left > start || (merge.left < start && merge.model.right > start)
+    );
     if (inserts.length > 0) {
       // must iterate over all rows whether they exist yet or not
       for (let i = 0; i < nRows; i++) {
@@ -280,6 +288,29 @@ class Worksheet {
         row.splice.apply(row, rowArguments);
       }
     } else {
+      // Iterate through mergeItems and move the merge to one column left
+      mergeItems.forEach(mergeItem => {
+        const {model, range} = mergeItem;
+        const leftCol = model.left < start ? model.left : model.left - count;
+        const rightCol = model.right - count;
+        const topRow = model.top;
+        const bottomRow = model.bottom;
+        const newMergeRange = `${this.getColumn(leftCol).letter}${topRow}:${
+          this.getColumn(rightCol).letter
+        }${bottomRow}`;
+        this.unMergeCells(range);
+        if (model.left > start) {
+          // Move cell value in the top left corner before merging
+          const sourceCell = this.getCell(topRow, model.left);
+          const targetCell = this.getCell(topRow, leftCol);
+          targetCell.value = sourceCell.value;
+          sourceCell.value = null;
+          targetCell.style = sourceCell.style;
+          sourceCell.style = {};
+        }
+
+        this.mergeCells(newMergeRange);
+      });
       // nothing to insert, so just splice all rows
       this._rows.forEach(r => {
         if (r) {
@@ -529,7 +560,9 @@ class Worksheet {
             if (cell._value.constructor.name === 'MergeValue') {
               const cellToBeMerged = this.getRow(cell._row._number + nInserts).getCell(colNumber);
               const prevMaster = cell._value._master;
-              const newMaster = this.getRow(prevMaster._row._number + nInserts).getCell(prevMaster._column._number);
+              const newMaster = this.getRow(prevMaster._row._number + nInserts).getCell(
+                prevMaster._column._number
+              );
               cellToBeMerged.merge(newMaster);
             }
           });
@@ -762,12 +795,15 @@ class Worksheet {
       };
       if (options && 'spinCount' in options) {
         // force spinCount to be integer >= 0
-        options.spinCount = Number.isFinite(options.spinCount) ? Math.round(Math.max(0, options.spinCount)) : 100000;
+        options.spinCount = Number.isFinite(options.spinCount)
+          ? Math.round(Math.max(0, options.spinCount))
+          : 100000;
       }
       if (password) {
         this.sheetProtection.algorithmName = 'SHA-512';
         this.sheetProtection.saltValue = Encryptor.randomBytes(16).toString('base64');
-        this.sheetProtection.spinCount = options && 'spinCount' in options ? options.spinCount : 100000; // allow user specified spinCount
+        this.sheetProtection.spinCount =
+          options && 'spinCount' in options ? options.spinCount : 100000; // allow user specified spinCount
         this.sheetProtection.hashValue = Encryptor.convertPasswordToHash(
           password,
           'SHA512',
@@ -846,13 +882,17 @@ Please leave feedback at https://github.com/exceljs/exceljs/discussions/2575`
   // Deprecated
   get tabColor() {
     // eslint-disable-next-line no-console
-    console.trace('worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor');
+    console.trace(
+      'worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor'
+    );
     return this.properties.tabColor;
   }
 
   set tabColor(value) {
     // eslint-disable-next-line no-console
-    console.trace('worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor');
+    console.trace(
+      'worksheet.tabColor property is now deprecated. Please use worksheet.properties.tabColor'
+    );
     this.properties.tabColor = value;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
I was facing an issue when we use spliceColumns when there are merged cells in the sliced column range. Which resulted in breaking the excel output as the row.slice was deleting the values of the merged cells and wasn't moving the other merged cells position as per the deleted columns.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Create a sheet with 2 different merged cells in a row then try to add a spliceColumns line after that with out any insert. Let's say if the spliceColumn is in first merged range it will delete the merged cell and doesn't move the other merged cell range, as per the old code. This fix is applied at row.splice as this method is responsible for moving the cells when we call spliceColumns.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Related to source code (for typings update)
To fix the above issue I have filtered all the merged cells which start before the spliceColumn range and end after and also the merged cells which starts are ends after the column range (ignored the merged cells which starts and ends before the splice range as they don't get effected).

```
const mergeItems = this.worksheet._merges.filter(
      merge => merge.model.left > start || (merge.model.left < start && merge.model.right > start)
    );
```
The above code will pull the mergedCells from the sheet. Then only in case of remove cells we iterate through the merged Cells and move them count range. When there is no insert I have added a logic to move the merged cells.
```
mergeItems.forEach(mergeItem => {
        const {model, range} = mergeItem;
        const leftCol = model.left < start ? model.left : model.left - count;
        const rightCol = model.right - count;
        const topRow = model.top;
        const bottomRow = model.bottom;
        const newMergeRange = `${this.getColumn(leftCol).letter}${topRow}:${
          this.getColumn(rightCol).letter
        }${bottomRow}`;
        this.unMergeCells(range);
        if (model.left > start) {
          // Move cell value in the top left corner before merging
          const sourceCell = this.getCell(topRow, model.left);
          const targetCell = this.getCell(topRow, leftCol);
          targetCell.value = sourceCell.value;
          sourceCell.value = null;
          targetCell.style = sourceCell.style;
          sourceCell.style = {};
        }

        this.mergeCells(newMergeRange);
      });
```
Also ignored the row.splice if the dest cell is merged with the following code
```
if (cDst.isMerged) {
            return;
          }
```

Other than the above rest of all are the format changes from prettier
<!-- List with permalink into source code to prove that changes are true -->
