### PR TITLE
Fix the return value from dateToExcel() when it's passed a non-numeric value.

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -57,6 +57,7 @@ const utils = {
     return 25569 + d.getTime() / (24 * 3600 * 1000) - (date1904 ? 1462 : 0);
   },
   excelToDate(v, date1904) {
+    if (!Number.isFinite(v)) return v; // dmjp: If v isn't actually a date, eg the cell style is a date format but the value isn't numeric, then return v instead of "Invalid Date".
     // eslint-disable-next-line no-mixed-operators
     const millisecondSinceEpoch = Math.round((v - 25569 + (date1904 ? 1462 : 0)) * 24 * 3600 * 1000);
     return new Date(millisecondSinceEpoch);


### PR DESCRIPTION
If a non-numeric value is passed to dateToExcel(), like when it's called because the cell style is a date format, the result is "Invalid Date", which gets converted to NaN when the sheet is persisted, which causes Excel to pop-up extremely annoying warnings the next time that the sheet is opened.  This 1-liner fixes that.

<img width="1920" height="1080" alt="damage" src="https://github.com/user-attachments/assets/10137d76-48df-48a7-ac7b-04894ce01107" />
