### PR TITLE
fix: parse wrapText/shrinkToFit as booleans, not truthy strings

### DIFF
--- a/lib/xlsx/xform/style/alignment-xform.js
+++ b/lib/xlsx/xform/style/alignment-xform.js
@@ -145,8 +145,8 @@ class AlignmentXform extends BaseXform {
       'vertical',
       node.attributes.vertical === 'center' ? 'middle' : node.attributes.vertical
     );
-    add(node.attributes.wrapText, 'wrapText', utils.parseBoolean(node.attributes.wrapText));
-    add(node.attributes.shrinkToFit, 'shrinkToFit', utils.parseBoolean(node.attributes.shrinkToFit));
+    add(utils.parseBoolean(node.attributes.wrapText), 'wrapText', true);
+    add(utils.parseBoolean(node.attributes.shrinkToFit), 'shrinkToFit', true);
     add(node.attributes.indent, 'indent', parseInt(node.attributes.indent, 10));
     add(
       node.attributes.textRotation,

--- a/spec/unit/xlsx/xform/style/alignment-xform.spec.js
+++ b/spec/unit/xlsx/xform/style/alignment-xform.spec.js
@@ -51,6 +51,22 @@ const expectations = [
     tests: ['render', 'renderIn', 'parse'],
   },
   {
+    title: 'Wrap Text explicit false',
+    create: () => new AlignmentXform(),
+    preparedModel: {wrapText: true},
+    xml: '<alignment wrapText="0"/>',
+    parsedModel: null,
+    tests: ['parse'],
+  },
+  {
+    title: 'Shrink To Fit explicit false',
+    create: () => new AlignmentXform(),
+    preparedModel: {wrapText: true},
+    xml: '<alignment shrinkToFit="0"/>',
+    parsedModel: null,
+    tests: ['parse'],
+  },
+  {
     title: 'Indent 1',
     create: () => new AlignmentXform(),
     preparedModel: {indent: 1},


### PR DESCRIPTION
## Problem

When an OOXML `.xlsx` file contains `<alignment wrapText="0"/>` or `<alignment shrinkToFit="0"/>`, the attributes are parsed incorrectly.

In JavaScript, the string `"0"` is **truthy** (non-empty string). The `parseOpen` guard:

```js
add(node.attributes.wrapText, 'wrapText', utils.parseBoolean(node.attributes.wrapText));
```

uses `node.attributes.wrapText` (the raw string `"0"`) as the truthy condition. This means:
- `valid` is set to `true` even when the only attributes present are `"0"` (the default/false value)  
- The alignment model is returned as `{wrapText: false}` instead of `null`
- Cells that should have no alignment return a non-null alignment object

This results in `cell.alignment` being `{wrapText: false}` (an object) rather than `undefined` when Excel writes the attribute explicitly as `"0"`.

Relates to issue #1908.

## Fix

Use `utils.parseBoolean()` as the truthy guard so that `"0"` maps to `false` (skip) and `"1"` maps to `true` (include). Since `parseBoolean` already handles the `"0"` → `false` conversion, the stored value is always `true` when the guard passes:

```js
// Before
add(node.attributes.wrapText, 'wrapText', utils.parseBoolean(node.attributes.wrapText));

// After
add(utils.parseBoolean(node.attributes.wrapText), 'wrapText', true);
```

## Tests

Added two new parse-only test cases:
- `wrapText="0"` → parsed model should be `null` (no alignment)  
- `shrinkToFit="0"` → parsed model should be `null` (no alignment)

Both tests fail before the fix and pass after.

All existing 883 unit tests continue to pass.