### PR TITLE
feat: add 'count' metric for pivot table

### DIFF
--- a/lib/doc/pivot-table.js
+++ b/lib/doc/pivot-table.js
@@ -14,13 +14,14 @@ function makePivotTable(worksheet, model) {
   //   rows: ['A', 'B'],
   //   columns: ['C'],
   //   values: ['E'], // only 1 item possible for now
-  //   metric: 'sum', // only 'sum' possible for now
+  //   metric: 'sum', 'count' // only 'sum' and 'count' are possible for now
   // }
 
   validate(worksheet, model);
 
   const {sourceSheet} = model;
   let {rows, columns, values} = model;
+  const {metric} = model;
 
   const cacheFields = makeCacheFields(sourceSheet, [...rows, ...columns]);
 
@@ -42,7 +43,7 @@ function makePivotTable(worksheet, model) {
     rows,
     columns,
     values,
-    metric: 'sum',
+    metric,
     cacheFields,
     // defined in <pivotTableDefinition> of xl/pivotTables/pivotTable1.xml;
     // also used in xl/workbook.xml
@@ -57,8 +58,8 @@ function validate(worksheet, model) {
     );
   }
 
-  if (model.metric && model.metric !== 'sum') {
-    throw new Error('Only the "sum" metric is supported at this time.');
+  if (model.metric && model.metric !== 'sum' && model.metric !== 'count') {
+    throw new Error('Only the "sum" and "count" metric is supported at this time.');
   }
 
   const headerNames = model.sourceSheet.getRow(1).values.slice(1);

--- a/lib/xlsx/xform/pivot-table/pivot-table-xform.js
+++ b/lib/xlsx/xform/pivot-table/pivot-table-xform.js
@@ -81,10 +81,11 @@ class PivotTableXform extends BaseXform {
       </colItems>
       <dataFields count="${values.length}">
         <dataField
-          name="Sum of ${cacheFields[values[0]].name}"
+          name="${metric === 'count' ? 'Count"' : 'Sum'} of ${cacheFields[values[0]].name}"
           fld="${values[0]}"
           baseField="0"
           baseItem="0"
+          ${metric === 'count' ? 'subtotal="count"' : ''}
         />
       </dataFields>
       <pivotTableStyleInfo

--- a/lib/xlsx/xform/pivot-table/pivot-table-xform.js
+++ b/lib/xlsx/xform/pivot-table/pivot-table-xform.js
@@ -81,7 +81,7 @@ class PivotTableXform extends BaseXform {
       </colItems>
       <dataFields count="${values.length}">
         <dataField
-          name="${metric === 'count' ? 'Count"' : 'Sum'} of ${cacheFields[values[0]].name}"
+          name="${metric === 'count' ? 'Count' : 'Sum'} of ${cacheFields[values[0]].name}"
           fld="${values[0]}"
           baseField="0"
           baseItem="0"

--- a/spec/integration/workbook/pivot-tables-with-count.spec.js
+++ b/spec/integration/workbook/pivot-tables-with-count.spec.js
@@ -1,0 +1,78 @@
+// *Note*: `fs.promises` not supported before Node.js 11.14.0;
+// ExcelJS version range '>=8.3.0' (as of 2023-10-08).
+const fs = require('fs');
+const {promisify} = require('util');
+
+const fsReadFileAsync = promisify(fs.readFile);
+
+const JSZip = require('jszip');
+
+const ExcelJS = verquire('exceljs');
+
+const PIVOT_TABLE_FILEPATHS = [
+  'xl/pivotCache/pivotCacheRecords1.xml',
+  'xl/pivotCache/pivotCacheDefinition1.xml',
+  'xl/pivotCache/_rels/pivotCacheDefinition1.xml.rels',
+  'xl/pivotTables/pivotTable1.xml',
+  'xl/pivotTables/_rels/pivotTable1.xml.rels',
+];
+
+const TEST_XLSX_FILEPATH = './spec/out/wb.test.xlsx';
+
+const TEST_DATA = [
+  ['A', 'B', 'C', 'D', 'E'],
+  ['a1', 'b1', 'c1', 4, 5],
+  ['a1', 'b2', 'c1', 4, 5],
+  ['a2', 'b1', 'c2', 14, 24],
+  ['a2', 'b2', 'c2', 24, 35],
+  ['a3', 'b1', 'c3', 34, 45],
+  ['a3', 'b2', 'c3', 44, 45],
+];
+
+// =============================================================================
+// Tests
+
+describe('Workbook', () => {
+  describe('Pivot Tables with count', () => {
+    it('if pivot table added, then certain xml and rels files are added', async () => {
+      const workbook = new ExcelJS.Workbook();
+
+      const worksheet1 = workbook.addWorksheet('Sheet1');
+      worksheet1.addRows(TEST_DATA);
+
+      const worksheet2 = workbook.addWorksheet('Sheet2');
+      worksheet2.addPivotTable({
+        sourceSheet: worksheet1,
+        rows: ['A', 'B'],
+        columns: ['C'],
+        values: ['E'],
+        metric: 'count',
+      });
+
+      return workbook.xlsx.writeFile(TEST_XLSX_FILEPATH).then(async () => {
+        const buffer = await fsReadFileAsync(TEST_XLSX_FILEPATH);
+        const zip = await JSZip.loadAsync(buffer);
+        for (const filepath of PIVOT_TABLE_FILEPATHS) {
+          expect(zip.files[filepath]).to.not.be.undefined();
+        }
+      });
+    });
+
+    it('if pivot table NOT added, then certain xml and rels files are not added', () => {
+      const workbook = new ExcelJS.Workbook();
+
+      const worksheet1 = workbook.addWorksheet('Sheet1');
+      worksheet1.addRows(TEST_DATA);
+
+      workbook.addWorksheet('Sheet2');
+
+      return workbook.xlsx.writeFile(TEST_XLSX_FILEPATH).then(async () => {
+        const buffer = await fsReadFileAsync(TEST_XLSX_FILEPATH);
+        const zip = await JSZip.loadAsync(buffer);
+        for (const filepath of PIVOT_TABLE_FILEPATHS) {
+          expect(zip.files[filepath]).to.be.undefined();
+        }
+      });
+    });
+  });
+});

--- a/test/test-pivot-table-with-count.js
+++ b/test/test-pivot-table-with-count.js
@@ -1,0 +1,54 @@
+// --------------------------------------------------
+// This enables the generation of a XLSX pivot table
+// with several restrictions
+//
+// Last updated: 2023-10-19
+// --------------------------------------------------
+/* eslint-disable */
+
+function main(filepath) {
+  const Excel = require('../lib/exceljs.nodejs.js');
+
+  const workbook = new Excel.Workbook();
+
+  const worksheet1 = workbook.addWorksheet('Sheet1');
+  worksheet1.addRows([
+    ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'],
+    ['a1', 'b1', 'c1', 'd1', 'e1', 'f1', 4, 5],
+    ['a1', 'b2', 'c1', 'd2', 'e1', 'f1', 4, 5],
+    ['a2', 'b1', 'c2', 'd1', 'e2', 'f1', 14, 24],
+    ['a2', 'b2', 'c2', 'd2', 'e2', 'f2', 24, 35],
+    ['a3', 'b1', 'c3', 'd1', 'e3', 'f2', 34, 45],
+    ['a3', 'b2', 'c3', 'd2', 'e3', 'f2', 44, 45],
+  ]);
+
+  const worksheet2 = workbook.addWorksheet('Sheet2');
+  worksheet2.addPivotTable({
+    // Source of data: the entire sheet range is taken;
+    // akin to `worksheet1.getSheetValues()`.
+    sourceSheet: worksheet1,
+    // Pivot table fields: values indicate field names;
+    // they come from the first row in `worksheet1`.
+    rows: ['A', 'B', 'E'],
+    columns: ['C', 'D'],
+    values: ['H'], // only 1 item possible for now
+    metric: 'count', // only 'sum' and 'count' are possible for now
+  });
+
+  save(workbook, filepath);
+}
+
+function save(workbook, filepath) {
+  const HrStopwatch = require('./utils/hr-stopwatch.js');
+  const stopwatch = new HrStopwatch();
+  stopwatch.start();
+
+  workbook.xlsx.writeFile(filepath).then(() => {
+    const microseconds = stopwatch.microseconds;
+    console.log('Done.');
+    console.log('Time taken:', microseconds);
+  });
+}
+
+const [, , filepath] = process.argv;
+main(filepath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR adds support for the **Count** metric in `PivotTable`, allowing users to aggregate data based on the number of occurrences in a given field.  
Currently, `exceljs` supports `sum` metric , but `count` is a widely used aggregation method in Excel that was missing.  
This enhancement aligns PivotTable functionality more closely with native Excel behavior.

## Test plan

- Added unit tests to validate the correct behavior of the Count metric in different scenarios.  
- Manually tested by generating an Excel file and verifying the PivotTable results in Excel.  
- Ensured backward compatibility with existing metric calculations.  

The PR includes a new unit test file, [pivot-tables-with-count.spec.js](https://github.com/dsilva01/exceljs/blob/master/spec/integration/workbook/pivot-tables-with-count.spec.js), with tests for valid and invalid the count metric. All unit tests, including the new tests and all existing tests, pass when running "npm run test:unit".

## Related to source code (for typings update)

👉 Feedback and discussion https://github.com/exceljs/exceljs/discussions/2575.