### PR TITLE
add: add color field in data bar cf in typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1078,6 +1078,7 @@ export interface DataBarRuleType extends ConditionalFormattingBaseRule {
 	axisPosition?: 'auto' | 'middle' | 'none';
 	direction?: 'context' | 'leftToRight' | 'rightToLeft';
 	cfvo?: Cvfo[];
+  color?: Partial<Color>;
 }
 
 export type ConditionalFormattingRule = ExpressionRuleType | CellIsRuleType | Top10RuleType | AboveAverageRuleType | ColorScaleRuleType | IconSetRuleType


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

While working with the Databar feature in Conditional formating (cf), I encountered an issue related to the color property in TypeScript typings.

## Purpose of Change

I identified a deficiency in the existing TypeScript typings for the Databar feature in conditional formatting. The current Databar interface lacks a 'color' type, which is essential for specifying colors within the Databar. This gap in the typings prevents developers from accurately representing and utilizing color settings in Databar conditions.

## Changes Made

I have made a targeted change to the TypeScript type file associated with the Databar interface. Specifically, I introduced the 'color' type, which aligns with the functionality of assigning colors in Databar conditions.

## Details

- **Issue Faced:** The absence of the 'color' type in the Databar interface impairs the ability to set colors for Databar conditions in conditional formatting.

- **Solution Proposed:** Addition of the 'color' type to the Databar interface in the TypeScript type file.

## Testing

I have conducted thorough testing to ensure that the introduced 'color' type integrates seamlessly with the Databar feature and does not introduce any regressions.

## Related to Source Code (for typings update)

I made a change in the TypeScript type file, specifically in the Databar interface, to address the color property's absence, enabling developers to utilize color settings in Databar conditions effectively.

<!-- Feel free to connect me. -->
