### PR TITLE
Add ImageEditAs type and update addImage method to support 'twoCell' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2054,6 +2054,7 @@ It can have one of the following values:
 | --------- | ----------- |
 | undefined | It specifies the image will be moved and sized with cells |
 | oneCell   | This is the default. Image will be moved with cells but not sized |
+| twoCell   | Image will be moved and sized with cells |
 | absolute  | Image will not be moved or sized with cells |
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -400,6 +400,8 @@ export type CellValue =
 
 	export type CommentEditAs = 'twoCells' | 'oneCells' | 'absolute';
 
+	export type ImageEditAs = 'twoCell' | 'oneCell' | 'absolute';
+
 	export interface Comment {
 		texts?: RichText[];
 		margins?: Partial<CommentMargins>;
@@ -1337,7 +1339,7 @@ export interface Worksheet {
 	 * Using the image id from `Workbook.addImage`,
 	 * embed an image within the worksheet to cover a range
 	 */
-	addImage(imageId: number, range: string | { editAs?: string; } & ImageRange & { hyperlinks?: ImageHyperlinkValue } | { editAs?: string; } & ImagePosition & { hyperlinks?: ImageHyperlinkValue }): void;
+	addImage(imageId: number, range: string | { editAs?: ImageEditAs; } & ImageRange & { hyperlinks?: ImageHyperlinkValue } | { editAs?: ImageEditAs; } & ImagePosition & { hyperlinks?: ImageHyperlinkValue }): void;
 
 	getImages(): Array<{
 		type: 'image',

--- a/spec/integration/workbook/images.spec.js
+++ b/spec/integration/workbook/images.spec.js
@@ -137,6 +137,47 @@ describe('Workbook', () => {
         });
     });
 
+    it('stores embedded image with twoCell', () => {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('blort');
+      let wb2;
+      let ws2;
+
+      const imageId = wb.addImage({
+        filename: IMAGE_FILENAME,
+        extension: 'jpeg',
+      });
+
+      ws.addImage(imageId, {
+        tl: {col: 0.1125, row: 0.4},
+        br: {col: 2.101046875, row: 3.4},
+        editAs: 'twoCell',
+      });
+
+      return wb.xlsx
+        .writeFile(TEST_XLSX_FILE_NAME)
+        .then(() => {
+          wb2 = new ExcelJS.Workbook();
+          return wb2.xlsx.readFile(TEST_XLSX_FILE_NAME);
+        })
+        .then(() => {
+          ws2 = wb2.getWorksheet('blort');
+          expect(ws2).to.not.be.undefined();
+
+          return fsReadFileAsync(IMAGE_FILENAME);
+        })
+        .then(imageData => {
+          const images = ws2.getImages();
+          expect(images.length).to.equal(1);
+
+          const imageDesc = images[0];
+          expect(imageDesc.range.editAs).to.equal('twoCell');
+
+          const image = wb2.getImage(imageDesc.imageId);
+          expect(Buffer.compare(imageData, image.buffer)).to.equal(0);
+        });
+    });
+
     it('stores embedded image with one-cell-anchor', () => {
       const wb = new ExcelJS.Workbook();
       const ws = wb.addWorksheet('blort');

--- a/test/test-image-oneCell.js
+++ b/test/test-image-oneCell.js
@@ -19,6 +19,17 @@ ws.addImage(imageId, {
   editAs: 'oneCell',
 });
 
+// Add another image with twoCell editAs
+const imageId2 = wb.addImage({
+  filename: path.join(__dirname, 'data/image2.png'),
+  extension: 'png',
+});
+ws.addImage(imageId2, {
+  tl: {col: 3.1125, row: 0.4},
+  br: {col: 5.101046875, row: 3.4},
+  editAs: 'twoCell',
+});
+
 const stopwatch = new HrStopwatch();
 stopwatch.start();
 wb.xlsx


### PR DESCRIPTION

## Summary

This PR adds support for the `twoCell` `editAs` option when adding images to Excel worksheets. This feature allows images to be moved and sized with cells, providing better integration with Excel's filtering and row manipulation features.

This addresses the issue discussed in [GitHub Discussion #2648](https://github.com/exceljs/exceljs/discussions/2648#discussioncomment-8133150) where the images remain visible when rows containing them are filtered or removed. The current library only supports `oneCell` (default) and `absolute` positioning, but Excel's native `twoCell` option provides the expected behavior for images that should move and resize with their containing cells.

- [x] All existing tests pass
- [x] Added new integration test for `twoCell` functionality
- [x] Manual testing completed with example code

## Test plan

See working example demonstrating the `twoCell` functionality: [ExcelJS twoCell Example](https://gist.github.com/hshoja/dd5f9ab63ce60a9b94646150b831d37f)

```javascript
worksheet.addImage(imageId, {
  tl: { col: 1, row: 1 },
  br: { col: 2, row: 2 },
  editAs: "twoCell",
});
```
