### PR TITLE
Fix: Changed error-prone race conditions

### DIFF
--- a/lib/utils/iterate-stream.js
+++ b/lib/utils/iterate-stream.js
@@ -1,48 +1,38 @@
+const { once } = require('events');
+
 module.exports = async function* iterateStream(stream) {
   const contents = [];
-  stream.on('data', data => contents.push(data));
-
-  let resolveStreamEndedPromise;
-  const streamEndedPromise = new Promise(resolve => (resolveStreamEndedPromise = resolve));
-
   let ended = false;
-  stream.on('end', () => {
-    ended = true;
-    resolveStreamEndedPromise();
-  });
+  let error = null;
 
-  let error = false;
-  stream.on('error', err => {
-    error = err;
-    resolveStreamEndedPromise();
-  });
+  const onData = data => contents.push(data);
+  const onEnd = () => { ended = true; };
+  const onError = err => { error = err; };
 
-  while (!ended || contents.length > 0) {
-    if (contents.length === 0) {
-      stream.resume();
-      // eslint-disable-next-line no-await-in-loop
-      await Promise.race([once(stream, 'data'), streamEndedPromise]);
-    } else {
-      stream.pause();
-      const data = contents.shift();
-      yield data;
-    }
-    if (error) throw error;
-  }
-  resolveStreamEndedPromise();
-};
+  stream.on('data', onData);
+  stream.on('end', onEnd);
+  stream.on('error', onError);
 
-function once(eventEmitter, type) {
-  // TODO: Use require('events').once when node v10 is dropped
-  return new Promise(resolve => {
-    let fired = false;
-    const handler = () => {
-      if (!fired) {
-        fired = true;
-        eventEmitter.removeListener(type, handler);
-        resolve();
+  try {
+    while (!ended || contents.length > 0) {
+      // first proccess thje data
+      if (contents.length > 0) {
+        const chunk = contents.shift();
+        yield chunk;
+        continue;
       }
-    };
-    eventEmitter.addListener(type, handler);
-  });
-}
+
+      // wait for new data or end 
+      if (!ended) {
+        await Promise.race([once(stream, 'data'), once(stream, 'end')]);
+      }
+
+      if (error) throw error;
+    }
+  } finally {
+    // cleanup to prevent leaks
+    stream.off('data', onData);
+    stream.off('end', onEnd);
+    stream.off('error', onError);
+  }
+};


### PR DESCRIPTION
## Summary

When dealing with import/export streams, different errors occured under certain circumstances. For example sharedStrings could sometimes not be resolved after editing the exported .xlsx file with excel, even though the inputOptions are set appropiately. More over there were also cases where the sheetnames could not be read after an export, due to the race conditions in the old iterate-stream method. The workbook was not properly initialized in time. There are surely more edge cases in which the current iterate-stream implementation would lead to unexpected behavior.

Unfortunately, I cannot offer sample files since it is somewhat flaky to reproduce and my own data include client information.

The new implementation utilizes Nodes built-in .once method and removes the race conditions that lead to the problems above.

## Test plan

None.

## Related to source code (for typings update)
