### PR TITLE
[Breaking] Replace unzipper with yauzl-promise

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 17.x, 18.x, 19.x, 20.x]
+        node-version: [16.x, 17.x, 18.x, 19.x, 20.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -2,9 +2,9 @@ const fs = require('fs');
 const {EventEmitter} = require('events');
 const {PassThrough, Readable} = require('readable-stream');
 const nodeStream = require('stream');
-const unzip = require('unzipper');
+const yauzl = require('yauzl-promise');
+const {pipeline} = require('stream/promises');
 const tmp = require('tmp');
-const iterateStream = require('../../utils/iterate-stream');
 const parseSax = require('../../utils/parse-sax');
 
 const StyleManager = require('../../xlsx/xform/style/styles-xform');
@@ -35,12 +35,20 @@ class WorkbookReader extends EventEmitter {
     this.styles.init();
   }
 
-  _getStream(input) {
+  async _getBufferOrFilename(input) {
+    // Zip files are not streamable files, but for backwards compatibility
+    // support it. In reality, if a stream is supplied, it will be loaded in
+    // memory.
     if (input instanceof nodeStream.Readable || input instanceof Readable) {
-      return input;
+      return new Promise((resolve, reject) => {
+        const _buf = [];
+        input.on('data', chunk => _buf.push(chunk));
+        input.on('end', () => resolve(Buffer.concat(_buf)));
+        input.on('error', err => reject(err));
+      });
     }
     if (typeof input === 'string') {
-      return fs.createReadStream(input);
+      return input;
     }
     throw new Error(`Could not recognise input: ${input}`);
   }
@@ -78,74 +86,84 @@ class WorkbookReader extends EventEmitter {
 
   async *parse(input, options) {
     if (options) this.options = options;
-    const stream = (this.stream = this._getStream(input || this.input));
-    const zip = unzip.Parse({forceStream: true});
-    stream.pipe(zip);
+    // Input may be a stream or a string indicating a filename. Convert the
+    // stream into a buffer, and keep the string as a string.
+    const bufFilename = await this._getBufferOrFilename(input || this.input);
 
-    // worksheets, deferred for parsing after shared strings reading
-    const waitingWorkSheets = [];
+    const zip = typeof bufFilename === 'string' ? await yauzl.open(bufFilename) : await yauzl.fromBuffer(bufFilename);
 
-    for await (const entry of iterateStream(zip)) {
-      let match;
-      let sheetNo;
-      switch (entry.path) {
-        case '_rels/.rels':
-          break;
-        case 'xl/_rels/workbook.xml.rels':
-          await this._parseRels(entry);
-          break;
-        case 'xl/workbook.xml':
-          await this._parseWorkbook(entry);
-          break;
-        case 'xl/sharedStrings.xml':
-          yield* this._parseSharedStrings(entry);
-          break;
-        case 'xl/styles.xml':
-          await this._parseStyles(entry);
-          break;
-        default:
-          if (entry.path.match(/xl\/worksheets\/sheet\d+[.]xml/)) {
-            match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
-            sheetNo = match[1];
-            if (this.sharedStrings && this.workbookRels) {
-              yield* this._parseWorksheet(iterateStream(entry), sheetNo);
-            } else {
-              // create temp file for each worksheet
-              await new Promise((resolve, reject) => {
-                tmp.file((err, path, fd, tempFileCleanupCallback) => {
-                  if (err) {
-                    return reject(err);
-                  }
-                  waitingWorkSheets.push({sheetNo, path, tempFileCleanupCallback});
+    try {
+      // worksheets, deferred for parsing after shared strings reading
+      const waitingWorkSheets = [];
 
-                  const tempStream = fs.createWriteStream(path);
-                  tempStream.on('error', reject);
-                  entry.pipe(tempStream);
-                  return tempStream.on('finish', () => {
-                    return resolve();
+      for await (const entry of zip) {
+        const readStream = await entry.openReadStream();
+        let match;
+        let sheetNo;
+        switch (entry.filename) {
+          case '_rels/.rels':
+            break;
+          case 'xl/_rels/workbook.xml.rels':
+            await this._parseRels(readStream);
+            break;
+          case 'xl/workbook.xml':
+            await this._parseWorkbook(readStream);
+            break;
+          case 'xl/sharedStrings.xml':
+            yield* this._parseSharedStrings(readStream);
+            break;
+          case 'xl/styles.xml':
+            await this._parseStyles(readStream);
+            break;
+          default:
+            if (entry.filename.match(/xl\/worksheets\/sheet\d+[.]xml/)) {
+              match = entry.filename.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
+              sheetNo = match[1];
+              if (this.sharedStrings && this.workbookRels) {
+                yield* this._parseWorksheet(readStream, sheetNo);
+              } else {
+                // create temp file for each worksheet
+                await new Promise((resolve, reject) => {
+                  tmp.file((err, path, fd, tempFileCleanupCallback) => {
+                    if (err) {
+                      return reject(err);
+                    }
+                    waitingWorkSheets.push({sheetNo, path, tempFileCleanupCallback});
+
+                    const tempStream = fs.createWriteStream(path);
+                    tempStream.on('error', reject);
+                    // Pipe the zip entry into a temporary file.
+                    pipeline(readStream, tempStream);
+                    return tempStream.on('finish', () => {
+                      return resolve();
+                    });
                   });
                 });
-              });
+              }
+            } else if (entry.filename.match(/xl\/worksheets\/_rels\/sheet\d+[.]xml.rels/)) {
+              match = entry.filename.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
+              sheetNo = match[1];
+              yield* this._parseHyperlinks(readStream, sheetNo);
             }
-          } else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d+[.]xml.rels/)) {
-            match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
-            sheetNo = match[1];
-            yield* this._parseHyperlinks(iterateStream(entry), sheetNo);
-          }
-          break;
+            break;
+        }
       }
-      entry.autodrain();
-    }
 
-    for (const {sheetNo, path, tempFileCleanupCallback} of waitingWorkSheets) {
-      let fileStream = fs.createReadStream(path);
-      // TODO: Remove once node v8 is deprecated
-      // Detect and upgrade old fileStreams
-      if (!fileStream[Symbol.asyncIterator]) {
-        fileStream = fileStream.pipe(new PassThrough());
+      for (const {sheetNo, path, tempFileCleanupCallback} of waitingWorkSheets) {
+        let fileStream = fs.createReadStream(path);
+        // TODO: Remove once node v8 is deprecated
+        // Detect and upgrade old fileStreams
+        if (!fileStream[Symbol.asyncIterator]) {
+          fileStream = fileStream.pipe(new PassThrough());
+        }
+        yield* this._parseWorksheet(fileStream, sheetNo);
+        tempFileCleanupCallback();
       }
-      yield* this._parseWorksheet(fileStream, sheetNo);
-      tempFileCleanupCallback();
+    } finally {
+      // Close file-descriptor if it's a file.
+      if (zip.close) {
+        zip.close();
+      }
     }
   }
 
@@ -157,14 +175,14 @@ class WorkbookReader extends EventEmitter {
 
   async _parseRels(entry) {
     const xform = new RelationshipsXform();
-    this.workbookRels = await xform.parseStream(iterateStream(entry));
+    this.workbookRels = await xform.parseStream(entry);
   }
 
   async _parseWorkbook(entry) {
     this._emitEntry({type: 'workbook'});
 
     const workbook = new WorkbookXform();
-    await workbook.parseStream(iterateStream(entry));
+    await workbook.parseStream(entry);
 
     this.properties = workbook.map.workbookPr;
     this.model = workbook.model;
@@ -186,7 +204,7 @@ class WorkbookReader extends EventEmitter {
     let richText = [];
     let index = 0;
     let font = null;
-    for await (const events of parseSax(iterateStream(entry))) {
+    for await (const events of parseSax(entry)) {
       for (const {eventType, value} of events) {
         if (eventType === 'opentag') {
           const node = value;
@@ -286,7 +304,7 @@ class WorkbookReader extends EventEmitter {
     this._emitEntry({type: 'styles'});
     if (this.options.styles === 'cache') {
       this.styles = new StyleManager();
-      await this.styles.parseStream(iterateStream(entry));
+      await this.styles.parseStream(entry);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/exceljs/exceljs.git"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=16"
   },
   "main": "./excel.js",
   "browser": "./dist/exceljs.min.js",

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
     "readable-stream": "^3.6.0",
     "saxes": "^5.0.1",
     "tmp": "^0.2.0",
-    "unzipper": "^0.10.11",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "yauzl-promise": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
## Summary

Unzipper had a transitive dependency on a package that does not have a license. This means that every user is potentially violating the law in using it. Personally, I think it's better to stick to following it, so I've replaced the root dependency with a modern (and updated) alternative.

However, yauzl-promise requires node v16 and above! I think there's some bikeshedding to be done for whether this is worthwhile or not.

This is a breaking change, as the minimum node engine has been bumped from v10 to v16. Note that the engines before this claimed v8 was supported, but the transitive dependencies required >=10. I believe this is an okay change to merge, as anything older than v18 is not supported anymore. https://endoflife.date/nodejs

## Test plan

The test suite passes locally (on my machine).

Resolves https://github.com/exceljs/exceljs/issues/2686