### PR TITLE
fix: inefficient merge check for large amount of merged cells within …

### DIFF
--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -613,20 +613,23 @@ class Worksheet {
   }
 
   _mergeCellsInternal(dimensions, ignoreStyle) {
-    // check cells aren't already merged
-    _.each(this._merges, merge => {
-      if (merge.intersects(dimensions)) {
-        throw new Error('Cannot merge already merged cells');
-      }
-    });
-
     // apply merge
     const master = this.getCell(dimensions.top, dimensions.left);
+    // check cells aren't already merged
+    if (master.isMerged()) {
+      throw new Error('Cannot merge already merged cells');
+    }
+    let cell;
     for (let i = dimensions.top; i <= dimensions.bottom; i++) {
       for (let j = dimensions.left; j <= dimensions.right; j++) {
         // merge all but the master cell
         if (i > dimensions.top || j > dimensions.left) {
-          this.getCell(i, j).merge(master, ignoreStyle);
+          cell = this.getCell(i, j);
+          // check cells aren't already merged
+          if (cell.isMerged()) {
+            throw new Error('Cannot merge already merged cells');
+          }
+          cell.merge(master, ignoreStyle);
         }
       }
     }


### PR DESCRIPTION
When there are a lot of merged cells within a worksheet, e.g. 30.000 merged cells (e.g. the same 2 cells are merged in every row in a 30.000 row table), parsing mergeCells is increasingly slow. This is due to the inefficient conflict check within `_mergeCellsInternal(dimensions, ignoreStyle)` in worksheet.js.

## Summary

My motivation is to let these big files function, rather than load forever. I believe the massive check is unnecessary. Rather than check every other merged range, can't you just see if any of the cells in the new range are merged, and then throw an error?

I do not know the original motivation for the `throw new Error('Cannot merge already merged cells');` error, and whether it always breaks the program, or if the error is caught somewhere. Hopefully the new implementation is much more efficient without breaking anything.

## Test plan

See the issue https://github.com/exceljs/exceljs/issues/2689
I have attached a file there. Loading that file goes from 1.5 minutes in node JS to only seconds. In the browser that file just will not load.

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
