### PR TITLE
Fix workbook corruption when print titles or print areas reference sheet names containing apostrophes

### DIFF
--- a/lib/xlsx/xform/book/workbook-xform.js
+++ b/lib/xlsx/xform/book/workbook-xform.js
@@ -47,12 +47,15 @@ class WorkbookXform extends BaseXform {
     const printAreas = [];
     let index = 0; // sheets is sparse array - calc index manually
     model.sheets.forEach(sheet => {
+      // Apostrophes inside a quoted sheet name must be doubled (ECMA-376 formula grammar);
+      // otherwise Excel reports the workbook as corrupt.
+      const escapedSheetName = sheet.name.replace(/'/g, '\'\'');
       if (sheet.pageSetup && sheet.pageSetup.printArea) {
         sheet.pageSetup.printArea.split('&&').forEach(printArea => {
           const printAreaComponents = printArea.split(':');
           const definedName = {
             name: '_xlnm.Print_Area',
-            ranges: [`'${sheet.name}'!$${printAreaComponents[0]}:$${printAreaComponents[1]}`],
+            ranges: [`'${escapedSheetName}'!$${printAreaComponents[0]}:$${printAreaComponents[1]}`],
             localSheetId: index,
           };
           printAreas.push(definedName);
@@ -64,12 +67,12 @@ class WorkbookXform extends BaseXform {
 
         if (sheet.pageSetup.printTitlesColumn) {
           const titlesColumns = sheet.pageSetup.printTitlesColumn.split(':');
-          ranges.push(`'${sheet.name}'!$${titlesColumns[0]}:$${titlesColumns[1]}`);
+          ranges.push(`'${escapedSheetName}'!$${titlesColumns[0]}:$${titlesColumns[1]}`);
         }
 
         if (sheet.pageSetup.printTitlesRow) {
           const titlesRows = sheet.pageSetup.printTitlesRow.split(':');
-          ranges.push(`'${sheet.name}'!$${titlesRows[0]}:$${titlesRows[1]}`);
+          ranges.push(`'${escapedSheetName}'!$${titlesRows[0]}:$${titlesRows[1]}`);
         }
 
         const definedName = {

--- a/spec/integration/issues/defined-names-sheet-name-apostrophe.spec.js
+++ b/spec/integration/issues/defined-names-sheet-name-apostrophe.spec.js
@@ -1,0 +1,27 @@
+const JSZip = require('jszip');
+
+const ExcelJS = verquire('exceljs');
+
+// Print_Titles / Print_Area defined names embed the sheet name in formula syntax, where an
+// apostrophe inside the quoted sheet name must be doubled (ECMA-376 formula grammar). Writing
+// the raw sheet name produces an invalid defined name ('D'Alsace'!$1:$1) and Excel reports the
+// workbook as corrupt ("We found a problem with some content...").
+describe('github issues', () => {
+  it('print titles and print areas escape apostrophes in sheet names', async () => {
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('D\'Alsace');
+    ws.getCell('A1').value = 'title row';
+    ws.getCell('A2').value = 42;
+    ws.pageSetup.printTitlesRow = '1:1';
+    ws.pageSetup.printArea = 'A1:B2';
+
+    const buffer = await wb.xlsx.writeBuffer();
+    const zip = await JSZip.loadAsync(buffer);
+    const workbookXml = await zip.file('xl/workbook.xml').async('string');
+    const definedNames = workbookXml.match(/<definedName[^>]*>[^<]*<\/definedName>/g);
+    expect(definedNames).to.have.length(2);
+    definedNames.forEach(definedName => {
+      expect(definedName).to.contain('&apos;D&apos;&apos;Alsace&apos;!');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Workbooks written by exceljs are reported as corrupt by Excel ("We found a problem with some content in '….xlsx'. Do you want us to try to recover as much as we can?") when a worksheet whose name contains an apostrophe has `pageSetup.printTitlesRow`, `printTitlesColumn`, or `printArea` set. Clicking "Yes" recovers the file (Excel drops the defined names), but automated pipelines consuming the files reject them outright.

Found in the same real-world workbook as #3070 — the two are independent corruption causes.

## Reproduction

```js
const wb = new ExcelJS.Workbook();
const ws = wb.addWorksheet("D'Alsace");
ws.getCell('A1').value = 'title row';
ws.pageSetup.printTitlesRow = '1:1';
await wb.xlsx.writeFile('repro.xlsx'); // Excel prompts for repair on open
```

The same applies to sheets read from an existing file: reading a template whose sheet has print titles, renaming the sheet to something containing an apostrophe, and writing it back produces the corrupt defined name.

## Root cause

`WorkbookXform.prepare()` rebuilds the `_xlnm.Print_Titles` / `_xlnm.Print_Area` defined names from `pageSetup`, interpolating the sheet name into the formula string:

```js
ranges.push(`'${sheet.name}'!$${titlesRows[0]}:$${titlesRows[1]}`);
```

In the formula grammar (ECMA-376), an apostrophe inside a quoted sheet name must be doubled. For a sheet named `D'Alsace` this emits `'D'Alsace'!$1:$1` instead of `'D''Alsace'!$1:$1`, which is not parseable as a sheet reference, so Excel flags the workbook part as corrupt. (#822 introduced the quoting itself but did not handle apostrophes within the name.)

## Fix

Escape apostrophes by doubling them at the three interpolation sites in `prepare()` (one for `Print_Area`, two for `Print_Titles`). Sheet names without apostrophes serialize byte-identically to before.

## Tests

- New integration spec `spec/integration/issues/defined-names-sheet-name-apostrophe.spec.js`: writes a workbook with print titles and a print area on a sheet named `D'Alsace` and asserts both defined names contain the doubled apostrophe. Fails against the previous code, passes with the fix.
- `npm run test:unit`: 883 passing (unchanged).
