### PR TITLE
Fix parse-sax.js broke utf8 string bug

### DIFF
--- a/lib/utils/parse-sax.js
+++ b/lib/utils/parse-sax.js
@@ -17,8 +17,12 @@ module.exports = async function* (iterable) {
   saxesParser.on('opentag', value => events.push({eventType: 'opentag', value}));
   saxesParser.on('text', value => events.push({eventType: 'text', value}));
   saxesParser.on('closetag', value => events.push({eventType: 'closetag', value}));
+  let cacheBuffer = Buffer.from([]);
   for await (const chunk of iterable) {
-    saxesParser.write(bufferToString(chunk));
+    const concatBuffer = Buffer.concat([cacheBuffer, chunk]);
+    const lastTagEnd = concatBuffer.lastIndexOf('>'.charCodeAt(0));
+    cacheBuffer = Uint8Array.prototype.slice.call(concatBuffer, lastTagEnd + 1, concatBuffer.length + 1);
+    saxesParser.write(bufferToString(Uint8Array.prototype.slice.call(concatBuffer, 0, lastTagEnd + 1)));
     // saxesParser.write and saxesParser.on() are synchronous,
     // so we can only reach the below line once all events have been emitted
     if (error) throw error;


### PR DESCRIPTION
## Summary

Fix #2084 split Chinese or other Unicode String bug.

## Test plan
Before the modification, BufferToString would cause the processed stream to be truncated. After the modification, the stream data following the > symbol will be cached until the next > symbol appears. The > symbol will always be the end of the XML file, so all streams will be processed.
