### PR TITLE
fix(stream): read xlsx via central directory so streaming WorkbookReader stops losing the workbook entry

### DIFF
--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
 const {EventEmitter} = require('events');
-const {PassThrough, Readable} = require('readable-stream');
+const {Readable} = require('readable-stream');
 const nodeStream = require('stream');
 const unzip = require('unzipper');
-const tmp = require('tmp');
 const iterateStream = require('../../utils/iterate-stream');
 const parseSax = require('../../utils/parse-sax');
 
@@ -13,8 +12,6 @@ const RelationshipsXform = require('../../xlsx/xform/core/relationships-xform');
 
 const WorksheetReader = require('./worksheet-reader');
 const HyperlinkReader = require('./hyperlink-reader');
-
-tmp.setGracefulCleanup();
 
 class WorkbookReader extends EventEmitter {
   constructor(input, options = {}) {
@@ -76,76 +73,89 @@ class WorkbookReader extends EventEmitter {
     }
   }
 
+  async _openZip(source) {
+    if (typeof source === 'string') {
+      return unzip.Open.file(source);
+    }
+    // unzip.Open reads the archive's central directory, which needs the whole
+    // (compressed) archive addressable, so buffer stream input here. This does NOT
+    // materialize the much larger decompressed workbook: worksheets below are still
+    // streamed row-by-row via iterateStream.
+    let buffer;
+    if (Buffer.isBuffer(source)) {
+      buffer = source;
+    } else {
+      const stream = this._getStream(source);
+      const chunks = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+      buffer = Buffer.concat(chunks);
+    }
+    return unzip.Open.buffer(buffer);
+  }
+
   async *parse(input, options) {
     if (options) this.options = options;
-    const stream = (this.stream = this._getStream(input || this.input));
-    const zip = unzip.Parse({forceStream: true});
-    stream.pipe(zip);
+    const source = input || this.input;
 
-    // worksheets, deferred for parsing after shared strings reading
-    const waitingWorkSheets = [];
-
-    for await (const entry of iterateStream(zip)) {
-      let match;
-      let sheetNo;
-      switch (entry.path) {
-        case '_rels/.rels':
-          break;
-        case 'xl/_rels/workbook.xml.rels':
-          await this._parseRels(entry);
-          break;
-        case 'xl/workbook.xml':
-          await this._parseWorkbook(entry);
-          break;
-        case 'xl/sharedStrings.xml':
-          yield* this._parseSharedStrings(entry);
-          break;
-        case 'xl/styles.xml':
-          await this._parseStyles(entry);
-          break;
-        default:
-          if (entry.path.match(/xl\/worksheets\/sheet\d+[.]xml/)) {
-            match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
-            sheetNo = match[1];
-            if (this.sharedStrings && this.workbookRels) {
-              yield* this._parseWorksheet(iterateStream(entry), sheetNo);
-            } else {
-              // create temp file for each worksheet
-              await new Promise((resolve, reject) => {
-                tmp.file((err, path, fd, tempFileCleanupCallback) => {
-                  if (err) {
-                    return reject(err);
-                  }
-                  waitingWorkSheets.push({sheetNo, path, tempFileCleanupCallback});
-
-                  const tempStream = fs.createWriteStream(path);
-                  tempStream.on('error', reject);
-                  entry.pipe(tempStream);
-                  return tempStream.on('finish', () => {
-                    return resolve();
-                  });
-                });
-              });
-            }
-          } else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d+[.]xml.rels/)) {
-            match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
-            sheetNo = match[1];
-            yield* this._parseHyperlinks(iterateStream(entry), sheetNo);
-          }
-          break;
+    // Read the archive through its central directory instead of a single streaming
+    // unzip pass. The streaming pass emits entries in stored order and can lose the
+    // final entry under async iteration on Node >= 18; because xl/workbook.xml is
+    // written last, this.model was frequently never set and _parseWorksheet threw on
+    // `this.model.sheets`. Opening the central directory makes every part addressable,
+    // so rels/workbook/sharedStrings/styles are always parsed before any worksheet.
+    // Worksheets are still consumed lazily, so the full workbook is never held in memory.
+    const directory = await this._openZip(source);
+    const byPath = new Map();
+    for (const file of directory.files) {
+      if (file.type === 'File') {
+        byPath.set(file.path, file);
       }
-      entry.autodrain();
     }
 
-    for (const {sheetNo, path, tempFileCleanupCallback} of waitingWorkSheets) {
-      let fileStream = fs.createReadStream(path);
-      // TODO: Remove once node v8 is deprecated
-      // Detect and upgrade old fileStreams
-      if (!fileStream[Symbol.asyncIterator]) {
-        fileStream = fileStream.pipe(new PassThrough());
+    const rels = byPath.get('xl/_rels/workbook.xml.rels');
+    if (rels) {
+      await this._parseRels(rels.stream());
+    }
+
+    const workbook = byPath.get('xl/workbook.xml');
+    if (workbook) {
+      await this._parseWorkbook(workbook.stream());
+    }
+
+    const sharedStrings = byPath.get('xl/sharedStrings.xml');
+    if (sharedStrings) {
+      yield* this._parseSharedStrings(sharedStrings.stream());
+    }
+
+    const styles = byPath.get('xl/styles.xml');
+    if (styles) {
+      await this._parseStyles(styles.stream());
+    }
+
+    const worksheetEntries = [];
+    const worksheetRels = new Map();
+    for (const file of byPath.values()) {
+      let match = file.path.match(/^xl\/worksheets\/sheet(\d+)[.]xml$/);
+      if (match) {
+        worksheetEntries.push({sheetNo: match[1], file});
+        // eslint-disable-next-line no-continue
+        continue;
       }
-      yield* this._parseWorksheet(fileStream, sheetNo);
-      tempFileCleanupCallback();
+      match = file.path.match(/^xl\/worksheets\/_rels\/sheet(\d+)[.]xml[.]rels$/);
+      if (match) {
+        worksheetRels.set(match[1], file);
+      }
+    }
+    worksheetEntries.sort((a, b) => Number(a.sheetNo) - Number(b.sheetNo));
+
+    for (const {sheetNo, file} of worksheetEntries) {
+      const relFile = worksheetRels.get(sheetNo);
+      if (relFile) {
+        yield* this._parseHyperlinks(iterateStream(relFile.stream()), sheetNo);
+      }
+      yield* this._parseWorksheet(iterateStream(file.stream()), sheetNo);
     }
   }
 

--- a/spec/integration/issues/issue-3064-streaming-workbook-model.spec.js
+++ b/spec/integration/issues/issue-3064-streaming-workbook-model.spec.js
@@ -1,0 +1,73 @@
+const {PassThrough} = require('stream');
+
+const ExcelJS = verquire('exceljs');
+
+function bufferToStream(buffer) {
+  const stream = new PassThrough();
+  stream.end(Buffer.from(buffer));
+  return stream;
+}
+
+// Regression: the streaming WorkbookReader read every part from a single streaming
+// unzip pass. That pass emits entries in stored order and, on Node >= 18, frequently
+// lost the final entry under async iteration. Because xl/workbook.xml is written last,
+// this.model was often never set and _parseWorksheet threw
+// "Cannot read properties of undefined (reading 'sheets')" (~90% of reads).
+describe('WorkbookReader - streaming resolves the workbook model', () => {
+  async function buildBuffer() {
+    const wb = new ExcelJS.Workbook();
+    const s1 = wb.addWorksheet('First');
+    s1.addRow(['id', 'name']);
+    s1.addRow([1, 'Alpha']);
+    const s2 = wb.addWorksheet('Second');
+    s2.addRow(['id', 'name']);
+    s2.addRow([2, 'Beta']);
+    s2.addRow([3, 'Gamma']);
+    return wb.xlsx.writeBuffer();
+  }
+
+  async function readSheets(buffer) {
+    const reader = new ExcelJS.stream.xlsx.WorkbookReader(
+      bufferToStream(buffer),
+      {
+        worksheets: 'emit',
+        sharedStrings: 'cache',
+        entries: 'ignore',
+      }
+    );
+    const sheets = [];
+    for await (const worksheet of reader) {
+      const rows = [];
+      for await (const row of worksheet) {
+        rows.push(row.values.slice(1).map(value => `${value}`));
+      }
+      sheets.push({name: worksheet.name, rows});
+    }
+    return sheets;
+  }
+
+  it('exposes sheet names and rows on every read', async function() {
+    this.timeout(20000);
+    const buffer = await buildBuffer();
+
+    // The failure was non-deterministic (~90% per read), so repeat the read to keep
+    // a regression from slipping through as an occasional pass.
+    for (let i = 0; i < 15; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const sheets = await readSheets(buffer);
+      expect(sheets.map(sheet => sheet.name)).to.deep.equal([
+        'First',
+        'Second',
+      ]);
+      expect(sheets[0].rows).to.deep.equal([
+        ['id', 'name'],
+        ['1', 'Alpha'],
+      ]);
+      expect(sheets[1].rows).to.deep.equal([
+        ['id', 'name'],
+        ['2', 'Beta'],
+        ['3', 'Gamma'],
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3064.

### Problem

`stream.xlsx.WorkbookReader` intermittently throws `Cannot read properties of undefined (reading 'sheets')` in `_parseWorksheet` on Node ≥ 18 (~90% of reads on Node 22 in my testing).

`parse()` reads the archive from a single streaming pass (`unzip.Parse({forceStream: true})`) that emits entries in stored order. `this.model` is set only when `xl/workbook.xml` is parsed — but the writer stores `xl/workbook.xml` **last**, and the streaming pass does not reliably deliver that final entry before the worksheets are parsed. So `this.model` is often still `undefined` when `_parseWorksheet` reads `this.model.sheets`.

### Change

Read the archive through its **central directory** (`unzipper.Open`) instead of a single streaming pass:

- `unzip.Open.file(path)` for a file‑path input, `unzip.Open.buffer(...)` for a stream/buffer input.
- Parse `xl/_rels/workbook.xml.rels` → `xl/workbook.xml` → `xl/sharedStrings.xml` → `xl/styles.xml` **before** any worksheet, so `this.model` is always set when sheet names resolve.
- Emit worksheets in numeric sheet order, still consuming each **row‑by‑row** via `iterateStream`, so the full workbook is never materialized in memory.

For stream/buffer input this buffers the compressed archive (the caller already holds those bytes); it does **not** expand the much larger decompressed workbook. The file‑path branch uses `Open.file`, which reads only the central directory + the parts it streams. This also removes the temp‑file worksheet spooling (and the `tmp` dependency usage) that the old deferred path needed.

### Tests

- New regression spec `spec/integration/issues/issue-3064-streaming-workbook-model.spec.js` reads a multi‑sheet workbook repeatedly and asserts sheet names + rows on every read (the failure was ~90% per read, so it repeats to avoid an occasional false pass).
- `npm run lint` clean; the existing `spec/integration/workbook-xlsx-reader.spec.js` streaming‑reader suite and the streaming issue specs (1364, 1328) pass unchanged.
