### PR TITLE
Fix parsing error for dynamicFilter nodes in Excel tables

### DIFF
--- a/lib/xlsx/xform/table/filter-column-xform.js
+++ b/lib/xlsx/xform/table/filter-column-xform.js
@@ -63,6 +63,9 @@ class FilterColumnXform extends BaseXform {
           filterButton: attributes.hiddenButton === '0',
         };
         return true;
+      case 'dynamicFilter':
+        // Ignore dynamicFilter nodes - we don't need to preserve them for reading
+        return true;
       default:
         this.parser = this.map[node.name];
         if (this.parser) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Prevent `Unexpected xml node in parseOpen` exception when loading an Excel file with dynamic filters in tables. See related issue: https://github.com/exceljs/exceljs/issues/2972

Demo to reproduce error here: https://github.com/examind-ai/exceljs-dynamicfilter-bug

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This is a very minor change. There is no attempt to add dynamic filter support in this PR. Only to prevent exception when loading Excel files with dynamic filters in tables.

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
