### PR TITLE
Fix for Bug 2678: Table creation allows empty array of rows

### DIFF
--- a/lib/doc/table.js
+++ b/lib/doc/table.js
@@ -151,7 +151,7 @@ class Table {
     };
     assert(table.ref, 'Table must have ref');
     assert(table.columns, 'Table must have column definitions');
-    assert(table.rows, 'Table must have row definitions');
+    assert(table.rows && table.rows.length, 'Table must have row definitions');
 
     table.tl = colCache.decodeAddress(table.ref);
     const {row, col} = table.tl;

--- a/spec/unit/doc/worksheet-table-error.spec.js
+++ b/spec/unit/doc/worksheet-table-error.spec.js
@@ -1,0 +1,57 @@
+const Excel = verquire('exceljs');
+
+function addTable(ws, tableOptions) {
+  return ws.addTable(tableOptions);
+}
+
+describe('Error handling of table creation', () => {
+  let tableOptions;
+
+  beforeEach(() => {
+    // Resuse this object for multiple tests of table creation error handling
+    tableOptions = {
+      name: 'TestTable',
+      ref: 'A1',
+      headerRow: true,
+      totalsRow: true,
+      style: {
+        theme: 'TableStyleDark3',
+        showRowStripes: true,
+      },
+      columns: [
+        {name: 'Date', totalsRowLabel: 'Totals', filterButton: true},
+        {
+          name: 'Id',
+          totalsRowFunction: 'max',
+          filterButton: true,
+          totalsRowResult: 4,
+        },
+        {
+          name: 'Word',
+          filterButton: false,
+          style: {font: {bold: true, name: 'Comic Sans MS'}},
+        },
+      ],
+      rows: [
+        [new Date('2020-01-01'), 1, 'one'],
+        [new Date('2020-01-02'), 2, 'two'],
+        [new Date('2020-01-03'), 3, 'three'],
+      ],
+    };
+  });
+
+  it('should create a table without error when all required options are provided', () => {
+    const wb = new Excel.Workbook();
+    const ws = wb.addWorksheet('blort');
+    expect(() => addTable(ws, tableOptions)).to.not.throw();
+  });
+
+  it('should throw an error when adding a table with empty rows', () => {
+    const wb = new Excel.Workbook();
+    const ws = wb.addWorksheet('blort');
+    tableOptions.rows = []; // empty rows, shouldn't be allowed
+    expect(() => addTable(ws, tableOptions)).to.throw(
+      'Table must have row definitions'
+    );
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
This is a fix for Bug #2678. It adds an additional test condition to the validate() method on the Table class, to ensure that the rows array is actually populated.

## Test plan

The PR includes a unit test file with the appropriate tests to confirm a complete set of table options works fine, while not populating the rows array results in a run-time error. I've run the full set of Mocha unit tests in my local system and all tests passed.

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
One line of code changed in [Table.js](https://github.com/exceljs/exceljs/blob/master/lib/doc/table.js)