### PR TITLE
Make to work with expressions with no formulae

### DIFF
--- a/lib/xlsx/xform/sheet/cf/cf-rule-xform.js
+++ b/lib/xlsx/xform/sheet/cf/cf-rule-xform.js
@@ -155,7 +155,7 @@ class CfRuleXform extends CompositeXform {
       priority: model.priority,
     });
 
-    this.formulaXform.render(xmlStream, model.formulae[0]);
+    if (model.formulae && model.formulae.length) this.formulaXform.render(xmlStream, model.formulae[0]);
 
     xmlStream.closeNode();
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
#2311 ran into this issue this other person had. I could not modify the sheet that I was working with so I had to modify the code to fix it. Issue is with expressions that have no fromulae.

Simple change that avoids calling render on a non existent formulae.

## Test plan

No tests as it is trying to avoid the error: TypeError: Cannot read properties of undefined (reading '0')

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
