### PR TITLE
Issue: style.xml has [Object object] as formatCode

### DIFF
--- a/lib/xlsx/xform/style/styles-xform.js
+++ b/lib/xlsx/xform/style/styles-xform.js
@@ -345,6 +345,11 @@ class StylesXform extends BaseXform {
 
   addDxfStyle(style) {
     if (style.numFmt) {
+      // Check if numFmt is not a string and if instead it is an object with the formatCode
+      // extract the formatCode out as the numFmt
+      if (!(style.numFmt instanceof String) && style.numFmt.hasOwnProperty("formatCode")) {
+          style.numFmt = style.numFmt.formatCode;
+      }
       // register numFmtId to use it during dxf-xform rendering
       style.numFmtId = this._addNumFmtStr(style.numFmt);
     }

--- a/lib/xlsx/xform/style/styles-xform.js
+++ b/lib/xlsx/xform/style/styles-xform.js
@@ -345,8 +345,8 @@ class StylesXform extends BaseXform {
 
   addDxfStyle(style) {
     if (style.numFmt) {
-      // Check if numFmt is not a string and if instead it is an object with the formatCode
-      // extract the formatCode out as the numFmt
+      // Check if numFmt is not a string and if it is an object with the formatCode property.
+      // If both are true, set numFmt's value equal to the value of the formatCode property.
       if (!(style.numFmt instanceof String) && style.numFmt.hasOwnProperty("formatCode")) {
           style.numFmt = style.numFmt.formatCode;
       }


### PR DESCRIPTION
## Summary

Somehow the excel file is in a state where exceljs does not handle extracting the numFmt of a DXF conditional format properly and instead has it set to an object.

This results in the generate style.xml file to have a formatCode of `[Object object]` inside which corrupts the file.

This fix is to check if the numFmt is of the appropriate string type and if not, corrects it by extracting the formatCode before moving forward on the prepare step of writing.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This is the test Excel file I used which has a conditional format on A1:C1 which conditional changes the fill color to yellow and the format to be a custom number format if A1 equals "NO".

[CF1.xlsx](https://github.com/exceljs/exceljs/files/14351092/CF1.xlsx)

I setup a simple `main.js` to read in the test Excel file and write a new file `temp.xlsx`.

```
const ExcelJS = require("exceljs");
const workbook = new ExcelJS.Workbook();
workbook.xlsx.readFile("CF1.xlsx").then(() => {
  workbook.xlsx.writeFile("temp.xlsx");
});
```

With current master branch the result of opening the generated file is this:

<img width="605" alt="original_error" src="https://github.com/exceljs/exceljs/assets/5776125/0e4bbd66-2740-4b79-b3a7-230d75ad88da">
<img width="377" alt="original_error_repair_report" src="https://github.com/exceljs/exceljs/assets/5776125/8b7e47b1-3ac4-4631-9644-e7bdab80eecc">

After repair conditional formatting is removed.

<img width="418" alt="original_error_cf_removed" src="https://github.com/exceljs/exceljs/assets/5776125/97ef75a5-542a-4b55-a2aa-acaf0d584101">

Screenshot of xl/style.xml file with the error:

<img width="398" alt="original_xml_file" src="https://github.com/exceljs/exceljs/assets/5776125/b0835d47-67ad-4e91-b72d-0f03f4e95058">


After the fix the file is generated properly and conditional formatting works as expected.

<img width="448" alt="after_fix" src="https://github.com/exceljs/exceljs/assets/5776125/eb8226b6-4b4c-46eb-b15e-b45f377454c5">

Screenshot of xl/style.xml with fixed format code:

<img width="654" alt="after_fix_xml_file" src="https://github.com/exceljs/exceljs/assets/5776125/d724c554-3dac-41e1-b85d-a41e0fc184d9">


## Related to source code (for typings update)

I'm not really sure what is supposed to go here.
