### PR TITLE
Don't render empty rich text substrings

### DIFF
--- a/lib/xlsx/xform/strings/rich-text-xform.js
+++ b/lib/xlsx/xform/strings/rich-text-xform.js
@@ -35,6 +35,9 @@ class RichTextXform extends BaseXform {
 
   render(xmlStream, model) {
     model = model || this.model;
+    if (model.text === '') {
+      return;
+    }
 
     xmlStream.openNode('r');
     if (model.font) {


### PR DESCRIPTION
Excel can't open file with empty rich text substrings. For instance, this code:

```
const workbook = new Workbook();
const worksheet = workbook.addWorksheet('Test');

worksheet.getCell('C1').value = {
	richText: [
		{font: {size: 10, color: {argb: 'ffff0000'}}, text: 'Test 1'},
		{font: {size: 10, color: {argb: 'ff00ff00'}}, text: ''},       // Empty string
		{font: {size: 10, color: {argb: 'ff0000ff'}}, text: 'Test 2'},
	],
};

workbook.xlsx.writeFile('test.xlsx');
```

creates a file for which Excel will throw the following error:

> We found a problem with some content in 'test.xlsx'. Do you want us to try to recover as much as we can? If you trust the source of this workbook, click Yes.

Not rendering the empty substring in the XML solves the problem, without changing the appearance of the resulting rich text.