### PR TITLE
fix #2751 - Csv reading - cells filled with spaces only are converted to 0 

### DIFF
--- a/lib/csv/csv.js
+++ b/lib/csv/csv.js
@@ -58,6 +58,9 @@ class CSV {
           if (datum === '') {
             return null;
           }
+          if(datum.trim() === '') {
+            return datum
+          }
           const datumNumber = Number(datum);
           if (!Number.isNaN(datumNumber) && datumNumber !== Infinity) {
             return datumNumber;


### PR DESCRIPTION

## Summary

Fix #2751 

## Test plan

```javascript
const wb = new ExcelJS.Workbook();
wb.csv.read(Stream.Readable.from('firstValue;    ;secondValue', { parserOptions: { delimiter: ';' } })
const ws = wb.worksheets[templateInfo.worksheet];

const row1 = ws.getRow(1);
const cell12 = row1.getCell(2);
console.log('cell: 1,2: ', cell12.value); // Displays:  '    ' 
```

## Related to source code (for typings update)

(https://github.com/exceljs/exceljs/blob/master/lib/csv/csv.js#L58)
