### PR TITLE
Update xlsx.js to allow compat with non office generated files.

### DIFF
--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -348,8 +348,14 @@ class XLSX {
           case 'docProps/app.xml': {
             const appXform = new AppXform();
             const appProperties = await appXform.parseStream(stream);
-            model.company = appProperties.company;
-            model.manager = appProperties.manager;
+            if ( !appProperties ) {
+              console.error("Invalid properties data. Filled with placeholder data")
+              model.company = 'PlaceholderCompany'
+              model.manager = 'PlaceholderManager'
+            } else {
+              model.company = appProperties.company;
+              model.manager = appProperties.manager;
+            }
             break;
           }
 


### PR DESCRIPTION
## Summary

Some xlsx files generated by 3rd party applications do not come with valid property data in the document formatting. The changes to xlsx.js in this patch seek to allow compatibility with these out of spec files while informing the user of the invalid data.

A simple 'fix' to a problem that shouldn't exist but for some reason 3rd party applications prefer to discard design specifications.

## Test plan

I tested this on one machine running Ubuntu 24.04. I would love to test it more but I have one laptop. I did test against files from 3 3rd party clients (fortiEDR collector export, apache openoffice calc, and libreoffice calc) and 1 file made in excel.

