### PR TITLE
fix: Prototype pollution vulnerability in deepMerge

### DIFF
--- a/lib/utils/under-dash.js
+++ b/lib/utils/under-dash.js
@@ -159,6 +159,9 @@ const _ = {
     let src, clone, copyIsArray;
 
     function assignValue(val, key) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return;
+      }
       src = target[key];
       copyIsArray = Array.isArray(val);
       if (_.isObject(val) || copyIsArray) {

--- a/spec/unit/utils/under-dash.spec.js
+++ b/spec/unit/utils/under-dash.spec.js
@@ -2,6 +2,19 @@ const _ = verquire('utils/under-dash');
 const util = require('util');
 
 describe('under-dash', () => {
+  describe('deepMerge', () => {
+    it('ignores prototype pollution keys', () => {
+      const maliciousValue = JSON.parse(
+        '{"__proto__":{"polluted":true},"constructor":{"polluted":true},"prototype":{"polluted":true}}'
+      );
+
+      const mergedValue = _.deepMerge({}, maliciousValue);
+
+      expect(Object.prototype.polluted).to.equal(undefined);
+      expect(mergedValue).to.deep.equal({});
+    });
+  });
+
   describe('isEqual', () => {
     const values = [
       0,


### PR DESCRIPTION
## Summary
In my project, we are using Enterprise Checkmarx for vulnerability scan. We are getting a prototype pollution vulnerability with Severity as `Critical`.
This PR adds a fix for prototype pollution vulnerability in the deepMerge helper.

## Vulnerability Details
exceljs contains a prototype pollution vulnerability in the deepMerge helper that fails to reject proto, constructor, or prototype keys when merging note objects. Attackers can assign parsed JSON with a malicious proto property to cell notes, modifying Object.prototype and affecting all plain objects created in the process.

## Test plan
- Added a new test case for deepMerge helper function (`spec/unit/utils/under-dash.spec.js`)
- Command executed: `npm run test:unit` - 884 passing (954ms)

