### PR TITLE
Fix error saving files when streaming using autofilter and sheet protection

### DIFF
--- a/lib/stream/xlsx/worksheet-writer.js
+++ b/lib/stream/xlsx/worksheet-writer.js
@@ -231,8 +231,8 @@ class WorksheetWriter {
       this._writeOpenSheetData();
     }
     this._writeCloseSheetData();
-    this._writeAutoFilter();
     this._writeSheetProtection();
+    this._writeAutoFilter();
     this._writeMergeCells();
 
     // for some reason, Excel can't handle dimensions at the bottom of the file

--- a/lib/stream/xlsx/worksheet-writer.js
+++ b/lib/stream/xlsx/worksheet-writer.js
@@ -232,6 +232,7 @@ class WorksheetWriter {
     }
     this._writeCloseSheetData();
     this._writeAutoFilter();
+    this._writeSheetProtection();
     this._writeMergeCells();
 
     // for some reason, Excel can't handle dimensions at the bottom of the file
@@ -240,7 +241,6 @@ class WorksheetWriter {
     this._writeHyperlinks();
     this._writeConditionalFormatting();
     this._writeDataValidations();
-    this._writeSheetProtection();
     this._writePageMargins();
     this._writePageSetup();
     this._writeBackground();


### PR DESCRIPTION
## Summary
Hello. Recently I came across a problem when, when recording a file in a stream, you set a password and autofilter, the file breaks and cannot be opened. Having slightly changed the source code, I was able to solve this problem by changing the order in which data was written to the file.
## Test plan
The code below on the current version of the library creates a file that does not open and causes an error
![image](https://github.com/exceljs/exceljs/assets/14010816/a5637509-dbd7-4651-8280-27562583bee7)

After commenting 
```ts
worksheet.autoFilter = { from: 'A1', to: 'C1' };
```
or
```ts
await worksheet.protect('test', { formatColumns: true, formatRows: true, autoFilter: true, pivotTables: true });
```
out the error disappears

```ts
import { stream } from 'exceljs';

async function main() {
    const workbook = new stream.xlsx.WorkbookWriter({ filename: './test.xlsx', useStyles: true });

    const worksheet = workbook.addWorksheet('test');
    worksheet.addRow([3, 'Sam', new Date()]).commit();
    worksheet.autoFilter = { from: 'A1', to: 'C1' };
    await worksheet.protect('test', { formatColumns: true, formatRows: true, autoFilter: true, pivotTables: true });
    worksheet.commit();
    await workbook.commit();
}
main();

```
Changes to the pull request correct this error.

