### PR TITLE
feat: support web-native streams for read/write methods

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,6 @@ jobs:
             v1-npm-
       - run: npm install
       - run: npm install typescript
-      - run: tsc index.d.ts
+      - run: tsc exceljs.d.ts
         env:
           CI: true

--- a/exceljs.d.ts
+++ b/exceljs.d.ts
@@ -1481,7 +1481,7 @@ export interface Xlsx {
 	 * read from a stream
 	 * @param stream
 	 */
-	read(stream: import('stream').Stream, options?: Partial<XlsxReadOptions>): Promise<Workbook>;
+	read(stream: import('stream').Stream | ReadableStream<Uint8Array>, options?: Partial<XlsxReadOptions>): Promise<Workbook>;
 
 	/**
 	 * load from an array buffer
@@ -1502,7 +1502,7 @@ export interface Xlsx {
 	/**
 	 * write to a stream
 	 */
-	write(stream: import('stream').Stream, options?: Partial<XlsxWriteOptions>): Promise<void>;
+	write(stream: import('stream').Stream | WritableStream<Uint8Array>, options?: Partial<XlsxWriteOptions>): Promise<void>;
 }
 
 // https://c2fo.github.io/fast-csv/docs/parsing/options

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -721,6 +721,22 @@ class XLSX {
     options = options || {};
     const {model} = this.workbook;
     const zip = new ZipStream.ZipWriter(options.zip);
+
+    // eslint-disable-next-line no-undef
+    if (typeof WritableStream === 'function' && stream instanceof WritableStream) {
+      const writer = stream.getWriter();
+
+      stream = {
+        write(chunk, cb) {
+          writer.write(chunk).then(cb);
+        },
+        end() {
+          // fire-and-forget
+          writer.close();
+        },
+      };
+    }
+
     zip.pipe(stream);
 
     this.prepareModel(model, options);

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -249,6 +249,28 @@ class XLSX {
     // Detect and upgrade old streams
     if (!stream[Symbol.asyncIterator] && stream.pipe) {
       stream = stream.pipe(new PassThrough());
+    } else if (
+      typeof ReadableStream === 'function' &&
+      // eslint-disable-next-line no-undef
+      stream instanceof ReadableStream &&
+      !stream[Symbol.asyncIterator]
+    ) {
+      // minimal ponyfill for ReadableStream.@@asyncIterator, which is not available in Safari as of 2024-12-17
+      stream = (async function* (s) {
+        const reader = s.getReader();
+
+        while (true) {
+          /* eslint-disable no-await-in-loop */
+          const chunk = await reader.read();
+          if (chunk.done) {
+            await reader.cancel();
+            reader.releaseLock();
+            return;
+          }
+
+          yield chunk.value;
+        }
+      })(stream);
     }
     const chunks = [];
     for await (const chunk of stream) {

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -727,12 +727,14 @@ class XLSX {
       const writer = stream.getWriter();
 
       stream = {
-        write(chunk, cb) {
-          writer.write(chunk).then(cb);
+        async write(chunk, cb) {
+          await writer.ready;
+          await writer.write(chunk);
+          cb();
         },
-        end() {
-          // fire-and-forget
-          writer.close();
+        async end() {
+          await writer.ready;
+          await writer.close();
         },
       };
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "./excel.js",
   "browser": "./dist/exceljs.min.js",
-  "types": "./index.d.ts",
+  "types": "./exceljs.d.ts",
   "files": [
     "dist",
     "lib",
@@ -26,12 +26,12 @@
     "README.md",
     "README_zh.md",
     "index.ts",
-    "index.d.ts"
+    "exceljs.d.ts"
   ],
   "scripts": {
     "test": "npm run test:full",
     "test:es5": "export EXCEL_BUILD=es5 && npm run test:full",
-    "test:full": "npm run build && npm run test:unit && npm run test:integration && npm run test:end-to-end && npm run test:jasmine",
+    "test:full": "npm run build && npm run test:unit && npm run test:integration && npm run test:end-to-end && npm run test:jasmine && npm run test:typescript",
     "test:version": "npm run build && npm run test:unit && npm run test:integration && npm run test:end-to-end && npm run test:browser && npm run test:dist",
     "test:all": "npm run test:native && npm run test:es5",
     "test:native": "npm run test:full",

--- a/spec/typescript/exceljs.spec.ts
+++ b/spec/typescript/exceljs.spec.ts
@@ -1,7 +1,10 @@
 import 'regenerator-runtime/runtime';
 
 import { expect } from 'chai';
-import ExcelJS from '../../index';
+import _ExcelJS from '../../index';
+import type * as ExcelJSModule from '../../exceljs';
+
+const ExcelJS = _ExcelJS as unknown as typeof ExcelJSModule;
 
 describe('typescript', () => {
   it('can create and buffer xlsx', async () => {
@@ -15,7 +18,7 @@ describe('typescript', () => {
 
     const wb2 = new ExcelJS.Workbook();
     await wb2.xlsx.load(buffer);
-    const ws2 = wb2.getWorksheet('blort');
+    const ws2 = wb2.getWorksheet('blort')!;
     expect(ws2.getCell('A1').value).to.equal(7);
   });
   it('can create and stream xlsx', async () => {
@@ -24,17 +27,21 @@ describe('typescript', () => {
     ws.getCell('A1').value = 7;
 
     const wb2 = new ExcelJS.Workbook();
-    const stream = wb2.xlsx.createInputStream();
-    await wb.xlsx.write(stream);
-    stream.end();
+    const transform = new TransformStream<Uint8Array, Uint8Array>();
 
-    await new Promise((resolve, reject) => {
-      stream.on('done', () => {
-        const ws2 = wb2.getWorksheet('blort');
-        expect(ws2.getCell('A1').value).to.equal(7);
-        resolve();
-      });
-      stream.on('error', reject);
-    })
+    // type checking - code should compile due to `@ts-expect-error`
+    // but will not run as function is never invoked
+    void (() => {
+      // @ts-expect-error
+      wb.xlsx.write({});
+    });
+
+    await Promise.all([
+      wb.xlsx.write(transform.writable),
+      wb2.xlsx.read(transform.readable),
+    ]);
+
+    const ws2 = wb2.getWorksheet('blort')!;
+    expect(ws2.getCell('A1').value).to.equal(7);
   });
 });

--- a/spec/unit/xlsx/write-writable-stream.spec.js
+++ b/spec/unit/xlsx/write-writable-stream.spec.js
@@ -1,28 +1,49 @@
 const ExcelJS = verquire('exceljs');
 
 describe('Web-native streams', () => {
-  it('can stream xlsx through a web-native TransformStream (readable/writable pair)', async function() {
-    // eslint-disable-next-line no-use-before-define
-    const TransformStream =
-      typeof global.TransformStream === 'function'
-        ? global.TransformStream
-        : null;
+  // eslint-disable-next-line no-use-before-define
+  const {TransformStream} = global;
+  const skip = typeof TransformStream !== 'function';
 
-    if (!TransformStream) {
-      this.skip();
-    }
-
+  async function testTransformStream(transform) {
     const wb = new ExcelJS.Workbook();
     const ws = wb.addWorksheet('blort');
     ws.getCell('A1').value = 7;
 
     const wb2 = new ExcelJS.Workbook();
-    const transform = new TransformStream();
 
-    await wb.xlsx.write(transform.writable);
-    await wb2.xlsx.read(transform.readable);
+    await Promise.all([
+      wb.xlsx.write(transform.writable),
+      wb2.xlsx.read(transform.readable),
+    ]);
 
     const ws2 = wb2.getWorksheet('blort');
     expect(ws2.getCell('A1').value).to.equal(7);
+  }
+
+  it('can stream xlsx through a web-native TransformStream (readable/writable pair)', async function() {
+    if (skip) {
+      this.skip();
+    }
+
+    await testTransformStream(new TransformStream());
+  });
+
+  it('handles ReadableStream lacking @@asyncIterator (Safari compat)', async function() {
+    if (skip) {
+      this.skip();
+    }
+
+    const safariTransformStream = new TransformStream();
+
+    Object.defineProperty(
+      safariTransformStream.readable,
+      Symbol.asyncIterator,
+      {
+        value: undefined,
+      }
+    );
+
+    await testTransformStream(safariTransformStream);
   });
 });

--- a/spec/unit/xlsx/write-writable-stream.spec.js
+++ b/spec/unit/xlsx/write-writable-stream.spec.js
@@ -1,0 +1,28 @@
+const ExcelJS = verquire('exceljs');
+
+describe('Web-native streams', () => {
+  it('can stream xlsx through a web-native TransformStream (readable/writable pair)', async function() {
+    // eslint-disable-next-line no-use-before-define
+    const TransformStream =
+      typeof global.TransformStream === 'function'
+        ? global.TransformStream
+        : null;
+
+    if (!TransformStream) {
+      this.skip();
+    }
+
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('blort');
+    ws.getCell('A1').value = 7;
+
+    const wb2 = new ExcelJS.Workbook();
+    const transform = new TransformStream();
+
+    await wb.xlsx.write(transform.writable);
+    await wb2.xlsx.read(transform.readable);
+
+    const ws2 = wb2.getWorksheet('blort');
+    expect(ws2.getCell('A1').value).to.equal(7);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/exceljs/exceljs/issues/1228
Fixes https://github.com/exceljs/exceljs/issues/2753

## Summary

Add support for `read(<web-native ReadableStream instance>)` and `write(<web-native WritableStream instance>)`. Both have excellent support in modern browsers and are also implemented in NodeJS, Deno, and Bun.

## Test plan

See `spec/unit/xlsx/write-writable-stream.spec.js` and changes to `spec/typescript/exceljs.spec.ts`.

## Related to source code (for typings update)

N/A (updated typings are reflected in diffs to runtime code + tests).