### PR TITLE
fix boolean read val error like as ：<strike val="0"/>

### DIFF
--- a/lib/xlsx/xform/simple/boolean-xform.js
+++ b/lib/xlsx/xform/simple/boolean-xform.js
@@ -17,7 +17,7 @@ class BooleanXform extends BaseXform {
 
   parseOpen(node) {
     if (node.name === this.tag) {
-      this.model = true;
+      this.model = node.attributes.val !== "0";
     }
   }
 


### PR DESCRIPTION
Fix strike tag parsing

The current code doesn't handle <strike val="0"/> correctly. This PR fixes it by:
- Adding support for val attribute in strike tag
- Setting model to false when val="0"
- Setting model to true for <strike/> and other cases

