### PR TITLE
Fix large validation ranges by clamping range to highest row in actual data

### DIFF
--- a/lib/xlsx/xform/sheet/data-validations-xform.js
+++ b/lib/xlsx/xform/sheet/data-validations-xform.js
@@ -216,6 +216,15 @@ class DataValidationsXform extends BaseXform {
         // The four known cases: 1. E4:L9 N4:U9  2.E4 L9  3. N4:U9  4. E4
         const list = this._address.split(/\s+/g) || [];
         list.forEach(addr => {
+          // If range has a large row end number, clamp to highest actual row number to avoid huge unnecessary loop
+          if(/^[A-Z]+[0-9]+\:[A-Z]+[0-9]{3,}$/.test(addr)) {
+            let highestActual = 0;
+            for(const rowNumber of Object.keys(this.model).map((x) => parseInt(x.match(/^[A-Z]+([0-9]+)$/)?.[1]) || 0)) {
+              highestActual = Math.max(highestActual, rowNumber);
+            }
+            addr = addr.replace(/\:([A-Z]+)([0-9]{3,})$/, (full, letters, number) => `${letters}:${highestActual}`);
+          }
+
           if (addr.includes(':')) {
             const range = new Range(addr);
             range.forEachAddress(address => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #1842

Some validation rules in Excel result in the sheet taking a very long time to load, because the validation loops over all numbers in the range without checking if anything might be in the targeted fields.

This fix looks at the model to find the highest actual row in use, and clamps the range to that row, before running the Range on it.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I don't know. Guidance appreciated.

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->

N/A
