### PR TITLE
fix: preserve falsy formula results

### DIFF
--- a/lib/doc/cell.js
+++ b/lib/doc/cell.js
@@ -750,7 +750,7 @@ class FormulaValue {
     const copy = {};
     const cp = name => {
       const value = model[name];
-      if (value) {
+      if (value !== undefined) {
         copy[name] = value;
       }
     };

--- a/spec/unit/doc/cell.spec.js
+++ b/spec/unit/doc/cell.spec.js
@@ -122,6 +122,14 @@ describe('Cell', () => {
     expect(a1.value).to.deep.equal({formula: 'A3'});
     expect(a1.type).to.equal(Enums.ValueType.Formula);
 
+    // falsy cached results are still valid formula results
+    for (const result of [0, false, '']) {
+      formulaValue = {formula: 'A4', result};
+      expect((a1.value = formulaValue)).to.deep.equal(formulaValue);
+      expect(a1.value).to.deep.equal(formulaValue);
+      expect(a1.type).to.equal(Enums.ValueType.Formula);
+    }
+
     const hyperlinkValue = {
       hyperlink: 'http://www.link.com',
       text: 'www.link.com',


### PR DESCRIPTION
## Summary

Fixes #2943.

`FormulaValue._copyModel()` currently copies only truthy fields. That drops valid cached formula results such as `0`, `false`, and `""` when reading `cell.value` or assigning it back.

This changes the copy guard to preserve every defined field while still omitting `undefined`, and adds unit coverage for the falsy formula-result cases.

## Test plan

```bash
npm run test:unit -- spec/unit/doc/cell.spec.js
./node_modules/.bin/eslint lib/doc/cell.js spec/unit/doc/cell.spec.js
git diff --check
```

## Related to source code (for typings update)

N/A. No typings change.
