### PR TITLE
:memo: Fix errors in document about image embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2042,24 +2042,24 @@ Fractions of cells can be specified by using floating point numbers, e.g. the mi
 ```javascript
 // insert an image over part of B2:D6
 worksheet.addImage(imageId2, {
-  tl: { col: 1.5, row: 1.5 },
-  br: { col: 3.5, row: 5.5 }
+  tl: new Anchor(worksheet, { col: 1.5, row: 1.5 }),
+  br: new Anchor(worksheet, { col: 3.5, row: 5.5 }),
 });
 ```
 
 The cell range can also have the property 'editAs' which will control how the image is anchored to the cell(s)
 It can have one of the following values:
 
-| Value     | Description |
-| --------- | ----------- |
-| undefined | It specifies the image will be moved and sized with cells |
-| oneCell   | This is the default. Image will be moved with cells but not sized |
-| absolute  | Image will not be moved or sized with cells |
+| Value    | Description |
+| -------- | ----------- |
+| twoCell  | It specifies the image will be moved and sized with cells |
+| oneCell  | This is the default. Image will be moved with cells but not sized |
+| absolute | Image will not be moved or sized with cells |
 
 ```javascript
 ws.addImage(imageId, {
-  tl: { col: 0.1125, row: 0.4 },
-  br: { col: 2.101046875, row: 3.4 },
+  tl: new Anchor(worksheet, { col: 0.1125, row: 0.4 }),
+  br: new Anchor(worksheet, { col: 2.101046875, row: 3.4 }),
   editAs: 'oneCell'
 });
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -1186,14 +1186,14 @@ ws.getCell('B1').note.protection = {
 它可以具有以下值之一：
 
 ```javascript
-ws.getCell('B1').note.editAs = 'twoCells'
+ws.getCell('B1').note.editAs = 'twoCell'
 ```
 
 | Value     | Description |
 | --------- | ----------- |
-| twoCells | 它指定注释的大小、位置随单元格而变 |
-| oneCells   | 它指定注释的大小固定，位置随单元格而变 |
-| absolute  | 这是默认值，它指定注释的大小、位置均固定 |
+| twoCell | 它指定注释的大小、位置随单元格而变 |
+| oneCell | 这是默认值，它指定注释的大小固定，位置随单元格而变 |
+| absolute | 它指定注释的大小、位置均固定 |
 
 ## 表格[⬆](#目录)<!-- Link generated with jump2header -->
 
@@ -1973,8 +1973,8 @@ worksheet.addImage(imageId2, 'B2:D6');
 ```javascript
 // 在 B2:D6 的一部分上插入图像
 worksheet.addImage(imageId2, {
-  tl: { col: 1.5, row: 1.5 },
-  br: { col: 3.5, row: 5.5 }
+  tl: new Anchor(worksheet, { col: 1.5, row: 1.5 }),
+  br: new Anchor(worksheet, { col: 3.5, row: 5.5 }),
 });
 ```
 
@@ -1988,8 +1988,8 @@ worksheet.addImage(imageId2, {
 
 ```javascript
 ws.addImage(imageId, {
-  tl: { col: 0.1125, row: 0.4 },
-  br: { col: 2.101046875, row: 3.4 },
+  tl: new Anchor(worksheet, { col: 0.1125, row: 0.4 }),
+  br: new Anchor(worksheet, { col: 2.101046875, row: 3.4 }),
   editAs: 'oneCell'
 });
 ```


### PR DESCRIPTION
## Summary

In the current documentation, the Chinese and English documents are inconsistent. One uses oneCell, the other uses oneCells. One says absolute is the default value, the other says oneCell is the default value. In addition, passing undefined in the English document is invalid because it will match the default value oneCell.

Fixed the inconsistency between the image embedding part in the document and the actual code. Please refer to the following Issue:

https://github.com/exceljs/exceljs/issues/2730

https://github.com/exceljs/exceljs/issues/1747

Please also refer to the documentation from Microsoft:

https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.spreadsheet.editasvalues?view=openxml-3.0.1

## Test plan
From my project code, it works correctly:

![image](https://github.com/exceljs/exceljs/assets/9296576/583fcc0b-d283-41dc-a3e8-b88e46043455)
