### PR TITLE
Keep the error result on a formula cell in the streaming reader

### DIFF
--- a/lib/stream/xlsx/worksheet-reader.js
+++ b/lib/stream/xlsx/worksheet-reader.js
@@ -294,6 +294,8 @@ class WorksheetReader extends EventEmitter {
                     if (c.v) {
                       if (c.t === 'str') {
                         cellValue.result = utils.xmlDecode(c.v.text);
+                      } else if (c.t === 'e') {
+                        cellValue.result = {error: c.v.text};
                       } else {
                         cellValue.result = parseFloat(c.v.text);
                       }

--- a/spec/integration/pr/test-issue-3074.spec.js
+++ b/spec/integration/pr/test-issue-3074.spec.js
@@ -1,0 +1,38 @@
+const ExcelJS = verquire('exceljs');
+
+describe('github issues', () => {
+  it('issue 3074 - streaming reader should keep an error result on a formula cell', async () => {
+    const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
+      filename: './test-issue-3074.xlsx',
+    });
+    const sheet = workbook.addWorksheet('data');
+    sheet.getCell('A1').value = {formula: 'C1/D1', result: {error: '#REF!'}};
+    sheet.commit();
+    await workbook.commit();
+
+    return new Promise((resolve, reject) => {
+      const workbookReader = new ExcelJS.stream.xlsx.WorkbookReader(
+        './test-issue-3074.xlsx',
+        {
+          entries: 'emit',
+          sharedStrings: 'cache',
+          styles: 'cache',
+          worksheets: 'emit',
+        }
+      );
+
+      workbookReader.on('worksheet', worksheet =>
+        worksheet.on('row', row => {
+          expect(row.getCell(1).value).to.eql({
+            formula: 'C1/D1',
+            result: {error: '#REF!'},
+          });
+          resolve();
+        })
+      );
+      workbookReader.on('error', reject);
+
+      workbookReader.read();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3074.

The non-streaming reader already handles a formula cell whose cached result is an error (t="e" in the underlying XML) by wrapping it as `{error: value}`, matching what the writer produces for the same thing. The streaming `WorkbookReader` never had that branch though: it only special-cased `t="str"` and ran everything else through `parseFloat`, so an error code like `#REF!` turned into `NaN` and the cell came back looking blank.

Added the missing branch in `lib/stream/xlsx/worksheet-reader.js` so both readers agree. Test uses the streaming `WorkbookWriter`/`WorkbookReader` round trip, following the pattern already used by the other `spec/integration/pr` tests.

Ran `npm run test:unit` (883 passing) and `npm run test:integration` (195 passing, one pre-existing unrelated failure in `issue-1328-xlsx-worksheet-reader-date.spec.js` that's there on master too, confirmed via git stash before touching anything).

One more thing worth flagging separately, not fixed here: building the fixture with the plain `Workbook` + `writeBuffer()` API instead of the streaming writer, then reading it back with the streaming `WorkbookReader`, throws `Cannot read properties of undefined (reading 'sheets')` for any sheet that has no shared strings at all (not specific to this formula case - a plain numeric cell triggers it too). Looks like the zip entries can end up in an order where `xl/workbook.xml` hasn't been parsed yet by the time a deferred worksheet gets processed. Didn't try to fix that here since it needs its own investigation, but wanted to note it in case it's a known gap or worth its own issue.