### PR TITLE
place pageSetUpPr in the end of sheetPr to fix getting broken xlsx do…

### DIFF
--- a/lib/xlsx/xform/sheet/sheet-properties-xform.js
+++ b/lib/xlsx/xform/sheet/sheet-properties-xform.js
@@ -9,8 +9,8 @@ class SheetPropertiesXform extends BaseXform {
 
     this.map = {
       tabColor: new ColorXform('tabColor'),
-      pageSetUpPr: new PageSetupPropertiesXform(),
       outlinePr: new OutlinePropertiesXform(),
+      pageSetUpPr: new PageSetupPropertiesXform(),
     };
   }
 
@@ -25,8 +25,8 @@ class SheetPropertiesXform extends BaseXform {
 
       let inner = false;
       inner = this.map.tabColor.render(xmlStream, model.tabColor) || inner;
-      inner = this.map.pageSetUpPr.render(xmlStream, model.pageSetup) || inner;
       inner = this.map.outlinePr.render(xmlStream, model.outlineProperties) || inner;
+      inner = this.map.pageSetUpPr.render(xmlStream, model.pageSetup) || inner;
 
       if (inner) {
         xmlStream.closeNode();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->



## Summary

Fix for this bug
https://github.com/exceljs/exceljs/issues/1348

## Test plan


    const workbook = new ExcelJS.Workbook();

    workbook.creator = 'Me';

    const worksheet = workbook.addWorksheet('My Sheet', {
        pageSetup: {paperSize: 9, orientation: 'landscape', fitToPage: true, fitToHeight: 0}
    });

    const filename = "result.xlsx"
    workbook.xlsx.writeFile(filename);

This code won't work in the 4.4.0 version, you will get an error while opening xlsx file
The problem code is **fitToPage: true**

## Related to source code (for typings update)

https://github.com/exceljs/exceljs/blob/5bed18b45e824f409b08456b59b87430ded023ab/lib/xlsx/xform/sheet/sheet-properties-xform.js#L28
