### PR TITLE
fix: table column style bug and addTable colum type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1836,7 +1836,7 @@ export interface TableColumnProperties {
 	/**
 	 * Styles applied to the column
 	 */
-	style: Partial<Style>;
+	style?: Partial<Style>;
 }
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1832,6 +1832,11 @@ export interface TableColumnProperties {
 	  * Optional formula for custom functions
 	  */
 	totalsRowFormula?: string;
+
+	/**
+	 * Styles applied to the column
+	 */
+	style: Partial<Style>;
 }
 
 

--- a/lib/doc/table.js
+++ b/lib/doc/table.js
@@ -183,7 +183,7 @@ class Table {
     const assignStyle = (cell, style) => {
       if (style) {
         Object.keys(style).forEach(key => {
-          cell[key] = style[key];
+          cell.style[key] = style[key];
         });
       }
     };

--- a/test/test-table.js
+++ b/test/test-table.js
@@ -1,4 +1,4 @@
-const Excel = require('../lib/exceljs.nodejs.js');
+const Excel = require('../lib/exceljs.nodejs');
 const HrStopwatch = require('./utils/hr-stopwatch');
 
 const [, , filename] = process.argv;
@@ -47,6 +47,7 @@ ws.addTable({
       totalsRowFunction: 'max',
       filterButton: true,
       totalsRowResult: 8,
+      style: {numFmt: '0.00%'},
     },
     {
       name: 'Word',
@@ -54,7 +55,10 @@ ws.addTable({
       style: {font: {bold: true, name: 'Comic Sans MS'}},
     },
   ],
-  rows: words.map((word, i) => [new Date(+today + (86400 * i)), i, word]),
+  rows: words.map((word, i) => {
+    const additionalDays = 86400 * i;
+    return [new Date(today + additionalDays), i, word];
+  }),
 });
 
 const stopwatch = new HrStopwatch();


### PR DESCRIPTION
## Summary
A continuation of https://github.com/exceljs/exceljs/pull/1907 with an added test and updates typings to allow for styles to be set in the column definition of a table


## Test plan

In a project that is using exceljs as a dependency, i took the following steps:

1. Navigated to `node_modules/exceljs/lib/doc/table.js`
2. Made the change in the PR here `cell[key] = style[key]` => `cell.style[key] = style[key]`
3. Added a column with the following format to my table `{ name: 'Column Name', totalsRowFunction: 'sum', style: { numFmt: '0.00%' } }`
4. Regenerated the report and confirmed that the colum was formatted as `0.00%'`

## Related to source code (for typings update)
https://github.com/exceljs/exceljs/blob/master/lib/doc/table.js#L183-L189