### PR TITLE
Fix corrupted file with conditional formatting and hyperlinks

### DIFF
--- a/lib/stream/xlsx/worksheet-writer.js
+++ b/lib/stream/xlsx/worksheet-writer.js
@@ -237,8 +237,8 @@ class WorksheetWriter {
     // for some reason, Excel can't handle dimensions at the bottom of the file
     // this._writeDimensions();
 
-    this._writeHyperlinks();
     this._writeConditionalFormatting();
+    this._writeHyperlinks();
     this._writeDataValidations();
     this._writeSheetProtection();
     this._writePageMargins();


### PR DESCRIPTION
## Summary

I faced the issue with stream writer creating corrupted file. Through some experiments and inspecting differences between the file created by the library and handmade file using Microsoft Excel I found out that the corruption appears when you use conditional formatting together with hyperlinks. The issue is that the order of blocks in the worksheet is wrong. This pull request solves this issue.

## Test plan

First we create file using Microsoft Excel with links and some conditional formatting eg. `=MOD(ROW();2)=0` to color every odd row:
![image](https://github.com/user-attachments/assets/d6e0138d-21a5-4d6d-8d1c-5a8ea2b713b3)
Then we inspect the file and see that the order in sheet is: first conditional formatting, second hyperlinks
![image](https://github.com/user-attachments/assets/f9eab3d3-07a8-4bfe-a1b3-1cfc5c470e1e)
After that we create similar file using the library:
```js
const ExcelJS = require("exceljs");
const fs = require("fs");

const fileStream = fs.createWriteStream("output.xlsx");

const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
  stream: fileStream,
  useSharedStrings: false,
  useStyles: true,
});
const worksheet = workbook.addWorksheet("Sheet1");
for (let index = 0; index < 4; index++) {
  worksheet.addRow([
    "test",
    {
      text: "Link",
      hyperlink: "https://google.com",
      tooltip: "https://google.com",
    },
  ]);
}

worksheet.addConditionalFormatting({
  ref: `A1:B4`,
  rules: [
    {
      priority: 1,
      type: "expression",
      formulae: ["MOD(ROW(),2)=0"],
      style: {
        fill: {
          type: "pattern",
          pattern: "solid",
          bgColor: "FFEDEDED",
        },
      },
    },
  ],
});

worksheet.commit();
workbook.commit();

```

If we open the resulting file with Excel we see the error:

![image](https://github.com/user-attachments/assets/2d54f3d4-a2ed-4e2a-9890-ebc55ff36b85)

If we inspect the underlying xml file we see that the order is different:

![image](https://github.com/user-attachments/assets/32b444c3-34cd-4cc9-a2cd-84e4e9a9316c)

So then we can change the order in `worksheet-writer.js` and try the script again:

![image](https://github.com/user-attachments/assets/1980bdd5-2b71-4739-ad92-4017e54b7f14)

The file generates successfully and opens in Excel:

![image](https://github.com/user-attachments/assets/403672bc-46d8-40a6-b1db-d8c781714e0e)
