### PR TITLE
Introducing styleCacheMode. Up to 3x performance improvements on xlsx…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,7 @@
   "parserOptions": {
     "sourceType": "script"
   },
-  "extends": [
-    "airbnb-base",
-    "prettier",
-    "plugin:node/recommended"
-  ],
+  "extends": ["airbnb-base", "prettier", "plugin:node/recommended"],
   "env": {
     "es6": true,
     "mocha": true,
@@ -14,36 +10,72 @@
   },
   "rules": {
     "arrow-parens": ["error", "as-needed"],
+    "import/extensions": ["off"],
     "class-methods-use-this": ["off"],
-    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline", "imports": "always-multiline", "exports": "always-multiline", "functions": "never"}],
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never"
+      }
+    ],
     "default-case": ["off"],
     "func-names": ["off", "never"],
     "global-require": ["off"],
-    "max-len": ["error", {"code": 120, "ignoreComments": true, "ignoreStrings": true}],
+    "max-len": [
+      "error",
+      { "code": 120, "ignoreComments": true, "ignoreStrings": true }
+    ],
     "no-console": ["error", { "allow": ["warn"] }],
     "no-continue": ["off"],
-    "no-mixed-operators": ["error", {"allowSamePrecedence": true}],
+    "no-mixed-operators": ["error", { "allowSamePrecedence": true }],
     "no-multi-assign": ["off"],
     "no-param-reassign": ["off"],
     "no-path-concat": ["off"],
     "no-plusplus": ["off"],
     "no-prototype-builtins": ["off"],
-    "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
+    "no-restricted-syntax": [
+      "error",
+      "ForInStatement",
+      "LabeledStatement",
+      "WithStatement"
+    ],
     "no-return-assign": ["off"],
     "no-trailing-spaces": ["error", { "skipBlankLines": true }],
-    "no-underscore-dangle": ["off", { "allowAfterThis": true, "allowAfterSuper": true }],
-    "no-unused-vars": ["error", {"vars": "all", "args": "none", "ignoreRestSiblings": true}],
-    "no-use-before-define": ["error", { "variables": false, "classes": false, "functions": false }],
-    "node/no-unsupported-features/es-syntax": ["error", {"version": ">=10.0.0","ignores": []}],
+    "no-underscore-dangle": [
+      "off",
+      { "allowAfterThis": true, "allowAfterSuper": true }
+    ],
+    "no-unused-vars": [
+      "error",
+      { "vars": "all", "args": "none", "ignoreRestSiblings": true }
+    ],
+    "no-use-before-define": [
+      "error",
+      { "variables": false, "classes": false, "functions": false }
+    ],
+    "node/no-unsupported-features/es-syntax": [
+      "error",
+      { "version": ">=10.0.0", "ignores": [] }
+    ],
     "node/process-exit-as-throw": ["off"],
     "object-curly-spacing": ["error", "never"],
-    "object-property-newline": ["off", { "allowMultiplePropertiesPerLine": true }],
-    "prefer-destructuring": ["warn", {"array": false, "object": true}],
+    "object-property-newline": [
+      "off",
+      { "allowMultiplePropertiesPerLine": true }
+    ],
+    "prefer-destructuring": ["warn", { "array": false, "object": true }],
     "prefer-object-spread": ["off"],
     "prefer-rest-params": ["off"],
     "quotes": ["error", "single"],
     "semi": ["error", "always"],
