### PR TITLE
Worksheet protect(): fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1084,7 +1084,7 @@ export type ConditionalFormattingRule = ExpressionRuleType | CellIsRuleType | To
 	| ContainsTextRuleType | TimePeriodRuleType | DataBarRuleType;
 
 
-export type RowValues = CellValue[] | { [key: string]: CellValue } | undefined | null; 
+export type RowValues = CellValue[] | { [key: string]: CellValue } | undefined | null;
 
 export interface ConditionalFormattingOptions {
 	ref: string;
@@ -1196,14 +1196,14 @@ export interface Worksheet {
 
 	/**
 	 * Tries to find and return row for row no, else undefined
-	 * 
+	 *
 	 * @param row The 1-index row number
 	 */
 	findRow(row: number): Row | undefined;
 
 	/**
 	 * Tries to find and return rows for row no start and length, else undefined
-	 * 
+	 *
 	 * @param start The 1-index starting row number
 	 * @param length The length of the expected array
 	 */
@@ -1352,7 +1352,8 @@ export interface Worksheet {
 	/**
 	 * Worksheet protection
 	 */
-	protect(password: string, options: Partial<WorksheetProtection>): Promise<void>;
+	protect(password?: string, options?: Partial<WorksheetProtection>): Promise<void>;
+
 	unprotect(): void;
 
 	/**

--- a/spec/integration/workbook/workbook.spec.js
+++ b/spec/integration/workbook/workbook.spec.js
@@ -1103,4 +1103,39 @@ describe('Workbook', () => {
         });
     });
   });
+
+  describe('Protect', () => {
+    it('works without passing any arguments', async () => {
+      const wb = new ExcelJS.Workbook();
+      const ws1 = wb.addWorksheet('Protected');
+      expect(ws1.name).to.equal('Protected');
+      ws1.getCell('A1').value = 'Protected';
+
+      const ws2 = wb.addWorksheet();
+      expect(ws2.name).to.match(/sheet\d+/);
+      ws2.getCell('A1').value = ws2.name;
+
+      wb.addWorksheet('Unprotected');
+
+      ws1.getCell('A1').protection = {
+        locked: true,
+      };
+
+      await ws1.protect();
+
+      return wb.xlsx
+        .writeFile(TEST_XLSX_FILE_NAME)
+        .then(() => {
+          const wb2 = new ExcelJS.Workbook();
+          return wb2.xlsx.readFile(TEST_XLSX_FILE_NAME);
+        })
+        .then(wb2 => {
+          expect(wb2.getWorksheet('Protected')).to.be.ok();
+          expect(wb2.getWorksheet('Unprotected')).to.be.ok();
+          expect(wb2.getWorksheet('Protected').sheetProtection.sheet).to.equal(
+            true
+          );
+        });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Calling `worksheet.protect()` without arguments works just fine ([code checks the existence of both password and options](https://github.com/exceljs/exceljs/blob/master/lib/doc/worksheet.js#L756-L786)); fixing types so TS won't complain :)

## Test plan

I added a basic test, let me know if you would like to make any change.