### PR TITLE
Fix workbook corruption when comments exist on multiple worksheets

### DIFF
--- a/lib/stream/xlsx/sheet-comments-writer.js
+++ b/lib/stream/xlsx/sheet-comments-writer.js
@@ -62,7 +62,9 @@ class SheetCommentsWriter {
       '<?xml version="1.0" encoding="UTF-8"?>' +
         '<xml xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:x="urn:schemas-microsoft-com:office:excel">' +
         '<o:shapelayout v:ext="edit">' +
-        '<o:idmap v:ext="edit" data="1" />' +
+        // Distinct 1024-id block per sheet so comment shape ids stay unique workbook-wide,
+        // see xlsx/xform/comment/vml-notes-xform.js.
+        `<o:idmap v:ext="edit" data="${this.id || 1}" />` +
         '</o:shapelayout>' +
         '<v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202" path="m,l,21600r21600,l21600,xe">' +
         '<v:stroke joinstyle="miter" />' +
@@ -103,7 +105,8 @@ class SheetCommentsWriter {
       });
 
       comments.forEach(comment => {
-        this._writeComment(comment, this.count);
+        // Offset shape ids into this sheet's 1024-id block, see _writeOpen.
+        this._writeComment(comment, (((this.id || 1) - 1) * 1024) + this.count);
         this.count += 1;
       });
     }

