### PR TITLE
fix: handle Excel files with missing or undefined sheets element

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -300,7 +300,8 @@ class WorkbookReader extends EventEmitter {
     });
 
     const matchingRel = (this.workbookRels || []).find(rel => rel.Target === `worksheets/sheet${sheetNo}.xml`);
-    const matchingSheet = matchingRel && (this.model.sheets || []).find(sheet => sheet.rId === matchingRel.Id);
+    const matchingSheet =
+      matchingRel && this.model && (this.model.sheets || []).find(sheet => sheet.rId === matchingRel.Id);
     if (matchingSheet) {
       worksheetReader.id = matchingSheet.id;
       worksheetReader.name = matchingSheet.name;

--- a/lib/xlsx/xform/book/workbook-xform.js
+++ b/lib/xlsx/xform/book/workbook-xform.js
@@ -140,9 +140,9 @@ class WorkbookXform extends BaseXform {
     switch (name) {
       case 'workbook':
         this.model = {
-          sheets: this.map.sheets.model,
+          sheets: this.map.sheets.model || [],
           properties: this.map.workbookPr.model || {},
-          views: this.map.bookViews.model,
+          views: this.map.bookViews.model || [],
           calcProperties: {},
         };
         if (this.map.definedNames.model) {

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -323,11 +323,11 @@ class XLSX {
 
           case 'xl/workbook.xml': {
             const workbook = await this.parseWorkbook(stream);
-            model.sheets = workbook.sheets;
-            model.definedNames = workbook.definedNames;
-            model.views = workbook.views;
-            model.properties = workbook.properties;
-            model.calcProperties = workbook.calcProperties;
+            model.sheets = workbook.sheets || [];
+            model.definedNames = workbook.definedNames || [];
+            model.views = workbook.views || [];
+            model.properties = workbook.properties || {};
+            model.calcProperties = workbook.calcProperties || {};
             break;
           }
 

--- a/spec/integration/issues/issue-undefined-sheets-property.spec.js
+++ b/spec/integration/issues/issue-undefined-sheets-property.spec.js
@@ -1,0 +1,89 @@
+const ExcelJS = verquire('exceljs');
+const JSZip = require('jszip');
+const fs = require('fs');
+const path = require('path');
+
+describe('github issues', () => {
+  describe('issue - undefined sheets property handling', () => {
+    const testDir = path.join(__dirname, '..', 'data');
+    const testFile = path.join(testDir, 'test-undefined-sheets.xlsx');
+
+    before(async () => {
+      // Create a test Excel file with missing sheets element
+      const zip = new JSZip();
+
+      // Add minimal required structure
+      zip.file(
+        '_rels/.rels',
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`
+      );
+
+      zip.file(
+        '[Content_Types].xml',
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+</Types>`
+      );
+
+      // Workbook without sheets element - this causes the issue
+      zip.file(
+        'xl/workbook.xml',
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <workbookPr/>
+  <bookViews>
+    <workbookView activeTab="0"/>
+  </bookViews>
+  <!-- sheets element is missing -->
+  <calcPr calcId="171027"/>
+</workbook>`
+      );
+
+      // Create the test file
+      const content = await zip.generateAsync({type: 'nodebuffer'});
+      fs.writeFileSync(testFile, content);
+    });
+
+    after(() => {
+      // Clean up test file
+      if (fs.existsSync(testFile)) {
+        fs.unlinkSync(testFile);
+      }
+    });
+
+    it('should handle Excel files with missing sheets element without throwing', async () => {
+      const wb = new ExcelJS.Workbook();
+
+      // This should not throw "Cannot read properties of undefined (reading 'sheets')"
+      await wb.xlsx.readFile(testFile);
+
+      // Workbook should be valid but with no worksheets
+      expect(wb.worksheets).to.be.an('array');
+      expect(wb.worksheets.length).to.equal(0);
+    });
+
+    it('should handle operations on workbook with no sheets', async () => {
+      const wb = new ExcelJS.Workbook();
+      await wb.xlsx.readFile(testFile);
+
+      // These operations should work safely
+      expect(() => {
+        wb.eachSheet(worksheet => {
+          // This won't execute since there are no sheets
+          expect.fail('Should not have any sheets');
+        });
+      }).to.not.throw();
+
+      // Can still add sheets to the workbook
+      const ws = wb.addWorksheet('NewSheet');
+      expect(ws).to.exist();
+      expect(wb.worksheets.length).to.equal(1);
+    });
+  });
+});

--- a/spec/unit/xlsx/xform/book/workbook-xform-undefined-sheets.spec.js
+++ b/spec/unit/xlsx/xform/book/workbook-xform-undefined-sheets.spec.js
@@ -1,0 +1,64 @@
+const WorkbookXform = verquire('xlsx/xform/book/workbook-xform');
+
+// This XML represents a workbook without sheets element
+const workbookWithoutSheets = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <fileVersion appName="xl" lastEdited="5" lowestEdited="5" rupBuild="9303"/>
+    <bookViews>
+        <workbookView visibility="hidden" xWindow="0" yWindow="0" windowWidth="12000" windowHeight="24000"/>
+    </bookViews>
+    <!-- sheets element is missing -->
+    <calcPr calcId="171027"/>
+</workbook>`;
+
+describe('WorkbookXform - undefined sheets handling', () => {
+  it('should handle workbook XML without sheets element', async () => {
+    const xform = new WorkbookXform();
+
+    // Parse the XML without sheets element
+    const model = await xform.parseStream(workbookWithoutSheets);
+
+    // After the fix, sheets should be an empty array instead of undefined
+    expect(model).to.exist();
+    expect(model.sheets).to.be.an('array').that.is.empty();
+    expect(model.views).to.be.an('array').that.is.empty();
+    expect(model.properties).to.be.an('object');
+  });
+
+  it('should safely handle operations on empty sheets array', () => {
+    const xform = new WorkbookXform();
+
+    return xform.parseStream(workbookWithoutSheets).then(model => {
+      // After the fix, this should work safely
+      const testAccess = () => {
+        const newModel = {};
+        newModel.sheets = model.sheets; // This assigns an empty array
+
+        // These operations should now work safely
+        expect(model.sheets.length).to.equal(0);
+
+        // Array methods work on empty arrays
+        const processSheets = sheets => {
+          return sheets.map(sheet => sheet.name);
+        };
+
+        // This should return an empty array instead of throwing
+        const result = processSheets(model.sheets);
+        expect(result).to.be.an('array').that.is.empty();
+
+        // Other safe operations
+        const names = model.sheets.filter(s => s.name).map(s => s.name);
+        expect(names).to.be.an('array').that.is.empty();
+
+        model.sheets.forEach(sheet => {
+          // This won't execute since array is empty
+          expect.fail('Should not have any sheets');
+        });
+      };
+
+      // This should not throw anymore
+      expect(testAccess).to.not.throw();
+      testAccess();
+    });
+  });
+});


### PR DESCRIPTION
This fix prevents "Cannot read properties of undefined (reading 'sheets')" errors when parsing Excel files that have malformed or missing sheet definitions in workbook.xml.

Changes:
- Add default empty arrays for sheets and views in WorkbookXform parser
- Add defensive checks with fallback values in xlsx.js for all workbook properties
- Add null check for this.model before accessing sheets in WorkbookReader
- Add comprehensive unit and integration tests

The library now gracefully handles workbooks without sheet definitions, returning empty arrays instead of throwing errors.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