-    "space-before-function-paren": ["error", {"anonymous": "never", "named": "never", "asyncArrow": "always"}],
+    "space-before-function-paren": [
+      "error",
+      { "anonymous": "never", "named": "never", "asyncArrow": "always" }
+    ],
     "strict": ["off"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -867,6 +867,12 @@ const cell = worksheet.getCell('C3');
 // Modify/Add individual cell
 cell.value = new Date(1968, 5, 1);
 
+// Override cell style with style provided.
+cell.style = {fill: {...}};
+
+// Updates cell style with a "merge" of the styles from the style provided, the row style and the Column style.
+cell.addStyle({fill: {...}});
+
 // query a cell's type
 expect(cell.type).toEqual(Excel.ValueType.Date);
 
@@ -2376,6 +2382,7 @@ The constructor takes an optional options object with the following fields:
 | filename         | If stream not specified, this field specifies the path to a file to write the XLSX workbook to. |
 | useSharedStrings | Specifies whether to use shared strings in the workbook. Default is `false`. |
 | useStyles        | Specifies whether to add style information to the workbook. Styles can add some performance overhead. Default is `false`. |
+| stylesCacheMode  | Specifies the styles cacheing mode for performance tunning. Default is WEAK_MAP for backwards compatibility. </br></br>WEAK_MAP: has poor performance if the style objects are not re-used. When you mix Col, row and cell styles a different style object is created per cell and performance deteriorates to being worse then with No Cache. </br>JSON_MAP: uses JSON.stringify as the key for a style map. The perfromance can be similar to WeakMap or up to 2.5x faster. </br>FAST_MAP: uses a custom function to encode a style to use it as a key on cache. Should be preferred over JSON_MAP. The encoded style is much smaller and faster to generate then a JSON. The encoding function is designed so two distinct styles can never be encoded to the same key, but if this happens use JSON_MAP instead.</br>NO_CACHE: In some cases NO_CACHE can be faster than WEAK_MAP. In rare cases it maybe faster than JSON_MAP.
 | zip              | [Zip options](https://www.archiverjs.com/global.html#ZipOptions) that ExcelJS internally passes to [Archiver](https://github.com/archiverjs/node-archiver). Default is `undefined`. |
 
 If neither stream nor filename is specified in the options, the workbook writer will create a StreamBuf object

--- a/benchmark-styles.js
+++ b/benchmark-styles.js
@@ -1,0 +1,140 @@
+/* eslint-disable no-console, no-unused-vars */
+const ExcelJS = require('./lib/exceljs.nodejs');
+
+const runs = 3;
+const N_ROWS = 1 * 200 * 1000;
+const profileMap = {};
+
+function generateRecords(n) {
+  const records = [];
+  for (let i = 0; i < n; i++) {
+    records.push({
+      id: '12313',
+      myString1: 'asdasdas',
+      myString2: 'asdasdasasdasdasdasdasdadsad',
+      myNumericString: '234234',
+      amount: 3425.34,
+      myDate1: '2004-01-01',
+      myDate2: '2005-01-01',
+    });
+  }
+  return records;
+}
+
+async function writeToExcel(records, stylesCacheMode) {
+  const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
+    filename: `benchmark-styles-${stylesCacheMode}.xlsx`,
+    useStyles: stylesCacheMode !== 'NO_STYLES',
+    stylesCacheMode,
+  });
+
+  const columns = [
+    {header: 'ID', key: 'id', width: 22},
+    {header: 'My String 1', key: 'myString1', width: 22},
+    {header: 'My Numeric String', key: 'myNumericString', width: 22},
+    {header: 'My Strign 2', key: 'myString2', width: 22},
+    {header: 'Amount', key: 'amount', width: 15, style: {numFmt: '0.0'}},
+    {header: 'My Date 1', key: 'myDate1', width: 15, style: {numFmt: 'yyyy-mm-dd'}},
+    {header: 'My Date 2', key: 'myDate2', width: 15, style: {numFmt: 'yyyy-mm-dd'}},
+  ];
+
+  await createSheet(workbook, 1, columns, records, stylesCacheMode);
+
+  await workbook.commit();
+}
+
+async function createSheet(workbook, i, columns, records) {
+  const worksheet = workbook.addWorksheet(`Sheet${i}`);
+  worksheet.columns = columns;
+
+  for (const record of records) {
+    const row = worksheet.addRow(record);
+    row.eachCell(cell => {
+      cell.style = {
+        border: {top: {style: 'thin'}, left: {style: 'thin'}, bottom: {style: 'thin'}, right: {style: 'thin'}},
+        font: {name: 'Times New Roman', size: 10},
+      };
+    });
+    row.commit();
+  }
+
+  await worksheet.commit();
+}
+
+(async () => {
+  try {
+    const records = generateRecords(N_ROWS);
+    await runProfiling('NO_STYLES', async () => {
+      await writeToExcel(records, 'NO_STYLES');
+    });
+    await runProfiling('WEAK_MAP', async () => {
+      await writeToExcel(records);
+    });
+    await runProfiling('JSON_MAP', async () => {
+      await writeToExcel(records, 'JSON_MAP');
+    });
+    await runProfiling('FAST_MAP', async () => {
+      await writeToExcel(records, 'FAST_MAP');
+    });
+    await runProfiling('NO_CACHE', async () => {
+      await writeToExcel(records, 'NO_CACHE');
+    });
+    const baseline = profileMap.NO_STYLES.reduce((a, v) => a + v, 0) / runs / 1000;
+    console.log('\n\nMode\t\tAVG (s)\t\tx NO_STYLES');
+    Object.keys(profileMap).forEach(key => {
+      const prof = profileMap[key];
+      const average = prof.reduce((a, v) => a + v, 0) / runs / 1000;
+      const x = average / baseline;
+      console.log(`${key}\t\t${average.toFixed(2)}\t\t${x.toFixed(2)}`);
+    });
+    // console.log(profileMap)
+  } catch (err) {
+    console.error(err);
+    process.exit(1); // eslint-disable-line no-process-exit
+  }
+})();
+
+async function runProfiling(name, run) {
+  console.log('');
+  console.log('####################################################');
+  console.log(`WARMUP: Current memory usage: ${currentMemoryUsage({runGarbageCollector: true})} MB`);
+  console.log(`WARMUP: ${name} profiling started`);
+  const warmupStartTime = Date.now();
+  await run();
+  console.log(`WARMUP: ${name} profiling finished in ${Date.now() - warmupStartTime}ms`);
+  console.log(
+    `WARMUP: Current memory usage (before GC): ${currentMemoryUsage({
+      runGarbageCollector: false,
+    })} MB`
+  );
+  console.log(`WARMUP: Current memory usage (after GC): ${currentMemoryUsage({runGarbageCollector: true})} MB`);
+
+  const prof = profileMap[name] || [];
+  profileMap[name] = prof;
+  for (let i = 1; i <= runs; i += 1) {
+    console.log('');
+    console.log('####################################################');
+    console.log(`RUN ${i}: ${name} profiling started`);
+    const startTime = Date.now();
+    await run(); // eslint-disable-line no-await-in-loop
+    const duration = Date.now() - startTime;
+    prof.push(duration);
+    console.log(`RUN ${i}: ${name} profiling finished in ${duration}ms`);
+
+    console.log(
+      `RUN ${i}: Current memory usage (before GC): ${currentMemoryUsage({
+        runGarbageCollector: false,
+      })} MB`
+    );
+    console.log(
+      `RUN ${i}: Current memory usage (after GC): ${currentMemoryUsage({
+        runGarbageCollector: true,
+      })} MB`
+    );
+  }
+}
+
+function currentMemoryUsage({runGarbageCollector}) {
+  if (runGarbageCollector) global.gc();
+  return Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) / 100;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1935,6 +1935,18 @@ export namespace stream {
 			 * Styles can add some performance overhead. Default is false
 			 */
 			useStyles: boolean;
+
+			/**
+			 * Specifies the cacheing mode for styles for performance fine tunning. Default is WEAK_MAP for backwards compatibility.
+			 * WEAK_MAP: has poor performance if the style objects are not re-used. When you mix Col, row and cell styles a different style object 
+			 * is created per cell and performance deteriorates to being worse then with No Cache.
+			 * JSON_MAP: uses JSON.stringify as the key for a style map. The perfromance can be similar to WeakMap or up to 2.5x faster. 
+			 * FAST_MAP: uses a custom function to encode a style to use it as a key on cache. Should be preferred over JSON_MAP
+			 * The encoded style is much smaller and faster to generate then a JSON. 
+			 * The encoding function is designed so two distinct styles can never be encoded to the same key, but if this happens use JSON_MAP instead.
+			 * NO_CACHE: In some cases NO_CACHE can be faster than WEAK_MAP. In rare cases it maybe faster than JSON_MAP.
+			 */
+			stylesCacheMode: 'WEAK_MAP' | 'JSON_MAP' | 'FAST_MAP' | 'NO_CACHE';
 		}
 
 		interface ArchiverZipOptions {

--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -24,7 +24,7 @@ class Cell {
     // TODO: lazy evaluation of this._value
     this._value = Value.create(Cell.Types.Null, this);
 
-    this.style = this._mergeStyle(row.style, column.style, {});
+    this.style = this._mergeStyle(column.style, row.style, {});
 
     this._mergeCount = 0;
   }
@@ -47,6 +47,10 @@ class Cell {
   }
 
   // =========================================================================
+  addStyle(style) {
+    this.style = this._mergeStyle(this._column.style, this._row.style, style);
+  }
+
   // Styles stuff
   get numFmt() {
     return this.style.numFmt;
@@ -96,25 +100,25 @@ class Cell {
     this.style.protection = value;
   }
 
-  _mergeStyle(rowStyle, colStyle, style) {
+  _mergeStyle(colStyle, rowStyle, cellStyle) {
+    const style = {};
     const numFmt = (rowStyle && rowStyle.numFmt) || (colStyle && colStyle.numFmt);
-    if (numFmt) style.numFmt = numFmt;
+    if (numFmt) style.numFmt = cellStyle.numFmt || numFmt;
 
     const font = (rowStyle && rowStyle.font) || (colStyle && colStyle.font);
-    if (font) style.font = font;
+    if (font) style.font = cellStyle.font || font;
 
     const alignment = (rowStyle && rowStyle.alignment) || (colStyle && colStyle.alignment);
-    if (alignment) style.alignment = alignment;
+    if (alignment) style.alignment = cellStyle.alignment || alignment;
 
     const border = (rowStyle && rowStyle.border) || (colStyle && colStyle.border);
-    if (border) style.border = border;
+    if (border) style.border = cellStyle.border || border;
 
     const fill = (rowStyle && rowStyle.fill) || (colStyle && colStyle.fill);
-    if (fill) style.fill = fill;
+    if (fill) style.fill = cellStyle.fill || fill;
 
     const protection = (rowStyle && rowStyle.protection) || (colStyle && colStyle.protection);
-    if (protection) style.protection = protection;
-
+    if (protection) style.protection = cellStyle.protection || protection;
     return style;
   }
 
@@ -178,7 +182,7 @@ class Cell {
     if (this.type === Cell.Types.Merge) {
       this._value.release();
       this._value = Value.create(Cell.Types.Null, this);
-      this.style = this._mergeStyle(this._row.style, this._column.style, {});
+      this.style = this._mergeStyle(this._column.style, this._row.style, {});
     }
   }
 
@@ -862,8 +866,7 @@ class FormulaValue {
     if (!this._translatedFormula && this.model.sharedFormula) {
       const {worksheet} = this.cell;
       const master = worksheet.findCell(this.model.sharedFormula);
-      this._translatedFormula =
-        master && slideFormula(master.formula, master.address, this.model.address);
+      this._translatedFormula = master && slideFormula(master.formula, master.address, this.model.address);
     }
     return this._translatedFormula;
   }

--- a/lib/stream/xlsx/workbook-writer.js
+++ b/lib/stream/xlsx/workbook-writer.js
@@ -34,7 +34,7 @@ class WorkbookWriter {
     this.sharedStrings = new SharedStrings();
 
     // style manager
-    this.styles = options.useStyles ? new StylesXform(true) : new StylesXform.Mock(true);
+    this.styles = options.useStyles ? new StylesXform(true, options.stylesCacheMode) : new StylesXform.Mock(true);
 
     // defined names
     this._definedNames = new DefinedNames();
@@ -138,8 +138,7 @@ class WorkbookWriter {
     // shared string handling
     // in fact, it's even possible to switch it mid-sheet
     options = options || {};
-    const useSharedStrings =
-      options.useSharedStrings !== undefined ? options.useSharedStrings : this.useSharedStrings;
+    const useSharedStrings = options.useSharedStrings !== undefined ? options.useSharedStrings : this.useSharedStrings;
 
     if (options.tabColor) {
       // eslint-disable-next-line no-console

--- a/lib/utils/style-fast-serialize.js
+++ b/lib/utils/style-fast-serialize.js
@@ -1,0 +1,312 @@
+// style.js
+
+const L1_SEPARATOR = '|';
+const L2_SEPARATOR = '>';
+const L3_SEPARATOR = '<';
+const L4_SEPARATOR = ':';
+const L5_SEPARATOR = ';';
+const L6_SEPARATOR = '!';
+const L7_SEPARATOR = '~';
+const L8_SEPARATOR = '^';
+
+function encodeBoolean(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (value === true) {
+    return '1';
+  }
+  if (value === false) {
+    return '0';
+  }
+  return value ? 'true' : 'false';
+}
+
+function addSerializedBooleanProperty(obj, property, value) {
+  if (value === '1') obj[property] = true;
+  if (value === '0') obj[property] = false;
+}
+
+function serializeColor(color) {
+  if (!color) return '';
+  return `${color.argb || ''}${L8_SEPARATOR}${color.theme !== undefined ? color.theme : ''}`;
+}
+
+function serializeBorder(border) {
+  if (!border) return '';
+  return `${border.style || ''}${L4_SEPARATOR}${serializeColor(border.color)}`;
+}
+
+function serializeFill(fill) {
+  if (!fill) return '';
+  if (fill.type === 'pattern') {
+    return (
+      `p${L3_SEPARATOR}${fill.pattern}${L4_SEPARATOR}${serializeColor(fill.fgColor)}` +
+      `${L4_SEPARATOR}${serializeColor(fill.bgColor)}`
+    );
+  }
+  if (fill.type === 'gradient') {
+    const stops = fill.stops
+      .map(stop => `${stop.position}${L7_SEPARATOR}${serializeColor(stop.color)}`)
+      .join(L6_SEPARATOR);
+
+    if (fill.gradient === 'angle') {
+      return `ga${L3_SEPARATOR}${fill.degree}${L4_SEPARATOR}${stops}`;
+    }
+    return `gp${L3_SEPARATOR}${fill.center.left}${L5_SEPARATOR}${fill.center.top}${L4_SEPARATOR}${stops}`;
+  }
+  return '';
+}
+
+function serializeFont(font) {
+  return [
+    font.name || '',
+    font.size || '',
+    font.family || '',
+    font.scheme || '',
+    font.charset || '',
+    serializeColor(font.color),
+    encodeBoolean(font.bold),
+    encodeBoolean(font.italic),
+    font.underline || '',
+    font.vertAlign || '',
+    encodeBoolean(font.strike),
+    encodeBoolean(font.outline),
+  ].join(L3_SEPARATOR);
+}
+
+function serializeBorders(border) {
+  const up = border.diagonal && border.diagonal.up;
+  const down = border.diagonal && border.diagonal.down;
+
+  return [
+    serializeBorder(border.top),
+    serializeBorder(border.left),
+    serializeBorder(border.bottom),
+    serializeBorder(border.right),
+    serializeBorder(border.diagonal),
+    encodeBoolean(up),
+    encodeBoolean(down),
+  ].join(L3_SEPARATOR);
+}
+
+function serializeAlignment(alignment) {
+  return [
+    alignment.horizontal || '',
+    alignment.vertical || '',
+    encodeBoolean(alignment.wrapText),
+    encodeBoolean(alignment.shrinkToFit),
+    alignment.indent || '',
+    alignment.readingOrder || '',
+    alignment.textRotation !== undefined ? alignment.textRotation : '',
+  ].join(L3_SEPARATOR);
+}
+
+function serializeProtection(protection) {
+  return [encodeBoolean(protection.locked), encodeBoolean(protection.hidden)].join(L3_SEPARATOR);
+}
+
+function serializeStyle(style) {
+  const parts = [];
+
+  if (style.font) parts.push(`f${L2_SEPARATOR}${serializeFont(style.font)}`);
+  if (style.border) parts.push(`b${L2_SEPARATOR}${serializeBorders(style.border)}`);
+  if (style.alignment) parts.push(`a${L2_SEPARATOR}${serializeAlignment(style.alignment)}`);
+  if (style.fill) parts.push(`fi${L2_SEPARATOR}${serializeFill(style.fill)}`);
+  if (style.protection) parts.push(`p${L2_SEPARATOR}${serializeProtection(style.protection)}`);
+  if (style.numFmt) parts.push(`n${L2_SEPARATOR}${style.numFmt}`);
+
+  return parts.join(L1_SEPARATOR);
+}
+
+function deserializeColor(str) {
+  if (!str) return undefined;
+  const [argb, theme] = str.split(L8_SEPARATOR);
+  const color = {};
+  if (argb) color.argb = argb;
+  if (theme !== '') color.theme = Number(theme);
+  return Object.keys(color).length ? color : undefined;
+}
+
+function deserializeBorder(str) {
+  if (!str) return undefined;
+  const [style, colorStr] = str.split(L4_SEPARATOR);
+  const border = {};
+  if (style) border.style = style;
+  const color = deserializeColor(colorStr);
+  if (color) border.color = color;
+  return Object.keys(border).length ? border : undefined;
+}
+
+function deserializeFill(str) {
+  if (!str) return undefined;
+
+  const [type, rest] = str.split(L3_SEPARATOR);
+  if (type === 'p') {
+    const [pattern, fgColorStr, bgColorStr] = rest.split(L4_SEPARATOR);
+    const fill = {
+      type: 'pattern',
+      pattern,
+    };
+    const fgColor = deserializeColor(fgColorStr);
+    const bgColor = deserializeColor(bgColorStr);
+    if (fgColor) fill.fgColor = fgColor;
+    if (bgColor) fill.bgColor = bgColor;
+    return fill;
+  }
+  if (type === 'ga' || type === 'gp') {
+    const [degreeOrCenter, stopsStr] = rest.split(L4_SEPARATOR);
+    const stops = stopsStr.split(L6_SEPARATOR).map(stop => {
+      const [position, colorStr] = stop.split(L7_SEPARATOR);
+      return {position: Number(position), color: deserializeColor(colorStr)};
+    });
+
+    if (type === 'ga') {
+      return {
+        type: 'gradient',
+        gradient: 'angle',
+        degree: Number(degreeOrCenter),
+        stops,
+      };
+    }
+    const [left, top] = degreeOrCenter.split(L5_SEPARATOR).map(Number);
+    return {
+      type: 'gradient',
+      gradient: 'path',
+      center: {left, top},
+      stops,
+    };
+  }
+  return undefined;
+}
+
+function deserializeFont(values) {
+  const [name, size, family, scheme, charset, color, bold, italic, underline, vertAlign, strike, outline] = values;
+  const font = {};
+
+  if (name) font.name = name;
+  if (size) font.size = Number(size);
+  if (family) font.family = Number(family);
+  if (scheme) font.scheme = scheme;
+  if (charset) font.charset = Number(charset);
+
+  const deserializedColor = deserializeColor(color);
+  if (deserializedColor) font.color = deserializedColor;
+
+  addSerializedBooleanProperty(font, 'bold', bold);
+  addSerializedBooleanProperty(font, 'italic', italic);
+
+  if (underline === 'true') {
+    font.underline = true;
+  } else if (underline === 'false') {
+    font.underline = false;
+  } else if (underline) {
+    font.underline = underline;
+  }
+
+  if (vertAlign) font.vertAlign = vertAlign;
+  addSerializedBooleanProperty(font, 'strike', strike);
+  addSerializedBooleanProperty(font, 'outline', outline);
+
+  return font;
+}
+
+function deserializeBorders(values) {
+  const [top, left, bottom, right, diagonal, up, down] = values;
+  const borders = {};
+
+  if (top !== '') {
+    const topBorder = deserializeBorder(top);
+    if (topBorder) borders.top = topBorder;
+  }
+
+  if (left !== '') {
+    const leftBorder = deserializeBorder(left);
+    if (leftBorder) borders.left = leftBorder;
+  }
+
+  if (bottom !== '') {
+    const bottomBorder = deserializeBorder(bottom);
+    if (bottomBorder) borders.bottom = bottomBorder;
+  }
+
+  if (right !== '') {
+    const rightBorder = deserializeBorder(right);
+    if (rightBorder) borders.right = rightBorder;
+  }
+
+  if (diagonal !== '') {
+    const diagonalBorder = deserializeBorder(diagonal);
+    if (diagonalBorder) {
+      borders.diagonal = diagonalBorder;
+      addSerializedBooleanProperty(borders.diagonal, 'up', up);
+      addSerializedBooleanProperty(borders.diagonal, 'down', down);
+    }
+  } else if (up || down) {
+    borders.diagonal = {};
+    addSerializedBooleanProperty(borders.diagonal, 'up', up);
+    addSerializedBooleanProperty(borders.diagonal, 'down', down);
+  }
+
+  return borders;
+}
+
+function deserializeAlignment(values) {
+  const [horizontal, vertical, wrapText, shrinkToFit, indent, readingOrder, textRotation] = values;
+  const alignment = {};
+
+  if (horizontal) alignment.horizontal = horizontal;
+  if (vertical) alignment.vertical = vertical;
+  addSerializedBooleanProperty(alignment, 'wrapText', wrapText);
+  addSerializedBooleanProperty(alignment, 'shrinkToFit', shrinkToFit);
+  if (indent) alignment.indent = Number(indent);
+  if (readingOrder) alignment.readingOrder = readingOrder;
+  if (textRotation !== '') {
+    alignment.textRotation = textRotation === 'vertical' ? 'vertical' : Number(textRotation);
+  }
+
+  return alignment;
+}
+
+function deserializeProtection(values) {
+  const [locked, hidden] = values;
+  const protection = {};
+  addSerializedBooleanProperty(protection, 'locked', locked);
+  addSerializedBooleanProperty(protection, 'hidden', hidden);
+  return protection;
+}
+
+function deserializeStyle(serialized) {
+  const style = {};
+  const parts = serialized.split(L1_SEPARATOR);
+
+  for (const part of parts) {
+    const [type, values] = part.split(L2_SEPARATOR);
+    const valuesArray = values.split(L3_SEPARATOR);
+
+    switch (type) {
+      case 'f':
+        style.font = deserializeFont(valuesArray);
+        break;
+      case 'b':
+        style.border = deserializeBorders(valuesArray);
+        break;
+      case 'a':
+        style.alignment = deserializeAlignment(valuesArray);
+        break;
+      case 'fi':
+        style.fill = deserializeFill(values);
+        break;
+      case 'p':
+        style.protection = deserializeProtection(valuesArray);
+        break;
+      case 'n':
+        style.numFmt = values;
+        break;
+    }
+  }
+
+  return style;
+}
+
+module.exports = {serializeStyle, deserializeStyle};

--- a/lib/utils/xml-stream.js
+++ b/lib/utils/xml-stream.js
@@ -19,7 +19,7 @@ function pushAttributes(xml, attributes) {
         pushAttribute(tmp, name, value);
       }
     });
-    xml.push(tmp.join(""));
+    xml.push(tmp.join(''));
   }
 }
 

--- a/lib/xlsx/xform/style/styles-xform.js
+++ b/lib/xlsx/xform/style/styles-xform.js
@@ -11,15 +11,20 @@ const BorderXform = require('./border-xform');
 const NumFmtXform = require('./numfmt-xform');
 const StyleXform = require('./style-xform');
 const DxfXform = require('./dxf-xform');
+const {serializeStyle} = require('../../../utils/style-fast-serialize');
 
 // custom numfmt ids start here
 const NUMFMT_BASE = 164;
-
+const JSON_MAP = 'JSON_MAP';
+const FAST_MAP = 'FAST_MAP';
+const NO_CACHE = 'NO_CACHE';
+const WEAK_MAP = 'WEAK_MAP'; // DEFAULT
+const CACHE_MODES = [JSON_MAP, FAST_MAP, WEAK_MAP, NO_CACHE];
 // =============================================================================
 // StylesXform is used to generate and parse the styles.xml file
 // it manages the collections of fonts, number formats, alignments, etc
 class StylesXform extends BaseXform {
-  constructor(initialise) {
+  constructor(initialise, cacheMode) {
     super();
 
     this.map = {
@@ -53,6 +58,7 @@ class StylesXform extends BaseXform {
     };
 
     if (initialise) {
+      this.cacheMode = CACHE_MODES.find(c => c === cacheMode) || WEAK_MAP;
       // StylesXform also acts as style manager and is used to build up styles-model during worksheet processing
       this.init();
     }
@@ -92,7 +98,11 @@ class StylesXform extends BaseXform {
     this._addFill({type: 'pattern', pattern: 'none'});
     this._addFill({type: 'pattern', pattern: 'gray125'});
 
-    this.weakMap = new WeakMap();
+    if (this.cacheMode === WEAK_MAP) {
+      this.styleMap = new WeakMap();
+    } else {
+      this.styleMap = new Map();
+    }
   }
 
   render(xmlStream, model) {
@@ -241,10 +251,21 @@ class StylesXform extends BaseXform {
       // default (zero) font
       this._addFont({size: 11, color: {theme: 1}, name: 'Calibri', family: 2, scheme: 'minor'});
     }
+    let cacheKey;
+    if (this.cacheMode === JSON_MAP) {
+      cacheKey = JSON.stringify(model);
+    } else if (this.cacheMode === FAST_MAP) {
+      cacheKey = serializeStyle(model);
+    } else {
+      cacheKey = model;
+    }
 
-    // if we have seen this style object before, assume it has the same styleId
-    if (this.weakMap && this.weakMap.has(model)) {
-      return this.weakMap.get(model);
+    if (this.cacheMode !== NO_CACHE) {
+      const cachedStyleId = this.styleMap.get(cacheKey);
+      // if we have seen this style object before, assume it has the same styleId
+      if (cachedStyleId) {
+        return cachedStyleId;
+      }
     }
 
     const style = {};
@@ -286,9 +307,11 @@ class StylesXform extends BaseXform {
     }
 
     const styleId = this._addStyle(style);
-    if (this.weakMap) {
-      this.weakMap.set(model, styleId);
+
+    if (this.cacheMode !== NO_CACHE) {
+      this.styleMap.set(cacheKey, styleId);
     }
+
     return styleId;
   }
 

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -683,7 +683,7 @@ class XLSX {
     model.sharedStrings = new SharedStringsXform();
 
     // add a style manager to handle cell formats, fonts, etc.
-    model.styles = model.useStyles ? new StylesXform(true) : new StylesXform.Mock();
+    model.styles = model.useStyles ? new StylesXform(true, options.stylesCacheMode) : new StylesXform.Mock();
 
     // prepare all of the things before the render
     const workbookXform = new WorkbookXform();

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "clean": "rm -rf build/ && rm -rf dist",
     "benchmark": "node --expose-gc benchmark",
     "benchmark:debug": "node --expose-gc --inspect-brk --trace-deopt benchmark",
+    "benchmark:styles": "node --expose-gc benchmark-styles",
     "build": "grunt build",
     "install-build": "npm install && grunt build",
     "preversion": "npm run clean && npm run build && npm run test:version",

--- a/spec/unit/utils/style-fast-serialize.spec.js
+++ b/spec/unit/utils/style-fast-serialize.spec.js
@@ -1,0 +1,187 @@
+const {
+  serializeStyle,
+  deserializeStyle,
+} = require('../../../lib/utils/style-fast-serialize'); // Adjust the import as needed
+// const deserializeStyle = require('../../utils/style-fast-deserialize');
+
+describe('Style Serialization and Deserialization', () => {
+  it('should correctly serialize and deserialize font', () => {
+    const originalStyle = {
+      font: {
+        name: 'Arial',
+        size: 12,
+        family: 2,
+        scheme: 'minor',
+        charset: 1,
+        color: {argb: 'FF0000FF'},
+        bold: true,
+        italic: false,
+        underline: 'single',
+        vertAlign: 'superscript',
+        strike: true,
+        outline: false,
+      },
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize border', () => {
+    const originalStyle = {
+      border: {
+        top: {style: 'thin', color: {argb: 'FF000000'}},
+        left: {style: 'medium', color: {theme: 1}},
+        bottom: {style: 'thick', color: {argb: 'FFFF0000'}},
+        right: {style: 'dashed', color: {theme: 2}},
+        diagonal: {
+          style: 'dotted',
+          color: {argb: 'FF00FF00'},
+          up: true,
+          down: false,
+        },
+      },
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize alignment', () => {
+    const originalStyle = {
+      alignment: {
+        horizontal: 'center',
+        vertical: 'middle',
+        wrapText: true,
+        shrinkToFit: false,
+        indent: 1,
+        readingOrder: 'rtl',
+        textRotation: 45,
+      },
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize fill (pattern)', () => {
+    const originalStyle = {
+      fill: {
+        type: 'pattern',
+        pattern: 'solid',
+        fgColor: {argb: 'FFFF0000'},
+        bgColor: {theme: 3},
+      },
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize fill (gradient angle)', () => {
+    const originalStyle = {
+      fill: {
+        type: 'gradient',
+        gradient: 'angle',
+        degree: 90,
+        stops: [
+          {position: 0, color: {argb: 'FFFF0000'}},
+          {position: 1, color: {theme: 4}},
+        ],
+      },
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize fill (gradient path)', () => {
+    const originalStyle = {
+      fill: {
+        type: 'gradient',
+        gradient: 'path',
+        center: {left: 0.5, top: 0.5},
+        stops: [
+          {position: 0, color: {argb: 'FFFF0000'}},
+          {position: 1, color: {theme: 4}},
+        ],
+      },
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize protection', () => {
+    const originalStyle = {
+      protection: {
+        locked: true,
+        hidden: false,
+      },
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize number format', () => {
+    const originalStyle = {
+      numFmt: '#,##0.00',
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+
+  it('should correctly serialize and deserialize a full style object', () => {
+    const originalStyle = {
+      font: {
+        name: 'Calibri',
+        size: 11,
+        color: {theme: 1},
+        bold: true,
+      },
+      border: {
+        top: {style: 'thin', color: {argb: 'FF000000'}},
+        left: {style: 'thin', color: {argb: 'FF000000'}},
+        bottom: {style: 'thin', color: {argb: 'FF000000'}},
+        right: {style: 'thin', color: {argb: 'FF000000'}},
+      },
+      alignment: {
+        horizontal: 'center',
+        vertical: 'middle',
+      },
+      fill: {
+        type: 'pattern',
+        pattern: 'solid',
+        fgColor: {argb: 'FFFF0000'},
+      },
+      protection: {
+        locked: true,
+        hidden: false,
+      },
+      numFmt: '0.00%',
+    };
+
+    const serialized = serializeStyle(originalStyle);
+    const deserialized = deserializeStyle(serialized);
+
+    expect(deserialized).to.deep.equal(originalStyle);
+  });
+});


### PR DESCRIPTION
Currently useStyles can have a dramatic impact on xlsx write performance, both on stream and non stream writer.

A large part of the problem is how WeakMap is used in conjunction with style object handling on cells. While this can be worked around as evidenced here: https://github.com/exceljs/exceljs/issues/2041 its an external workaround and does not give users that much flexibility.

Most of the times style objects are either cloned or created anew, so the same style configuration are actually distinct objects and the WeakMap in styles-xform.js does not recognize them as the same style config. This causes the WeakMap to grow very large and have few hits per key, in some cases actually hindering performance compared to not cacheing. While its possible to have good performance with WeakMap the developer needs to be very aware of object re-use and its not obvious for most.

A great example of poor WeakMap performance is when there is a Colum/Row style combination or a style is set inside a loop with a cell.style={..} notation. An example of when is has good performance is when a style is created outside a loop and assigned to many cells via cell.style = myStyleRef; But this also causes issues if a style is modified indirectly impacting all other cells (addressing this is not in scope for this change).

This PR introduces an option when creating a workbook styleCacheMode. 
If not specified it behaves just like today using WeakMap so this feature is 100% backwards compatible.
```javascript
const options = {
  filename: './streamed-workbook.xlsx',
  useStyles: true,
  styleCacheMode: 'FAST_MAP,
  useSharedStrings: true
};
const workbook = new Excel.stream.xlsx.WorkbookWriter(options);
``` 

WEAK_MAP: has poor performance if the style objects are not re-used. When you mix Col, row and cell styles a different style object is created per cell and performance deteriorates to being worse then with No Cache.
JSON_MAP: uses JSON.stringify as the key for a style map. The perfromance can be similar to WeakMap or up to 2.5x faster.
FAST_MAP: uses a custom function to encode a style to use it as a key on cache. Should be preferred over JSON_MAP. The encoded style is much smaller and faster to generate then a JSON. The encoding function is designed so two distinct styles can never be encoded to the same key, but if this happens use JSON_MAP instead.
NO_CACHE: In some cases NO_CACHE can be faster than WEAK_MAP. In rare cases it maybe faster than JSON_MAP.

Beanchmark on t3.large for 200k rows with 7 columns:

Mode|AVG (seconds)|x slower than useStyles:false
NO_STYLES|4.16|1.00
WEAK_MAP|21.58|5.19
JSON_MAP|9.24|2.22
FAST_MAP|7.56|1.82
NO_CACHE|19.97|4.81

I have also introduced a convenience method on cell.js called addStyle(style). This is for when you want to add a style to a cell but still respect inheritance of the Col and Row styles.

I'd be happy to make adjustments as needed.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Improve performance on xlsx writer when useStyles: true. 
Cases like and similar for both stream and non stream API: https://github.com/exceljs/exceljs/issues/2041

## Test plan

I have added a new unit test file to test FAST_MAP serialization and a new bench mark testing the different cache modes.
to run the benchmark 
```shell
npm run benchmark:styles
``` 

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