--- a/lib/xlsx/xform/comment/vml-notes-xform.js
+++ b/lib/xlsx/xform/comment/vml-notes-xform.js
@@ -22,7 +22,13 @@ class VmlNotesXform extends BaseXform {
     xmlStream.openNode(this.tag, VmlNotesXform.DRAWING_ATTRIBUTES);
 
     xmlStream.openNode('o:shapelayout', {'v:ext': 'edit'});
-    xmlStream.leafNode('o:idmap', {'v:ext': 'edit', data: 1});
+    // Excel allocates VML shape ids workbook-globally in blocks of 1024 per drawing part and
+    // expects each part to reserve a distinct block (ISO 29500 §14.2.2.14 "idmap"). Emitting
+    // block "1" and shape ids _x0000_s1025... for every sheet makes Excel report workbooks with
+    // comments on two or more sheets as corrupt ("We found a problem with some content...").
+    // Use the sheet id as block index (sheet 1 -> data="1", ids 1025+; sheet 2 -> data="2",
+    // ids 2049+; ...), which is how Excel itself numbers these parts.
+    xmlStream.leafNode('o:idmap', {'v:ext': 'edit', data: model.id || 1});
     xmlStream.closeNode();
 
     xmlStream.openNode('v:shapetype', {
@@ -36,7 +42,8 @@ class VmlNotesXform extends BaseXform {
     xmlStream.closeNode();
 
     model.comments.forEach((item, index) => {
-      this.map['v:shape'].render(xmlStream, item, index);
+      // Offset shape ids into this sheet's 1024-id block so they are unique workbook-wide.
+      this.map['v:shape'].render(xmlStream, item, (((model.id || 1) - 1) * 1024) + index);
     });
 
     xmlStream.closeNode();

--- a/spec/integration/issues/comments-on-multiple-sheets.spec.js
+++ b/spec/integration/issues/comments-on-multiple-sheets.spec.js
@@ -1,0 +1,40 @@
+const JSZip = require('jszip');
+
+const ExcelJS = verquire('exceljs');
+
+// Excel allocates VML comment shape ids workbook-globally in blocks of 1024 per drawing part
+// (ISO 29500 §14.2.2.14 "idmap") and expects each part to reserve a distinct block. Reusing
+// block "1" and shape ids _x0000_s1025... in every sheet's vmlDrawingN.vml makes Excel report
+// the file as corrupt ("We found a problem with some content...") as soon as two or more
+// sheets have comments.
+describe('github issues', () => {
+  it('comments on multiple sheets produce workbook-unique VML shape ids', async () => {
+    const wb = new ExcelJS.Workbook();
+    ['One', 'Two', 'Three'].forEach(name => {
+      const ws = wb.addWorksheet(name);
+      ws.getCell('A1').value = name;
+      ws.getCell('A1').note = `first note on ${name}`;
+      ws.getCell('C3').value = 42;
+      ws.getCell('C3').note = `second note on ${name}`;
+    });
+
+    const buffer = await wb.xlsx.writeBuffer();
+    const zip = await JSZip.loadAsync(buffer);
+    const vmlNames = Object.keys(zip.files).filter(name =>
+      /^xl\/drawings\/vmlDrawing\d+\.vml$/.test(name)
+    );
+    expect(vmlNames.length).to.equal(3);
+
+    const shapeIds = [];
+    const idmapBlocks = [];
+    for (const name of vmlNames) {
+      // eslint-disable-next-line no-await-in-loop
+      const xml = await zip.file(name).async('string');
+      shapeIds.push(...xml.match(/id="_x0000_s\d+"/g));
+      idmapBlocks.push(...xml.match(/<o:idmap [^>]*data="\d+"/g));
+    }
+    expect(shapeIds.length).to.equal(6);
+    expect(new Set(shapeIds).size).to.equal(shapeIds.length);
+    expect(new Set(idmapBlocks).size).to.equal(idmapBlocks.length);
+  });
+});


### PR DESCRIPTION
## Summary

Workbooks written by exceljs are reported as corrupt by Excel ("We found a problem with some content in '….xlsx'. Do you want us to try to recover as much as we can?") whenever **two or more worksheets contain cell comments** (`cell.note`). Clicking "Yes" recovers the file, but automated pipelines that consume the generated files reject them outright.

## Reproduction

```js
const wb = new ExcelJS.Workbook();
for (const name of ['One', 'Two']) {
  const ws = wb.addWorksheet(name);
  ws.getCell('A1').value = name;
  ws.getCell('A1').note = `a note on ${name}`;
}
await wb.xlsx.writeFile('repro.xlsx'); // Excel prompts for repair on open
```

With a single commented sheet the file opens fine — the problem appears as soon as a second sheet has a comment.

## Root cause

Excel allocates VML shape ids **workbook-globally** in blocks of 1024 per drawing part. ISO/IEC 29500-1 §14.2.2.14 (`idmap`) describes the scheme: each part records the 1024-id block(s) it reserves in `<o:idmap data="…"/>`, and "the application's internal constraint would be that each part reserve a different set of IDs".

exceljs writes every `xl/drawings/vmlDrawingN.vml` part with the same hardcoded block (`<o:idmap v:ext="edit" data="1"/>`) and with shape ids restarting at `_x0000_s1025` (`vml-shape-xform.js`: `` `_x0000_s${1025 + index}` `` with a per-sheet index). With 2+ commented sheets, the same shape ids exist in multiple parts and multiple parts claim block 1, so Excel's loader flags the workbook as corrupt. Each part on its own is perfectly well-formed, which is why lenient readers (openpyxl, sheetjs, zip/XML validators) see nothing wrong — the violation only exists *across* parts.

Files authored by Excel itself confirm the expected numbering — one distinct block per part:

| part | idmap | shape ids |
|---|---|---|
| vmlDrawing1.vml | `data="1"` | `_x0000_s1025`, `_x0000_s1026`, … |
| vmlDrawing2.vml | `data="2"` | `_x0000_s2049`, `_x0000_s2050`, … |
| vmlDrawing3.vml | `data="3"` | `_x0000_s3073`, `_x0000_s3074`, … |

XlsxWriter (Python) implements the same scheme (`workbook.py`: "Each VML should start with a shape id incremented by 1024").

## Fix

Use the worksheet id as the block index in both writers, so each sheet's part gets its own 1024-id block:

- `lib/xlsx/xform/comment/vml-notes-xform.js` (document writer): `data: model.id`, shape ids offset by `(model.id - 1) * 1024`
- `lib/stream/xlsx/sheet-comments-writer.js` (streaming writer): same change using `this.id`

Sheet 1 keeps producing `data="1"` / ids `1025+`, so output for workbooks with comments on a single sheet is **byte-identical to before**. Multi-sheet workbooks now match Excel's own numbering (sheet 2 → `data="2"` / `2049+`, etc.) and open without the repair prompt.

## Tests

- New integration spec `spec/integration/issues/comments-on-multiple-sheets.spec.js`: writes a workbook with comments on three sheets and asserts shape ids and idmap blocks are unique workbook-wide. Fails against the previous code (only 2 unique ids across 6 shapes), passes with the fix.
- `npm run test:unit`: 883 passing (unchanged).
- Integration suite: same results before and after the change apart from the new spec (the 3 failures in streaming-reader specs on my machine are pre-existing on master and unrelated to comments).
